### PR TITLE
[WIP] Add 'none' to possible stack underflows

### DIFF
--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -289,7 +289,7 @@ extension StackLayout {
 
         switch underflow {
         case .none:
-            space = 0.0
+            space = minimumSpacing
         case .growProportionally:
             space = minimumSpacing
         case .growUniformly:

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -137,6 +137,9 @@ extension StackLayout {
 
     /// Determines the on-axis layout when there is extra free space available.
     public enum UnderflowDistribution {
+        
+        /// Additional space will appear after all items are laid out (bottom for vertical stacks, left for horizontal stacks).
+        case none
 
         /// Additional space will be evenly devided into the spacing between items.
         case spaceEvenly
@@ -285,6 +288,8 @@ extension StackLayout {
         let space: CGFloat
 
         switch underflow {
+        case .none:
+            space = 0.0
         case .growProportionally:
             space = minimumSpacing
         case .growUniformly:
@@ -304,6 +309,8 @@ extension StackLayout {
             let traits = traits[index]
             var priority: CGFloat
             switch underflow {
+            case .none:
+                priority = 0.0
             case .growProportionally:
                 priority = basis.axis / totalBasisSize
             case .growUniformly:


### PR DESCRIPTION
There's currently no easy way to have stacks that are sized by their container (versus sized by their content) leave all their space at the end of the stack – adding this underflow value makes that doable without needing a growing spacer, or without needing a custom list layout.

- [ ] Figure out the right name
- [ ] Add tests
- [ ] Do we want more customizability? Eg, able to also specify if the extra space should be left at the top, bottom, or if the content should be centered.