### PR TITLE
Screen scale rounding

### DIFF
--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -5,6 +5,8 @@ public struct AttributedLabel: Element {
 
     public var attributedText: NSAttributedString
     public var numberOfLines: Int = 0
+    /// The scale to which pixel measurements will be rounded. Defaults to `UIScreen.main.scale`.
+    public var roundingScale: CGFloat = UIScreen.main.scale
 
     public init(attributedText: NSAttributedString) {
         self.attributedText = attributedText
@@ -14,6 +16,7 @@ public struct AttributedLabel: Element {
         struct Measurer: Measurable {
 
             var attributedText: NSAttributedString
+            var roundingScale: CGFloat
 
             func measure(in constraint: SizeConstraint) -> CGSize {
                 var size = attributedText.boundingRect(
@@ -21,14 +24,14 @@ public struct AttributedLabel: Element {
                     options: [.usesLineFragmentOrigin],
                     context: nil)
                     .size
-                size.width = ceil(size.width)
-                size.height = ceil(size.height)
+                size.width = size.width.rounded(.up, by: roundingScale)
+                size.height = size.height.rounded(.up, by: roundingScale)
 
                 return size
             }
         }
 
-        return ElementContent(measurable: Measurer(attributedText: attributedText))
+        return ElementContent(measurable: Measurer(attributedText: attributedText, roundingScale: roundingScale))
     }
 
     public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {

--- a/BlueprintUICommonControls/Sources/FloatingPoint+ScaleRounding.swift
+++ b/BlueprintUICommonControls/Sources/FloatingPoint+ScaleRounding.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension FloatingPoint {
+    mutating func round(_ rule: FloatingPointRoundingRule, by scale: Self) {
+        self = self.rounded(rule, by: scale)
+    }
+
+    func rounded(_ rule: FloatingPointRoundingRule, by scale: Self) -> Self {
+        return (self * scale).rounded(rule) / scale
+    }
+}

--- a/BlueprintUICommonControls/Sources/Label.swift
+++ b/BlueprintUICommonControls/Sources/Label.swift
@@ -12,7 +12,9 @@ public struct Label: Element {
     public var alignment: NSTextAlignment = .left
     public var numberOfLines: Int = 0
     public var lineBreakMode: NSLineBreakMode = .byWordWrapping
-    
+    /// The scale to which pixel measurements will be rounded. Defaults to `UIScreen.main.scale`.
+    public var roundingScale: CGFloat = UIScreen.main.scale
+
     public init(text: String, configure: (inout Label) -> Void = { _ in }) {
         self.text = text
         configure(&self)
@@ -34,6 +36,7 @@ public struct Label: Element {
     public var content: ElementContent {
         var element = AttributedLabel(attributedText: attributedText)
         element.numberOfLines = numberOfLines
+        element.roundingScale = roundingScale
         return ElementContent(child: element)
     }
 

--- a/BlueprintUICommonControls/Sources/SegmentedControl.swift
+++ b/BlueprintUICommonControls/Sources/SegmentedControl.swift
@@ -9,6 +9,7 @@ public struct SegmentedControl: Element, Measurable {
     public var selection: Selection = .none
 
     public var font: UIFont = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
+    public var roundingScale: CGFloat = UIScreen.main.scale
 
     public init(items: [Item] = []) {
         self.items = items
@@ -24,7 +25,7 @@ public struct SegmentedControl: Element, Measurable {
 
     public func measure(in constraint: SizeConstraint) -> CGSize {
         return items.reduce(CGSize.zero, { (current, item) -> CGSize in
-            let itemSize = item.measure(font: font, in: constraint)
+            let itemSize = item.measure(font: font, in: constraint, roundingScale: roundingScale)
             return CGSize(
                 width: itemSize.width + current.width,
                 height: max(itemSize.height, current.height))
@@ -67,9 +68,9 @@ extension SegmentedControl {
 
         public var onSelect: () -> Void
 
-        internal func measure(font: UIFont, in constraint: SizeConstraint) -> CGSize {
+        internal func measure(font: UIFont, in constraint: SizeConstraint, roundingScale: CGFloat) -> CGSize {
             return CGSize(
-                width: width.requiredWidth(for: title, font: font, in: constraint),
+                width: width.requiredWidth(for: title, font: font, in: constraint, roundingScale: roundingScale),
                 height: 36.0)
         }
 
@@ -92,7 +93,12 @@ extension SegmentedControl.Item {
             }
         }
 
-        fileprivate func requiredWidth(for title: String, font: UIFont, in constraint: SizeConstraint) -> CGFloat {
+        fileprivate func requiredWidth(
+            for title: String,
+            font: UIFont,
+            in constraint: SizeConstraint,
+            roundingScale: CGFloat
+        ) -> CGFloat {
             switch self {
             case .automatic:
                 let width = (title as NSString)
@@ -103,8 +109,9 @@ extension SegmentedControl.Item {
                         context: nil)
                     .size
                     .width
+                    .rounded(.up, by: roundingScale)
 
-                return ceil(width) + 8 // 4pt padding on each side
+                return width + 8 // 4pt padding on each side
             case let .specific(width):
                 return width
             }

--- a/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
@@ -12,7 +12,8 @@ class AttributedLabelTests: XCTestCase {
             .appending(string: "llo, ", font: .italicSystemFont(ofSize: 13.0), color: .magenta)
             .appending(string: "World!", font: .monospacedDigitSystemFont(ofSize: 32.0, weight: .black), color: .yellow)
 
-        let element = AttributedLabel(attributedText: string)
+        var element = AttributedLabel(attributedText: string)
+        element.roundingScale = 1
 
         compareSnapshot(of: element)
         
@@ -22,6 +23,7 @@ class AttributedLabelTests: XCTestCase {
 
         let string = NSAttributedString(string: "Hello, world. This is some long text that runs onto several lines.")
         var element = AttributedLabel(attributedText: string)
+        element.roundingScale = 1
 
         element.numberOfLines = 0
         compareSnapshot(
@@ -52,11 +54,12 @@ class AttributedLabelTests: XCTestCase {
                 .appending(string: "llo, ", font: .italicSystemFont(ofSize: 13.0), color: .magenta)
                 .appending(string: "World!", font: .monospacedDigitSystemFont(ofSize: 32.0, weight: .black), color: .yellow)
 
-            let element = AttributedLabel(attributedText: string)
+            var element = AttributedLabel(attributedText: string)
+            element.roundingScale = 1
 
             var measuredSize = string.boundingRect(with: size, options: .usesLineFragmentOrigin, context: nil).size
-            measuredSize.width = ceil(measuredSize.width)
-            measuredSize.height = ceil(measuredSize.height)
+            measuredSize.width = measuredSize.width.rounded(.up)
+            measuredSize.height = measuredSize.height.rounded(.up)
 
             let elementSize = element.content.measure(in: SizeConstraint(size))
 
@@ -70,7 +73,20 @@ class AttributedLabelTests: XCTestCase {
 
     }
 
+    func test_rounding() {
+        let string = NSAttributedString(
+            string: "iiiii",
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 23)
+            ])
 
+        var element = AttributedLabel(attributedText: string)
+        element.roundingScale = 2.0
+
+        let size = element.content.measure(in: SizeConstraint(CGSize(width: 100, height: 100)))
+
+        XCTAssertEqual(size, CGSize(width: 25.5, height: 27.5))
+    }
 }
 
 

--- a/BlueprintUICommonControls/Tests/Sources/ButtonTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/ButtonTests.swift
@@ -7,13 +7,17 @@ class ButtonTests: XCTestCase {
 
     func test_snapshots() {
 
+        let label = Label(text: "Hello, world") { (label) in
+            label.roundingScale = 1
+        }
+
         do {
-            let button = Button(wrapping: Label(text: "Hello, world"))
+            let button = Button(wrapping: label)
             compareSnapshot(of: button, identifier: "simple")
         }
 
         do {
-            var button = Button(wrapping: Label(text: "Hello, world"))
+            var button = Button(wrapping: label)
             button.isEnabled = false
             compareSnapshot(of: button, identifier: "disabled")
         }

--- a/BlueprintUICommonControls/Tests/Sources/LabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/LabelTests.swift
@@ -71,6 +71,7 @@ class LabelTests: XCTestCase {
 
     fileprivate func compareSnapshot(identifier: String? = nil, file: StaticString = #file, testName: String = #function, line: UInt = #line, configuration: (inout Label) -> Void) {
         var label = Label(text: "Hello, world. This is a long run of text that should wrap at some point. Someone should improve this test by adding a joke or something. Alright, it's been fun!")
+        label.roundingScale = 1
         configuration(&label)
         compareSnapshot(of: label, size: CGSize(width: 300, height: 300), identifier: identifier, file: file, testName: testName, line: line)
     }

--- a/BlueprintUICommonControls/Tests/Sources/ScaleRoundingTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/ScaleRoundingTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import BlueprintUICommonControls
+
+final class ScaleRoundingTests: XCTestCase {
+    func assert(
+        _ x: Double,
+        roundsTo expected: Double,
+        rule: FloatingPointRoundingRule,
+        scale: Double,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        var rounded: Double
+
+        // non-mutating variant
+        rounded = x.rounded(rule, by: scale)
+        XCTAssertEqual(
+            rounded,
+            expected,
+            accuracy: .ulpOfOne,
+            "\(x) should round to \(expected) with rule: \(rule), scale: \(scale)",
+            file: file,
+            line: line
+        )
+
+        // mutating variant
+        rounded = x
+        rounded.round(rule, by: scale)
+        XCTAssertEqual(
+            rounded,
+            expected,
+            accuracy: .ulpOfOne,
+            "\(x) should round to \(expected) with rule: \(rule), scale: \(scale)",
+            file: file,
+            line: line
+        )
+    }
+
+    func test_scale1() {
+        let scale = 1.0
+
+        assert(0.0, roundsTo: 0.0, rule: .awayFromZero, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .down, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .toNearestOrAwayFromZero, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .toNearestOrEven, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .towardZero, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .up, scale: scale)
+
+        assert(0.1, roundsTo: 1.0, rule: .awayFromZero, scale: scale)
+        assert(0.1, roundsTo: 0.0, rule: .down, scale: scale)
+        assert(0.1, roundsTo: 0.0, rule: .toNearestOrAwayFromZero, scale: scale)
+        assert(0.1, roundsTo: 0.0, rule: .toNearestOrEven, scale: scale)
+        assert(0.1, roundsTo: 0.0, rule: .towardZero, scale: scale)
+        assert(0.1, roundsTo: 1.0, rule: .up, scale: scale)
+
+        assert(0.5, roundsTo: 1.0, rule: .awayFromZero, scale: scale)
+        assert(0.5, roundsTo: 0.0, rule: .down, scale: scale)
+        assert(0.5, roundsTo: 1.0, rule: .toNearestOrAwayFromZero, scale: scale)
+        assert(0.5, roundsTo: 0.0, rule: .toNearestOrEven, scale: scale)
+        assert(0.5, roundsTo: 0.0, rule: .towardZero, scale: scale)
+        assert(0.5, roundsTo: 1.0, rule: .up, scale: scale)
+
+        assert(0.9, roundsTo: 1.0, rule: .awayFromZero, scale: scale)
+        assert(0.9, roundsTo: 0.0, rule: .down, scale: scale)
+        assert(0.9, roundsTo: 1.0, rule: .toNearestOrAwayFromZero, scale: scale)
+        assert(0.9, roundsTo: 1.0, rule: .toNearestOrEven, scale: scale)
+        assert(0.9, roundsTo: 0.0, rule: .towardZero, scale: scale)
+        assert(0.9, roundsTo: 1.0, rule: .up, scale: scale)
+    }
+
+    func test_scale2() {
+        let scale = 2.0
+
+        assert(0.0, roundsTo: 0.0, rule: .awayFromZero, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .down, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .toNearestOrAwayFromZero, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .toNearestOrEven, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .towardZero, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .up, scale: scale)
+
+        assert(0.1, roundsTo: 0.5, rule: .awayFromZero, scale: scale)
+        assert(0.1, roundsTo: 0.0, rule: .down, scale: scale)
+        assert(0.1, roundsTo: 0.0, rule: .toNearestOrAwayFromZero, scale: scale)
+        assert(0.1, roundsTo: 0.0, rule: .toNearestOrEven, scale: scale)
+        assert(0.1, roundsTo: 0.0, rule: .towardZero, scale: scale)
+        assert(0.1, roundsTo: 0.5, rule: .up, scale: scale)
+
+        assert(0.5, roundsTo: 0.5, rule: .awayFromZero, scale: scale)
+        assert(0.5, roundsTo: 0.5, rule: .down, scale: scale)
+        assert(0.5, roundsTo: 0.5, rule: .toNearestOrAwayFromZero, scale: scale)
+        assert(0.5, roundsTo: 0.5, rule: .toNearestOrEven, scale: scale)
+        assert(0.5, roundsTo: 0.5, rule: .towardZero, scale: scale)
+        assert(0.5, roundsTo: 0.5, rule: .up, scale: scale)
+
+        assert(0.9, roundsTo: 1.0, rule: .awayFromZero, scale: scale)
+        assert(0.9, roundsTo: 0.5, rule: .down, scale: scale)
+        assert(0.9, roundsTo: 1.0, rule: .toNearestOrAwayFromZero, scale: scale)
+        assert(0.9, roundsTo: 1.0, rule: .toNearestOrEven, scale: scale)
+        assert(0.9, roundsTo: 0.5, rule: .towardZero, scale: scale)
+        assert(0.9, roundsTo: 1.0, rule: .up, scale: scale)
+    }
+
+    func test_scale3() {
+        let scale = 3.0
+
+        assert(0.0, roundsTo: 0.0, rule: .awayFromZero, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .down, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .toNearestOrAwayFromZero, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .toNearestOrEven, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .towardZero, scale: scale)
+        assert(0.0, roundsTo: 0.0, rule: .up, scale: scale)
+
+        assert(0.1, roundsTo: 1/3, rule: .awayFromZero, scale: scale)
+        assert(0.1, roundsTo: 0.0, rule: .down, scale: scale)
+        assert(0.1, roundsTo: 0.0, rule: .toNearestOrAwayFromZero, scale: scale)
+        assert(0.1, roundsTo: 0.0, rule: .toNearestOrEven, scale: scale)
+        assert(0.1, roundsTo: 0.0, rule: .towardZero, scale: scale)
+        assert(0.1, roundsTo: 1/3, rule: .up, scale: scale)
+
+        assert(0.5, roundsTo: 2/3, rule: .awayFromZero, scale: scale)
+        assert(0.5, roundsTo: 1/3, rule: .down, scale: scale)
+        assert(0.5, roundsTo: 2/3, rule: .toNearestOrAwayFromZero, scale: scale)
+        assert(0.5, roundsTo: 2/3, rule: .toNearestOrEven, scale: scale)
+        assert(0.5, roundsTo: 1/3, rule: .towardZero, scale: scale)
+        assert(0.5, roundsTo: 2/3, rule: .up, scale: scale)
+
+        assert(0.9, roundsTo: 1.0, rule: .awayFromZero, scale: scale)
+        assert(0.9, roundsTo: 2/3, rule: .down, scale: scale)
+        assert(0.9, roundsTo: 1.0, rule: .toNearestOrAwayFromZero, scale: scale)
+        assert(0.9, roundsTo: 1.0, rule: .toNearestOrEven, scale: scale)
+        assert(0.9, roundsTo: 2/3, rule: .towardZero, scale: scale)
+        assert(0.9, roundsTo: 1.0, rule: .up, scale: scale)
+    }
+}


### PR DESCRIPTION
This PR changes the rounding behavior when measuring text-containing elements to round up to the nearest screen pixel instead of the nearest point. This is accomplished through a new `roundingScale` property on affected elements, which defaults to `UIScreen.main.scale`. It can be set explicitly to other values but is not an initializer argument (since it will rarely be set outside of testing).

For tests that measure affected elements the scale is explicitly set to 1 to match current behavior. I also added one new test to make sure the rounding works on a known font/text combination.