### PR TITLE
ConstrainedAspectRatio element

### DIFF
--- a/BlueprintUI/Sources/Layout/AspectRatio.swift
+++ b/BlueprintUI/Sources/Layout/AspectRatio.swift
@@ -1,0 +1,29 @@
+/// Represents an a proportional relationship between width and height.
+public struct AspectRatio {
+    /// A 1:1 aspect ratio.
+    public static let square = AspectRatio(x: 1, y: 1)
+
+    /// The horizontal component of this ratio.
+    public var x: CGFloat
+    /// The vertical component of this ratio.
+    public var y: CGFloat
+
+    /// Initializes with a horizontal and vertical components.
+    ///
+    /// - Parameter x: The horizontal comonent.
+    /// - Parameter y: The vertical component.
+    public init(x: CGFloat, y: CGFloat) {
+        self.x = x
+        self.y = y
+    }
+
+    func height(forWidth width: CGFloat) -> CGFloat {
+        // TODO: round to screen scale when that lands
+        return (width * y / x).rounded()
+    }
+
+    func width(forHeight height: CGFloat) -> CGFloat {
+        // TODO: round to screen scale when that lands
+        return (height * x / y).rounded()
+    }
+}

--- a/BlueprintUI/Sources/Layout/AspectRatio.swift
+++ b/BlueprintUI/Sources/Layout/AspectRatio.swift
@@ -1,29 +1,33 @@
 /// Represents an a proportional relationship between width and height.
 public struct AspectRatio {
     /// A 1:1 aspect ratio.
-    public static let square = AspectRatio(x: 1, y: 1)
+    public static let square = AspectRatio(ratio: 1)
 
-    /// The horizontal component of this ratio.
-    public var x: CGFloat
-    /// The vertical component of this ratio.
-    public var y: CGFloat
+    /// The width:height ratio value.
+    public var ratio: CGFloat
 
-    /// Initializes with a horizontal and vertical components.
+    /// Initializes with a width & height ratio.
     ///
-    /// - Parameter x: The horizontal comonent.
-    /// - Parameter y: The vertical component.
-    public init(x: CGFloat, y: CGFloat) {
-        self.x = x
-        self.y = y
+    /// - Parameter width: The relative width of the ratio.
+    /// - Parameter height: The relative height of the ratio.
+    public init(width: CGFloat, height: CGFloat) {
+        self.init(ratio: width / height)
+    }
+
+    /// Initializes with a specific ratio.
+    ///
+    /// - Parameter ratio: The width:height ratio.
+    public init(ratio: CGFloat) {
+        self.ratio = ratio
     }
 
     func height(forWidth width: CGFloat) -> CGFloat {
         // TODO: round to screen scale when that lands
-        return (width * y / x).rounded()
+        return (width / ratio).rounded()
     }
 
     func width(forHeight height: CGFloat) -> CGFloat {
         // TODO: round to screen scale when that lands
-        return (height * x / y).rounded()
+        return (height * ratio).rounded()
     }
 }

--- a/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
@@ -1,0 +1,74 @@
+/// Constrains the size of the content element to an aspect ratio.
+public struct ConstrainedAspectRatio: Element {
+    /// Represents whether the content element's size should be expanded or shrunk to match the
+    /// constraint aspect ratio.
+    public enum Constraint {
+        case expand
+        case shrink
+
+        func constrain(size: CGSize, to aspectRatio: AspectRatio) -> CGSize {
+            let constrainedHeight = aspectRatio.height(forWidth: size.width)
+            let constrainedWidth = aspectRatio.width(forHeight: size.height)
+
+            switch self {
+            case .expand:
+                if constrainedWidth > size.width {
+                    return CGSize(width: constrainedWidth, height: size.height)
+                } else if constrainedHeight > size.height {
+                    return CGSize(width: size.width, height: constrainedHeight)
+                }
+
+            case .shrink:
+                if constrainedWidth < size.width {
+                    return CGSize(width: constrainedWidth, height: size.height)
+                } else if constrainedHeight < size.height {
+                    return CGSize(width: size.width, height: constrainedHeight)
+                }
+            }
+
+            return size
+        }
+    }
+
+    /// The element being constrained.
+    public var wrappedElement: Element
+    /// The target aspect ratio.
+    public var aspectRatio: AspectRatio
+    /// Whether the aspect ratio should be reached by expanding the content element's size or shrinking it.
+    public var constraint: Constraint
+
+    /// Initializes with the given properties.
+    ///
+    /// - parameters:
+    ///   - aspectRatio: The aspect ratio that the content size should match.
+    ///   - constraint: Whether the aspect ratio should be reached by expanding the content
+    ///     element's size or shrinking it.
+    ///   - wrapping: The content element.
+    public init(aspectRatio: AspectRatio, constraint: Constraint = .expand, wrapping wrappedElement: Element) {
+        self.aspectRatio = aspectRatio
+        self.constraint = constraint
+        self.wrappedElement = wrappedElement
+    }
+
+    public var content: ElementContent {
+        return ElementContent(child: wrappedElement, layout: Layout(aspectRatio: aspectRatio, constraint: constraint))
+    }
+
+    public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
+        return nil
+    }
+
+    private struct Layout: SingleChildLayout {
+        var aspectRatio: AspectRatio
+        var constraint: Constraint
+
+        func measure(in sizeConstraint: SizeConstraint, child: Measurable) -> CGSize {
+            let size = child.measure(in: sizeConstraint)
+            return constraint.constrain(size: size, to: aspectRatio)
+        }
+
+        func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
+            return LayoutAttributes(size: size)
+        }
+    }
+}

--- a/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
@@ -1,24 +1,26 @@
 /// Constrains the size of the content element to an aspect ratio.
 public struct ConstrainedAspectRatio: Element {
-    /// Represents whether the content element's size should be expanded or shrunk to match the
-    /// constraint aspect ratio.
-    public enum Constraint {
-        case expand
-        case shrink
+    /// Represents whether the content element's size should be expanded to fill its parent
+    /// or shrunk to fit it.
+    public enum ContentMode: Equatable {
+        /// Expand the content to fill its parent.
+        case fill
+        /// Shrink the content to fit within its parent.
+        case fit
 
         func constrain(size: CGSize, to aspectRatio: AspectRatio) -> CGSize {
             let constrainedHeight = aspectRatio.height(forWidth: size.width)
             let constrainedWidth = aspectRatio.width(forHeight: size.height)
 
             switch self {
-            case .expand:
+            case .fill:
                 if constrainedWidth > size.width {
                     return CGSize(width: constrainedWidth, height: size.height)
                 } else if constrainedHeight > size.height {
                     return CGSize(width: size.width, height: constrainedHeight)
                 }
 
-            case .shrink:
+            case .fit:
                 if constrainedWidth < size.width {
                     return CGSize(width: constrainedWidth, height: size.height)
                 } else if constrainedHeight < size.height {
@@ -34,24 +36,25 @@ public struct ConstrainedAspectRatio: Element {
     public var wrappedElement: Element
     /// The target aspect ratio.
     public var aspectRatio: AspectRatio
-    /// Whether the aspect ratio should be reached by expanding the content element's size or shrinking it.
-    public var constraint: Constraint
+    /// Whether the aspect ratio should be reached by expanding the content element's size to fill its parent
+    /// or shrinking it to fit.
+    public var contentMode: ContentMode
 
     /// Initializes with the given properties.
     ///
     /// - parameters:
     ///   - aspectRatio: The aspect ratio that the content size should match.
-    ///   - constraint: Whether the aspect ratio should be reached by expanding the content
-    ///     element's size or shrinking it.
+    ///   - contentMode: Whether the aspect ratio should be reached by expanding the content
+    ///     element's size to fill its parent or shrinking it to fit.
     ///   - wrapping: The content element.
-    public init(aspectRatio: AspectRatio, constraint: Constraint = .expand, wrapping wrappedElement: Element) {
+    public init(aspectRatio: AspectRatio, contentMode: ContentMode = .fill, wrapping wrappedElement: Element) {
         self.aspectRatio = aspectRatio
-        self.constraint = constraint
+        self.contentMode = contentMode
         self.wrappedElement = wrappedElement
     }
 
     public var content: ElementContent {
-        return ElementContent(child: wrappedElement, layout: Layout(aspectRatio: aspectRatio, constraint: constraint))
+        return ElementContent(child: wrappedElement, layout: Layout(aspectRatio: aspectRatio, contentMode: contentMode))
     }
 
     public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
@@ -60,11 +63,11 @@ public struct ConstrainedAspectRatio: Element {
 
     private struct Layout: SingleChildLayout {
         var aspectRatio: AspectRatio
-        var constraint: Constraint
+        var contentMode: ContentMode
 
         func measure(in sizeConstraint: SizeConstraint, child: Measurable) -> CGSize {
             let size = child.measure(in: sizeConstraint)
-            return constraint.constrain(size: size, to: aspectRatio)
+            return contentMode.constrain(size: size, to: aspectRatio)
         }
 
         func layout(size: CGSize, child: Measurable) -> LayoutAttributes {

--- a/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
+++ b/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import BlueprintUI
+
+class ConstrainedAspectRatioTests: XCTestCase {
+    func test_expandWide() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(x: 2, y: 1),
+            constraint: .expand,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: .unconstrained)
+        XCTAssertEqual(size, CGSize(width: 200, height: 100))
+    }
+
+    func test_expandTall() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(x: 1, y: 2),
+            constraint: .expand,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: .unconstrained)
+        XCTAssertEqual(size, CGSize(width: 120, height: 240))
+    }
+
+    func test_expandSquare() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: .square,
+            constraint: .expand,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: .unconstrained)
+        XCTAssertEqual(size, CGSize(width: 120, height: 120))
+    }
+
+    func test_shrinkWide() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(x: 2, y: 1),
+            constraint: .shrink,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: .unconstrained)
+        XCTAssertEqual(size, CGSize(width: 120, height: 60))
+    }
+
+    func test_shrinkTall() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(x: 1, y: 2),
+            constraint: .shrink,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: .unconstrained)
+        XCTAssertEqual(size, CGSize(width: 50, height: 100))
+    }
+
+    func test_shrinkSquare() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: .square,
+            constraint: .shrink,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: .unconstrained)
+        XCTAssertEqual(size, CGSize(width: 100, height: 100))
+    }
+}
+
+private struct TestElement: Element {
+    var content: ElementContent {
+        return ElementContent(intrinsicSize: CGSize(width: 120, height: 100))
+    }
+
+    func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
+        return nil
+    }
+}

--- a/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
+++ b/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
@@ -4,7 +4,7 @@ import BlueprintUI
 class ConstrainedAspectRatioTests: XCTestCase {
     func test_expandWide() {
         let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(x: 2, y: 1),
+            aspectRatio: AspectRatio(width: 2, height: 1),
             constraint: .expand,
             wrapping: TestElement())
 
@@ -14,7 +14,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
 
     func test_expandTall() {
         let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(x: 1, y: 2),
+            aspectRatio: AspectRatio(width: 1, height: 2),
             constraint: .expand,
             wrapping: TestElement())
 
@@ -34,7 +34,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
 
     func test_shrinkWide() {
         let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(x: 2, y: 1),
+            aspectRatio: AspectRatio(width: 2, height: 1),
             constraint: .shrink,
             wrapping: TestElement())
 
@@ -44,7 +44,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
 
     func test_shrinkTall() {
         let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(x: 1, y: 2),
+            aspectRatio: AspectRatio(width: 1, height: 2),
             constraint: .shrink,
             wrapping: TestElement())
 

--- a/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
+++ b/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
@@ -5,7 +5,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
     func test_expandWide() {
         let element = ConstrainedAspectRatio(
             aspectRatio: AspectRatio(width: 2, height: 1),
-            constraint: .expand,
+            contentMode: .fill,
             wrapping: TestElement())
 
         let size = element.content.measure(in: .unconstrained)
@@ -15,7 +15,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
     func test_expandTall() {
         let element = ConstrainedAspectRatio(
             aspectRatio: AspectRatio(width: 1, height: 2),
-            constraint: .expand,
+            contentMode: .fill,
             wrapping: TestElement())
 
         let size = element.content.measure(in: .unconstrained)
@@ -25,7 +25,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
     func test_expandSquare() {
         let element = ConstrainedAspectRatio(
             aspectRatio: .square,
-            constraint: .expand,
+            contentMode: .fill,
             wrapping: TestElement())
 
         let size = element.content.measure(in: .unconstrained)
@@ -35,7 +35,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
     func test_shrinkWide() {
         let element = ConstrainedAspectRatio(
             aspectRatio: AspectRatio(width: 2, height: 1),
-            constraint: .shrink,
+            contentMode: .fit,
             wrapping: TestElement())
 
         let size = element.content.measure(in: .unconstrained)
@@ -45,7 +45,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
     func test_shrinkTall() {
         let element = ConstrainedAspectRatio(
             aspectRatio: AspectRatio(width: 1, height: 2),
-            constraint: .shrink,
+            contentMode: .fit,
             wrapping: TestElement())
 
         let size = element.content.measure(in: .unconstrained)
@@ -55,7 +55,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
     func test_shrinkSquare() {
         let element = ConstrainedAspectRatio(
             aspectRatio: .square,
-            constraint: .shrink,
+            contentMode: .fit,
             wrapping: TestElement())
 
         let size = element.content.measure(in: .unconstrained)


### PR DESCRIPTION
A new `ConstrainedAspectRatio` element that constrains the size of its child to — you guessed it — an aspect ratio.

You can choose to enforce this constraint by expanding or shrinking the child. Open to alternative suggestions for the name of "expand or shrink" behavior.