### PR TITLE
[WIP] Round all view frames to pixel boundaries

### DIFF
--- a/BlueprintUI/Sources/Internal/Extensions/CGRect.swift
+++ b/BlueprintUI/Sources/Internal/Extensions/CGRect.swift
@@ -1,0 +1,26 @@
+import QuartzCore
+
+
+extension CGRect {
+
+    init(minX: CGFloat, minY: CGFloat, maxX: CGFloat, maxY: CGFloat) {
+        self.init(
+            x: minX,
+            y: minY,
+            width: maxX - minX,
+            height: maxY - minY)
+    }
+
+    func rounded(toScale scale: CGFloat) -> CGRect {
+        return CGRect(
+            minX: minX.rounded(.toNearestOrAwayFromZero, by: scale),
+            minY: minY.rounded(.toNearestOrAwayFromZero, by: scale),
+            maxX: maxX.rounded(.toNearestOrAwayFromZero, by: scale),
+            maxY: maxY.rounded(.toNearestOrAwayFromZero, by: scale))
+    }
+
+    mutating func round(toScale scale: CGFloat) {
+        self = rounded(toScale: scale)
+    }
+
+}

--- a/BlueprintUI/Sources/Internal/Extensions/FloatingPoint+ScaleRounding.swift
+++ b/BlueprintUI/Sources/Internal/Extensions/FloatingPoint+ScaleRounding.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension FloatingPoint {
+    mutating func round(_ rule: FloatingPointRoundingRule, by scale: Self) {
+        self = self.rounded(rule, by: scale)
+    }
+
+    func rounded(_ rule: FloatingPointRoundingRule, by scale: Self) -> Self {
+        return (self * scale).rounded(rule) / scale
+    }
+}

--- a/BlueprintUI/Sources/Layout/Aligned.swift
+++ b/BlueprintUI/Sources/Layout/Aligned.swift
@@ -89,10 +89,6 @@ public struct Aligned: Element {
                 attributes.frame.origin.x = size.width - contentSize.width
             }
 
-            // TODO: screen-scale round here once that lands
-            attributes.frame.origin.x.round()
-            attributes.frame.origin.y.round()
-
             return attributes
         }
     }

--- a/BlueprintUI/Sources/Layout/AspectRatio.swift
+++ b/BlueprintUI/Sources/Layout/AspectRatio.swift
@@ -23,11 +23,11 @@ public struct AspectRatio {
 
     func height(forWidth width: CGFloat) -> CGFloat {
         // TODO: round to screen scale when that lands
-        return (width / ratio).rounded()
+        return width / ratio
     }
 
     func width(forHeight height: CGFloat) -> CGFloat {
         // TODO: round to screen scale when that lands
-        return (height * ratio).rounded()
+        return height * ratio
     }
 }

--- a/BlueprintUI/Sources/Layout/LayoutAttributes.swift
+++ b/BlueprintUI/Sources/Layout/LayoutAttributes.swift
@@ -62,6 +62,15 @@ public struct LayoutAttributes {
         }
     }
 
+    internal func rounded(toScale scale: CGFloat) -> LayoutAttributes {
+        guard CATransform3DIsIdentity(transform) else {
+            return self
+        }
+        var attributes = self
+        attributes.frame.round(toScale: scale)
+        return attributes
+    }
+
     internal func apply(to view: UIView) {
         view.bounds = bounds
         view.center = center

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -322,7 +322,7 @@ extension StackLayout {
         case .justifyToStart:
             axisOrigin = 0.0
         case .justifyToCenter:
-            axisOrigin = (extraSize / 2.0).rounded() // TODO: @narenh - Add screen scale rounding
+            axisOrigin = extraSize / 2.0
         case .justifyToEnd:
             axisOrigin = extraSize
         }


### PR DESCRIPTION
Proof of concept infrastructural fix for aligning views to pixel boundaries. This removes the need for layouts to do their own pixel-alignment.

This rounds each rect edge to the closest pixel (sometimes shrinking a frame, sometimes growing it, sometimes just moving it).

It’s still the case that certain elements may want to measure themselves rounded specifically (e.g. `Label` will want to round its measurement up to avoid truncation). For those cases, it may be worth passing the screen scale into `Measurable.measure` (with my implementation, if the main screen is 3x but the `BlueprintView` is on a screen that’s 1x, a `Label` won’t round up sufficiently to always avoid truncation).