### PR TITLE
Change travis config to use iOS 9.3 for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ os: osx
 matrix:
   include:
     - language: swift
-      name: "Cocoapods BlueprintUI (Xcode 10.3)"
+      name: "Cocoapods BlueprintUI (Xcode 10.2)"
       xcode_scheme: BlueprintUI-Unit-Tests
-      osx_image: xcode10.3
+      osx_image: xcode10.2
       xcode_workspace: SampleApp.xcworkspace
-      xcode_destination: platform=iOS Simulator,OS=12.2,name=iPad Pro (9.7-inch)
+      xcode_destination: platform=iOS Simulator,OS=9.3,name=iPhone 4s
       before_install:
         - cd SampleApp
         - gem update --system


### PR DESCRIPTION
In order to catch test failures that only happen on 32-bit devices (see #35).

I had to downgrade Xcode back to 10.2 in order for the Travis config to have an iOS 9.3 simulator available.

Open to discussion on whether we should run these tests twice on both 32-bit and 64-bit platforms.