### PR TITLE
Remove snapshot test spec

### DIFF
--- a/BlueprintUICommonControls.podspec
+++ b/BlueprintUICommonControls.podspec
@@ -14,10 +14,4 @@ Pod::Spec.new do |s|
   s.source_files = 'BlueprintUICommonControls/Sources/**/*.swift'
 
   s.dependency 'BlueprintUI'
-
-  s.test_spec 'SnapshotTests' do |test_spec|
-    test_spec.source_files = 'BlueprintUICommonControls/Tests/Sources/**/*.{swift, png}'
-    test_spec.resources = 'BlueprintUICommonControls/Tests/Resources/**/*'
-    test_spec.framework = 'XCTest'
-  end
 end

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,12 +32,10 @@ See [the CocoaPods documentation for pod trunk](https://guides.cocoapods.org/mak
 
 When linting before publishing, CocoaPods will build `BlueprintUICommonControls` using the latest published version of `BlueprintUI` (not your local version). You will need to run `pod repo update` to pull the new version of `BlueprintUI` into your local specs repo immediately after publishing it.
 
-The snapshot tests for `BlueprintUICommonControls` will likely fail due to the way `pod trunk` runs tests. Use the `--skip-tests` option to get around this.
-
 You may also need to quit Xcode before running these commands in order for the linting builds to succeed.
 
 ```bash
 bundle exec pod trunk push BlueprintUI.podspec
 bundle exec pod repo update
-bundle exec pod trunk push BlueprintUICommonControls.podspec --skip-tests
+bundle exec pod trunk push BlueprintUICommonControls.podspec
 ```

--- a/SampleApp/Podfile
+++ b/SampleApp/Podfile
@@ -6,7 +6,7 @@ project 'SampleApp.xcodeproj'
 
 def blueprint_pods
   pod 'BlueprintUI', :path => '../BlueprintUI.podspec', :testspecs => ['Tests'] 
-  pod 'BlueprintUICommonControls', :path => '../BlueprintUICommonControls.podspec', :testspecs => ['SnapshotTests'] 
+  pod 'BlueprintUICommonControls', :path => '../BlueprintUICommonControls.podspec', :testspecs => [] 
 end
 
 target 'SampleApp' do

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -3,14 +3,11 @@ PODS:
   - BlueprintUI/Tests (0.3.0)
   - BlueprintUICommonControls (0.3.0):
     - BlueprintUI
-  - BlueprintUICommonControls/SnapshotTests (0.3.0):
-    - BlueprintUI
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
   - BlueprintUI/Tests (from `../BlueprintUI.podspec`)
   - BlueprintUICommonControls (from `../BlueprintUICommonControls.podspec`)
-  - BlueprintUICommonControls/SnapshotTests (from `../BlueprintUICommonControls.podspec`)
 
 EXTERNAL SOURCES:
   BlueprintUI:
@@ -20,8 +17,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   BlueprintUI: fce00cd8b9e73cf09462b8b74159b6d1f40d9f93
-  BlueprintUICommonControls: c502dba54ddb9215ec7d7165fa17e5cee67784b4
+  BlueprintUICommonControls: a18b65138a2feb3a15c5da2cf5d10b963c4bdbf5
 
-PODFILE CHECKSUM: 1a2a79db4323f9e1ef0821cbe856ba7a97403713
+PODFILE CHECKSUM: e9562cee84054ca8676daa6bfce31541238548f0
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
This makes `pod lib lint` and similar linting commands succeed for `BlueprintUICommonControls`.