### PR TITLE
[WIP DNR] Respect numberOfLines for label sizing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
       xcode_destination: platform=iOS Simulator,OS=9.3,name=iPhone 4s
       before_install:
         - cd SampleApp
-        - gem update --system
-        - gem install bundler
         - bundle install
         - bundle exec pod repo update
         - bundle exec pod install

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,13 @@ matrix:
         - bundle install
         - bundle exec pod repo update
         - bundle exec pod install
+
     - language: swift
       name: "SPM (Xcode 11.2)"
       os: osx
       osx_image: xcode11.2
       script:
-        - xcodebuild -scheme "BlueprintUI-Package" test -destination "name=iPad Pro (9.7-inch)"
+        # Split into two commands so that we can pass 'quiet' during build to only see errors and warnings.
+        - xcodebuild build-for-testing -quiet -scheme "BlueprintUI-Package" -destination "name=iPad Pro (9.7-inch)"
+        - xcodebuild test-without-building -scheme "BlueprintUI-Package" -destination "name=iPad Pro (9.7-inch)"
 

--- a/BlueprintUICommonControls.podspec
+++ b/BlueprintUICommonControls.podspec
@@ -14,4 +14,9 @@ Pod::Spec.new do |s|
   s.source_files = 'BlueprintUICommonControls/Sources/**/*.swift'
 
   s.dependency 'BlueprintUI'
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'BlueprintUICommonControls/Tests/**/*.swift'
+    test_spec.framework = 'XCTest'
+  end
 end

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -16,10 +16,13 @@ public struct AttributedLabel: Element {
     /// Creates a new label with the provided text and number of lines to display.
     public init(
         text: NSAttributedString,
-        numberOfLines: Int = 0
+        numberOfLines: Int = 0,
+        configure : (inout AttributedLabel) -> () = { _ in }
     ) {
         self.text = text
         self.numberOfLines = numberOfLines
+        
+        configure(&self)
     }
     
     /**
@@ -56,8 +59,8 @@ public struct AttributedLabel: Element {
             // constraint's maximum size. UILabel can return a size larger
             // than the provided size, and we want to stay within the provided size.
             
-            size.width = min(size.width, fittingSize.width)
-            size.height = min(size.height, fittingSize.height)
+            size.width = min(size.width, fittingSize.width).rounded(.up, by: self.roundingScale)
+            size.height = min(size.height, fittingSize.height).rounded(.up, by: self.roundingScale)
 
             return size
         }

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -1,53 +1,72 @@
 import BlueprintUI
 import UIKit
 
+// Displays attributed text in a label.
 public struct AttributedLabel: Element {
 
-    public var attributedText: NSAttributedString
+    /// The text shown within the label.
+    public var text: NSAttributedString
+    
+    /// The number of lines the label should display.
     public var numberOfLines: Int
+    
     /// The scale to which pixel measurements will be rounded. Defaults to `UIScreen.main.scale`.
     public var roundingScale: CGFloat = UIScreen.main.scale
 
-    public init(attributedText: NSAttributedString, numberOfLines: Int = 0) {
-        self.attributedText = attributedText
+    /// Creates a new label with the provided text and number of lines to display.
+    public init(
+        text: NSAttributedString,
+        numberOfLines: Int = 0
+    ) {
+        self.text = text
         self.numberOfLines = numberOfLines
     }
     
     /**
      Keep around a label to use for measurement and sizing.
      
-     We would usually do this using NSString or NSAttributedString's boundingRect family of methods,
-     but these do not let you specify a `numberOfLines` parameter, which is critical to correct sizing.
+     We would usually do this using `NSString` or `NSAttributedString's` `boundingRect` family of methods,
+     but these do not let you specify a `numberOfLines` parameter, which is critical to correct sizing. Further,
+     `UILabel`'s sizing is complex enough that we prefer to defer to its implementation, rather than atttempting
+     to re-implement it.
      
-     As such, we will allocate this label once and then use it to measure by setting its text and attributes.
+     As such, we will allocate this label once and then use it to measure by setting its text and attributes. A static
+     label is acceptable because layout code operates on the main thread.
      */
-    static let measurementLabel = UILabel()
+    private static let measurementLabel = UILabel()
 
     public var content: ElementContent {
-        
+        assert(Thread.isMainThread, "Expected sizing to occur on the main thread. This is required due to the use of `measurementLabel`.")
+
         return ElementContent { constraint in
             let label = AttributedLabel.measurementLabel
-            let description = self.backingViewDescription(bounds: CGRect(origin: .zero, size: constraint.maximum), subtreeExtent: nil)!
+            let fittingSize = constraint.maximum
+            
+            // Configure the measurement label to prepare it for measuring our text.
+            
+            let description = self.backingViewDescription(bounds: CGRect(origin: .zero, size: fittingSize), subtreeExtent: nil)!
             
             description.apply(to: label)
-            label.attributedText = self.attributedText
             
-            var size = label.sizeThatFits(constraint.maximum)
+            // Determine the returned size.
             
-            size.width = size.width.rounded(.up, by: self.roundingScale)
-            size.height = size.height.rounded(.up, by: self.roundingScale)
+            var size = label.sizeThatFits(fittingSize)
             
-            size.width = min(size.width, constraint.maximum.width, size.width)
+            // Constrain the returned size from the label to the
+            // constraint's maximum size. UILabel can return a size larger
+            // than the provided size, and we want to stay within the provided size.
+            
+            size.width = min(size.width, fittingSize.width)
+            size.height = min(size.height, fittingSize.height)
 
             return size
         }
     }
 
     public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
-        return UILabel.describe { (config) in
-            config[\.attributedText] = attributedText
+        return UILabel.describe { config in
+            config[\.attributedText] = text
             config[\.numberOfLines] = numberOfLines
         }
     }
-
 }

--- a/BlueprintUICommonControls/Sources/Label.swift
+++ b/BlueprintUICommonControls/Sources/Label.swift
@@ -7,34 +7,73 @@ public struct Label : ProxyElement {
 
     /// The text to be displayed.
     public var text: String
-    public var font: UIFont = UIFont.systemFont(ofSize: UIFont.systemFontSize)
-    public var color: UIColor = .black
-    public var alignment: NSTextAlignment = .left
-    public var numberOfLines: Int = 0
-    public var lineBreakMode: NSLineBreakMode = .byWordWrapping
-    /// The scale to which pixel measurements will be rounded. Defaults to `UIScreen.main.scale`.
-    public var roundingScale: CGFloat = UIScreen.main.scale
+    
+    /// The font used to display the label.
+    public var font: UIFont
+    
+    /// The color of the label.
+    /// Defaults to black.
+    public var color: UIColor
+    
+    /// The alignment of the label.
+    /// Defaults to left alignment.
+    public var alignment: NSTextAlignment
+    
+    /// The max number of lines the label will render.
+    /// Defaults to zero, which is as many lines as needed.
+    public var numberOfLines: Int
+    
+    /// The line break mode for displaying text.
+    /// Defaults to word wrapping.
+    public var lineBreakMode: NSLineBreakMode
+    
+    //
+    // MARK: Initialization
+    //
 
-    public init(text: String, configure: (inout Label) -> Void = { _ in }) {
+    /// Creates a new label with the provided text and options.
+    /// You can further customize the label within the `configure` block.
+    public init(
+        text: String,
+        font: UIFont = UIFont.systemFont(ofSize: UIFont.systemFontSize),
+        color: UIColor = .black,
+        alignment: NSTextAlignment = .left,
+        numberOfLines: Int = 0,
+        lineBreakMode: NSLineBreakMode = .byWordWrapping,
+        configure: (inout Label) -> Void = { _ in }
+    ) {
         self.text = text
+        
+        self.font = font
+        self.color = color
+        self.alignment = alignment
+        self.numberOfLines = numberOfLines
+        self.lineBreakMode = lineBreakMode
+        
         configure(&self)
     }
     
+    //
+    // MARK: ProxyElement
+    //
+
+    public var elementRepresentation: Element {
+        return AttributedLabel(text: self.attributedText, numberOfLines: self.numberOfLines)
+    }
+    
     private var attributedText: NSAttributedString {
+        
         let paragraphStyle = NSParagraphStyle.default.mutableCopy() as! NSMutableParagraphStyle
         paragraphStyle.alignment = alignment
         paragraphStyle.lineBreakMode = lineBreakMode
+        
         return NSAttributedString(
             string: text,
             attributes: [
                 NSAttributedString.Key.font: font,
                 NSAttributedString.Key.foregroundColor: color,
                 NSAttributedString.Key.paragraphStyle: paragraphStyle
-            ])
+            ]
+        )
     }
-
-    public var elementRepresentation: Element {
-        return AttributedLabel(attributedText: self.attributedText, numberOfLines: self.numberOfLines)
-    }
-
 }

--- a/BlueprintUICommonControls/Sources/Label.swift
+++ b/BlueprintUICommonControls/Sources/Label.swift
@@ -27,6 +27,9 @@ public struct Label : ProxyElement {
     /// Defaults to word wrapping.
     public var lineBreakMode: NSLineBreakMode
     
+    /// The scale to which pixel measurements will be rounded. Defaults to `UIScreen.main.scale`.
+    public var roundingScale: CGFloat = UIScreen.main.scale
+    
     //
     // MARK: Initialization
     //
@@ -58,7 +61,9 @@ public struct Label : ProxyElement {
     //
 
     public var elementRepresentation: Element {
-        return AttributedLabel(text: self.attributedText, numberOfLines: self.numberOfLines)
+        AttributedLabel(text: self.attributedText, numberOfLines: self.numberOfLines) {
+            $0.roundingScale = self.roundingScale
+        }
     }
     
     private var attributedText: NSAttributedString {

--- a/BlueprintUICommonControls/Sources/Label.swift
+++ b/BlueprintUICommonControls/Sources/Label.swift
@@ -3,7 +3,7 @@ import UIKit
 
 
 /// Displays text content.
-public struct Label: Element {
+public struct Label : ProxyElement {
 
     /// The text to be displayed.
     public var text: String
@@ -33,15 +33,8 @@ public struct Label: Element {
             ])
     }
 
-    public var content: ElementContent {
-        var element = AttributedLabel(attributedText: attributedText)
-        element.numberOfLines = numberOfLines
-        element.roundingScale = roundingScale
-        return ElementContent(child: element)
-    }
-
-    public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
-        return nil
+    public var elementRepresentation: Element {
+        return AttributedLabel(attributedText: self.attributedText, numberOfLines: self.numberOfLines)
     }
 
 }

--- a/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
@@ -12,7 +12,7 @@ class AttributedLabelTests: XCTestCase {
             .appending(string: "llo, ", font: .italicSystemFont(ofSize: 13.0), color: .magenta)
             .appending(string: "World!", font: .monospacedDigitSystemFont(ofSize: 32.0, weight: .black), color: .yellow)
 
-        var element = AttributedLabel(attributedText: string)
+        var element = AttributedLabel(text: string)
         element.roundingScale = 1
 
         compareSnapshot(of: element)
@@ -24,7 +24,7 @@ class AttributedLabelTests: XCTestCase {
         let string = NSAttributedString(string: "Hello, world. This is some long text that runs onto several lines.")
         let constraint = SizeConstraint(CGSize(width: 100.0, height: 200.0))
         
-        var element = AttributedLabel(attributedText: string)
+        var element = AttributedLabel(text: string)
         element.roundingScale = 1
 
         element.numberOfLines = 0
@@ -40,7 +40,7 @@ class AttributedLabelTests: XCTestCase {
     func test_numberOfLines_drawing() {
 
         let string = NSAttributedString(string: "Hello, world. This is some long text that runs onto several lines.")
-        var element = AttributedLabel(attributedText: string)
+        var element = AttributedLabel(text: string)
         element.roundingScale = 1
 
         element.numberOfLines = 0
@@ -72,8 +72,10 @@ class AttributedLabelTests: XCTestCase {
                 .appending(string: "llo, ", font: .italicSystemFont(ofSize: 13.0), color: .magenta)
                 .appending(string: "World!", font: .monospacedDigitSystemFont(ofSize: 32.0, weight: .black), color: .yellow)
 
-            var element = AttributedLabel(attributedText: string)
+            var element = AttributedLabel(text: string)
             element.roundingScale = 1
+            
+            // TODO: Measured size is entirely useless now. Replace.
 
             var measuredSize = string.boundingRect(with: size, options: .usesLineFragmentOrigin, context: nil).size
             measuredSize.width = measuredSize.width.rounded(.up)
@@ -98,7 +100,7 @@ class AttributedLabelTests: XCTestCase {
                 .font: UIFont.systemFont(ofSize: 23)
             ])
 
-        var element = AttributedLabel(attributedText: string)
+        var element = AttributedLabel(text: string)
         element.roundingScale = 2.0
 
         let size = element.content.measure(in: SizeConstraint(CGSize(width: 100, height: 100)))

--- a/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
@@ -18,8 +18,26 @@ class AttributedLabelTests: XCTestCase {
         compareSnapshot(of: element)
         
     }
+    
+    func test_numberOfLines_sizing() {
 
-    func test_numberOfLines() {
+        let string = NSAttributedString(string: "Hello, world. This is some long text that runs onto several lines.")
+        let constraint = SizeConstraint(CGSize(width: 100.0, height: 200.0))
+        
+        var element = AttributedLabel(attributedText: string)
+        element.roundingScale = 1
+
+        element.numberOfLines = 0
+        XCTAssertEqual(element.content.measure(in: constraint), CGSize(width: 100.0, height: 122.0))
+
+        element.numberOfLines = 1
+        XCTAssertEqual(element.content.measure(in: constraint), CGSize(width: 100.0, height: 21.0))
+
+        element.numberOfLines = 2
+        XCTAssertEqual(element.content.measure(in: constraint), CGSize(width: 100.0, height: 41.0))
+    }
+
+    func test_numberOfLines_drawing() {
 
         let string = NSAttributedString(string: "Hello, world. This is some long text that runs onto several lines.")
         var element = AttributedLabel(attributedText: string)

--- a/BlueprintUICommonControls/Tests/Sources/LabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/LabelTests.swift
@@ -69,8 +69,15 @@ class LabelTests: XCTestCase {
 
     }
 
-    fileprivate func compareSnapshot(identifier: String? = nil, file: StaticString = #file, testName: String = #function, line: UInt = #line, configuration: (inout Label) -> Void) {
+    fileprivate func compareSnapshot(
+        identifier: String? = nil,
+        file: StaticString = #file,
+        testName: String = #function,
+        line: UInt = #line,
+        configuration: (inout Label) -> Void
+    ) {
         var label = Label(text: "Hello, world. This is a long run of text that should wrap at some point. Someone should improve this test by adding a joke or something. Alright, it's been fun!")
+        
         label.roundingScale = 1
         configuration(&label)
         compareSnapshot(of: label, size: CGSize(width: 300, height: 300), identifier: identifier, file: file, testName: testName, line: line)

--- a/SampleApp/Podfile
+++ b/SampleApp/Podfile
@@ -6,7 +6,7 @@ project 'SampleApp.xcodeproj'
 
 def blueprint_pods
   pod 'BlueprintUI', :path => '../BlueprintUI.podspec', :testspecs => ['Tests'] 
-  pod 'BlueprintUICommonControls', :path => '../BlueprintUICommonControls.podspec', :testspecs => [] 
+  pod 'BlueprintUICommonControls', :path => '../BlueprintUICommonControls.podspec', :testspecs => ['Tests'] 
 end
 
 target 'SampleApp' do

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -3,11 +3,14 @@ PODS:
   - BlueprintUI/Tests (0.4.0)
   - BlueprintUICommonControls (0.4.0):
     - BlueprintUI
+  - BlueprintUICommonControls/Tests (0.4.0):
+    - BlueprintUI
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
   - BlueprintUI/Tests (from `../BlueprintUI.podspec`)
   - BlueprintUICommonControls (from `../BlueprintUICommonControls.podspec`)
+  - BlueprintUICommonControls/Tests (from `../BlueprintUICommonControls.podspec`)
 
 EXTERNAL SOURCES:
   BlueprintUI:
@@ -17,8 +20,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   BlueprintUI: b8dd9fbd16ac02e614be0b419648cf58194f29b1
-  BlueprintUICommonControls: b7770d0fb7b5f8de3ece216e1e8d8a82e57ab786
+  BlueprintUICommonControls: 238e022768c4af3d75084c015e020d5575413a52
 
-PODFILE CHECKSUM: e9562cee84054ca8676daa6bfce31541238548f0
+PODFILE CHECKSUM: b8516a9699aae5ba59c93dd0044a80633cec43dc
 
 COCOAPODS: 1.8.4

--- a/SampleApp/SampleApp.xcodeproj/xcshareddata/xcschemes/SampleApp.xcscheme
+++ b/SampleApp/SampleApp.xcodeproj/xcshareddata/xcschemes/SampleApp.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,28 @@
             ReferencedContainer = "container:SampleApp.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3F0DBD15A7E34A7177B40DF27414BFF9"
+               BuildableName = "BlueprintUI-Unit-Tests.xctest"
+               BlueprintName = "BlueprintUI-Unit-Tests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7E570D38AB322DDDC9CAA6AB1EC2BD87"
+               BuildableName = "BlueprintUICommonControls-Unit-Tests.xctest"
+               BlueprintName = "BlueprintUICommonControls-Unit-Tests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +79,6 @@
             ReferencedContainer = "container:SampleApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Need to respect the `numberOfLines` on a `Label` or `AttributedLabel` when measuring elements. Otherwise, the size returned from the `measure` function ends up being wrong.

Ended up doing this by keeping around a static `UILabel`, which we can then use via `sizeThatFits` to get the correct size of the label. This seemed easier than dropping down to the CoreText or TextKit APIs... thoughts?