### PR TITLE
[WIP DNR] Cache Text Sizing / Measurement

### DIFF
--- a/BlueprintUI/Sources/Layout/StringSizingCache.swift
+++ b/BlueprintUI/Sources/Layout/StringSizingCache.swift
@@ -1,0 +1,86 @@
+//
+//  StringSizingCache.swift
+//  BlueprintUI
+//
+//  Created by Kyle Van Essen on 12/16/19.
+//
+
+import Foundation
+
+
+public final class StringSizingCache
+{
+    public static let `default` = StringSizingCache()
+    
+    public init() {}
+    
+    private var cache : [Entry:CGSize] = [:]
+    
+    public func size(with size : CGSize, string : NSAttributedString, numberOfLines : Int) -> CGSize
+    {
+        let entry = Entry(size: size, string: string, numberOfLines: numberOfLines)
+        
+        if let existing = self.cache[entry] {
+            return existing
+        } else {
+            let size = entry.measure()
+            
+            self.cache[entry] = size
+            
+            return size
+        }
+    }
+}
+
+public extension StringSizingCache
+{
+    struct Entry : Hashable
+    {
+        public let size : CGSize
+        
+        public let string : NSAttributedString
+        public let numberOfLines : Int
+            
+        public init(size : CGSize, string : NSAttributedString, numberOfLines : Int)
+        {
+            self.size = size
+            self.string = string.copy() as! NSAttributedString
+            self.numberOfLines = numberOfLines
+            
+            var hasher = Hasher()
+            self.size.width.hash(into: &hasher)
+            self.size.height.hash(into: &hasher)
+            self.string.hash(into: &hasher)
+            self.numberOfLines.hash(into: &hasher)
+
+            self.hashCode = hasher.finalize()
+        }
+        
+        private let hashCode : Int
+        
+        public func hash(into hasher: inout Hasher)
+        {
+            self.hashCode.hash(into: &hasher)
+        }
+        
+        /**
+         Keep around a label to use for measurement and sizing.
+         
+         We would usually do this using NSString or NSAttributedString's boundingRect family of methods,
+         but these do not let you specify a `numberOfLines` parameter, which is critical to correct sizing.
+         
+         As such, we will allocate this label once and then use it to measure by setting its text and attributes.
+         */
+        private static let measuringLabel = UILabel()
+        
+        public func measure() -> CGSize
+        {
+            let label = Entry.measuringLabel
+            
+            label.attributedText = self.string
+            label.numberOfLines = self.numberOfLines
+            
+            return label.sizeThatFits(self.size)
+        }
+    }
+}

--- a/BlueprintUI/Sources/Layout/StringSizingCache.swift
+++ b/BlueprintUI/Sources/Layout/StringSizingCache.swift
@@ -32,7 +32,7 @@ public final class StringSizingCache
     }
 }
 
-public extension StringSizingCache
+extension StringSizingCache
 {
     struct Entry : Hashable
     {
@@ -58,7 +58,7 @@ public extension StringSizingCache
         
         private let hashCode : Int
         
-        public func hash(into hasher: inout Hasher)
+        func hash(into hasher: inout Hasher)
         {
             self.hashCode.hash(into: &hasher)
         }

--- a/BlueprintUI/Tests/StringSizingCacheTests.swift
+++ b/BlueprintUI/Tests/StringSizingCacheTests.swift
@@ -24,10 +24,23 @@ class StringSizingCacheTests : XCTestCase
             "Donec id suscipit elit, at sagittis sem. Duis faucibus tempus lacus et porta.",
             "Vivamus aliquam, nibh laoreet iaculis vehicula, sapien elit rhoncus leo, sed elementum augue risus vel orci. Vivamus imperdiet interdum quam vitae rutrum. Curabitur ac augue eu eros mollis pretium.",
             "Phasellus mauris velit, tristique id leo at, varius semper neque. Suspendisse potenti. Integer aliquet porta ante, et convallis est cursus ac.",
+            
+            """
+            Cras ultricies aliquam nisl, dictum maximus massa semper vitae. Maecenas mattis tempus turpis. Integer fermentum purus in velit posuere, vitae tristique lorem eleifend. Duis ultricies mauris massa, a auctor nibh ultrices quis. Sed ultricies auctor facilisis. Vivamus a lacus accumsan, pellentesque justo vulputate, molestie tortor. Mauris ut nunc quis lacus sagittis faucibus. Praesent sed posuere tortor, facilisis commodo erat. Quisque arcu lorem, egestas at luctus sit amet, dictum ut lacus. Phasellus ac sapien in massa mollis dapibus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam ultricies tortor ut lobortis luctus.
+
+            Maecenas viverra justo lectus, quis consectetur augue rhoncus ut. In porta tellus eu pellentesque cursus. Donec ultrices tortor tellus, vel elementum urna aliquet sit amet. Morbi metus arcu, lobortis in lacus egestas, tincidunt condimentum turpis. Nam sit amet dui velit. Nullam lacinia mauris pharetra est porta, ac sodales nulla pellentesque. Pellentesque feugiat venenatis libero id placerat.
+            """,
+            
+            """
+            Cras ut enim sed nibh tempor sollicitudin lobortis sed lacus. Praesent eget luctus arcu. Integer eget est blandit, rutrum quam sit amet, hendrerit risus. Vestibulum cursus efficitur turpis, quis varius mauris semper at. Integer tempor eu nulla ut lacinia. Sed a orci volutpat, volutpat magna id, porta leo. Vestibulum posuere purus orci, at sollicitudin tortor consectetur sed.
+
+            Sed ut nisl a nunc tempus bibendum. Integer semper lorem sed augue feugiat ullamcorper. Sed at sapien eget enim rhoncus viverra nec a sem. Ut commodo tellus mauris, a finibus tortor mattis vel. Mauris sed justo vestibulum, molestie tortor ut, ullamcorper turpis. Proin a varius neque. Curabitur leo orci, porttitor ut enim ut, blandit commodo magna. Fusce hendrerit cursus dui, non faucibus arcu hendrerit eget. Integer vitae faucibus nunc. Praesent auctor eros quis auctor feugiat. Proin nibh urna, consequat at suscipit quis, aliquet id urna. Suspendisse commodo, est id vulputate iaculis, nulla arcu accumsan tortor, eget sagittis arcu libero at turpis.
+            """,
         ]
         
+        let cache = StringSizingCache()
+        
         let cachedTime = self.measureDuration {
-            let cache = StringSizingCache()
             
             for string in strings {
                 _ = cache.size(with: CGSize(width: 200.0, height: 1000.0), string: NSAttributedString(string: string), numberOfLines: 0)

--- a/BlueprintUI/Tests/StringSizingCacheTests.swift
+++ b/BlueprintUI/Tests/StringSizingCacheTests.swift
@@ -1,0 +1,61 @@
+//
+//  StringSizingCacheTests.swift
+//  BlueprintUI-Unit-Tests
+//
+//  Created by Kyle Van Essen on 12/16/19.
+//
+
+import XCTest
+@testable import BlueprintUI
+
+
+class StringSizingCacheTests : XCTestCase
+{
+    func test_size()
+    {
+        
+    }
+    
+    func test_performance()
+    {
+        let strings : [String] = [
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+            "Sed laoreet tristique nunc ac malesuada. Integer at tristique lacus. Ut tristique libero et libero vehicula, nec posuere libero tincidunt.",
+            "Donec id suscipit elit, at sagittis sem. Duis faucibus tempus lacus et porta.",
+            "Vivamus aliquam, nibh laoreet iaculis vehicula, sapien elit rhoncus leo, sed elementum augue risus vel orci. Vivamus imperdiet interdum quam vitae rutrum. Curabitur ac augue eu eros mollis pretium.",
+            "Phasellus mauris velit, tristique id leo at, varius semper neque. Suspendisse potenti. Integer aliquet porta ante, et convallis est cursus ac.",
+        ]
+        
+        let cachedTime = self.measureDuration {
+            let cache = StringSizingCache()
+            
+            for string in strings {
+                _ = cache.size(with: CGSize(width: 200.0, height: 1000.0), string: NSAttributedString(string: string), numberOfLines: 0)
+            }
+        }
+        
+        let uncachedTime = self.measureDuration {
+            for string in strings {
+                let attributed = NSAttributedString(string: string)
+                
+                _ = attributed.boundingRect(with: CGSize(width: 200.0, height: 1000.0), options: .usesLineFragmentOrigin, context: nil)
+            }
+        }
+        
+        print("Cached: \(cachedTime)")
+        print("Uncached: \(uncachedTime)")
+        
+        XCTAssertTrue(cachedTime < uncachedTime)
+    }
+    
+    private func measureDuration( _ block : () -> ()) -> TimeInterval
+    {
+        let start = Date()
+        
+        for _ in 1...10_000 {
+            block()
+        }
+        
+        return Date().timeIntervalSince(start)
+    }
+}

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -12,33 +12,18 @@ public struct AttributedLabel: Element {
         self.attributedText = attributedText
         self.numberOfLines = numberOfLines
     }
-    
-    /**
-     Keep around a label to use for measurement and sizing.
-     
-     We would usually do this using NSString or NSAttributedString's boundingRect family of methods,
-     but these do not let you specify a `numberOfLines` parameter, which is critical to correct sizing.
-     
-     As such, we will allocate this label once and then use it to measure by setting its text and attributes.
-     */
-    static let measurementLabel = UILabel()
 
     public var content: ElementContent {
-        
         return ElementContent { constraint in
-            let label = AttributedLabel.measurementLabel
-            let description = self.backingViewDescription(bounds: CGRect(origin: .zero, size: constraint.maximum), subtreeExtent: nil)!
-            
-            description.apply(to: label)
-            label.attributedText = self.attributedText
-            
-            var size = label.sizeThatFits(constraint.maximum)
+            var size = StringSizingCache.default.size(
+                with: constraint.maximum,
+                string: self.attributedText,
+                numberOfLines: self.numberOfLines
+            )
             
             size.width = size.width.rounded(.up, by: self.roundingScale)
             size.height = size.height.rounded(.up, by: self.roundingScale)
             
-            size.width = min(size.width, constraint.maximum.width, size.width)
-
             return size
         }
     }


### PR DESCRIPTION
WIP WIP WIP

Makes text measurement way faster by caching it. Downside is layout is now restricted to main thread, or I could drop down to TextKit...

```
Cached: 0.19604599475860596
Uncached: 6.434000015258789
```