### PR TITLE
Fix zero-size elements in Stacks causing NaN in LayoutAttributes

### DIFF
--- a/BlueprintUI/Sources/Internal/ElementPath.swift
+++ b/BlueprintUI/Sources/Internal/ElementPath.swift
@@ -42,13 +42,12 @@ struct ElementPath: Hashable {
     static var empty: ElementPath {
         return ElementPath()
     }
-    
 }
 
 extension ElementPath {
 
     /// Represents an element in a hierarchy.
-    struct Component: Hashable {
+    struct Component: Hashable, CustomDebugStringConvertible {
 
         /// The type of element represented by this component.
         var elementType: Element.Type
@@ -71,13 +70,17 @@ extension ElementPath {
             hasher.combine(identifier)
         }
 
+        // MARK: CustomDebugStringConvertible
+        
+        var debugDescription: String {
+            return "\(self.elementType).\(self.identifier)"
+        }
     }
-    
 }
 
 extension ElementPath {
     
-    fileprivate final class Storage: Hashable {
+    fileprivate final class Storage: Hashable, CustomDebugStringConvertible {
         
         private var _hash: Int? = nil
         
@@ -110,7 +113,11 @@ extension ElementPath {
             return lhs.components == rhs.components
         }
         
+        // MARK: CustomDebugStringConvertible
+        
+        var debugDescription: String {
+            return self.components.map { $0.debugDescription }.joined()
+        }
     }
-    
 }
 

--- a/BlueprintUI/Sources/Layout/LayoutAttributes.swift
+++ b/BlueprintUI/Sources/Layout/LayoutAttributes.swift
@@ -30,7 +30,8 @@ public struct LayoutAttributes {
     public init(frame: CGRect) {
         self.init(
             center: CGPoint(x: frame.midX, y: frame.midY),
-            bounds: CGRect(origin: .zero, size: frame.size))
+            bounds: CGRect(origin: .zero, size: frame.size)
+        )
     }
     
     public init(size: CGSize) {
@@ -167,38 +168,40 @@ extension LayoutAttributes: Equatable {
 }
 
 extension CGRect {
-    fileprivate var isFinite: Bool {
-        return origin.isFinite || size.isFinite
+    var isFinite: Bool {
+        return origin.isFinite && size.isFinite
     }
 }
 
 extension CGPoint {
-    fileprivate var isFinite: Bool {
-        return x.isFinite || y.isFinite
+    var isFinite: Bool {
+        return x.isFinite && y.isFinite
     }
 }
 
 extension CGSize {
-    fileprivate var isFinite: Bool {
-        return width.isFinite || height.isFinite
+    var isFinite: Bool {
+        return width.isFinite && height.isFinite
     }
 }
 
 extension CATransform3D {
-
-    fileprivate var isFinite: Bool {
+    var isFinite: Bool {
         return m11.isFinite
             && m12.isFinite
             && m13.isFinite
             && m14.isFinite
+            
             && m21.isFinite
             && m22.isFinite
             && m23.isFinite
             && m24.isFinite
+            
             && m31.isFinite
             && m32.isFinite
             && m33.isFinite
             && m34.isFinite
+            
             && m41.isFinite
             && m42.isFinite
             && m43.isFinite

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -253,7 +253,11 @@ extension StackLayout {
             var priority: CGFloat
             switch overflow {
             case .condenseProportionally:
-                priority = basis.axis / totalBasisSize
+                if totalBasisSize > 0 {
+                    priority = basis.axis / totalBasisSize
+                } else {
+                    priority = basis.axis
+                }
             case .condenseUniformly:
                 priority = 1.0
             }
@@ -291,8 +295,9 @@ extension StackLayout {
 
         let minimumTotalSpace = minimumSpacing * CGFloat(basisSizes.count-1)
         let extraSize: CGFloat = layoutSize.axis - (totalBasisSize + minimumTotalSpace)
+        
         assert(extraSize >= 0.0)
-
+        
         let space: CGFloat
 
         switch underflow {
@@ -337,7 +342,11 @@ extension StackLayout {
             var priority: CGFloat
             switch underflow {
             case .growProportionally:
-                priority = basis.axis / totalBasisSize
+                if totalBasisSize > 0 {
+                    priority = basis.axis / totalBasisSize
+                } else {
+                    priority = basis.axis
+                }
             case .growUniformly:
                 priority = 1.0
             case .spaceEvenly:

--- a/BlueprintUI/Tests/LayoutAttributesTests.swift
+++ b/BlueprintUI/Tests/LayoutAttributesTests.swift
@@ -4,9 +4,6 @@ import QuartzCore
 
 final class LayoutAttributesTests: XCTestCase {
     
-    
-    
-    
     func testEquality() {
         
         let attributes = LayoutAttributes(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
@@ -116,4 +113,47 @@ final class LayoutAttributesTests: XCTestCase {
 
     }
     
+}
+
+final class LayoutAttributesTests_CGRect : XCTestCase {
+    
+    func test_isFinite() {
+        XCTAssertTrue(CGRect(origin: CGPoint(x: 0.0, y: 0.0), size: CGSize(width: 100.0, height: 100.0)).isFinite)
+        
+        XCTAssertFalse(CGRect(origin: CGPoint(x: 0.0, y: CGFloat.nan), size: CGSize(width: 100.0, height: 100.0)).isFinite)
+        XCTAssertFalse(CGRect(origin: CGPoint(x: 0.0, y: 0.0), size: CGSize(width: 100.0, height: CGFloat.nan)).isFinite)
+        XCTAssertFalse(CGRect(origin: CGPoint(x: 0.0, y: CGFloat.nan), size: CGSize(width: 100.0, height: CGFloat.nan)).isFinite)
+    }
+}
+
+final class LayoutAttributesTests_CGPoint : XCTestCase {
+    
+    func test_isFinite() {
+        XCTAssertTrue(CGPoint(x: 10.0, y: 5.0).isFinite)
+        
+        XCTAssertFalse(CGPoint(x: CGFloat.nan, y: 5.0).isFinite)
+        XCTAssertFalse(CGPoint(x: 10.0, y: CGFloat.nan).isFinite)
+    }
+}
+
+final class LayoutAttributesTests_CGSize : XCTestCase {
+    
+    func test_isFinite() {
+        XCTAssertTrue(CGSize(width: 10.0, height: 5.0).isFinite)
+        
+        XCTAssertFalse(CGSize(width: CGFloat.nan, height: 5.0).isFinite)
+        XCTAssertFalse(CGSize(width: 10.0, height: CGFloat.nan).isFinite)
+    }
+}
+
+final class LayoutAttributesTests_CATransform3D : XCTestCase {
+    
+    func test_isFinite() {
+        XCTAssertTrue(CATransform3DIdentity.isFinite)
+        
+        var invalid = CATransform3DIdentity
+        invalid.m11 = CGFloat.nan
+        
+        XCTAssertFalse(invalid.isFinite)
+    }
 }

--- a/BlueprintUI/Tests/StackTests.swift
+++ b/BlueprintUI/Tests/StackTests.swift
@@ -180,6 +180,24 @@ class StackTests: XCTestCase {
 
         }
 
+        // Ensure that elements of size zero do not result in NaN in the outputted frames.
+        
+        do {
+            // Note: Only applicable to `growProportionally`.
+            
+            test(
+                underflow: .growProportionally,
+                layoutLength: 100,
+                items: [
+                    (measuredLength: 0, growPriority: 1.0),
+                    (measuredLength: 0, growPriority: 1.0),
+                ],
+                expectedRanges: [
+                    0...0,
+                    0...0
+                ]
+            )
+        }
 
         // Test single child for different underflow distributions, including different grow priorities.
         do {
@@ -513,7 +531,28 @@ class StackTests: XCTestCase {
             }
 
         }
-
+        
+        // Ensure that elements of size zero do not result in NaN in the outputted frames.
+        
+        do {
+            // Note: Only applicable to `condenseProportionally`.
+            
+            test(
+                overflow: .condenseProportionally,
+                
+                // Requires zero, otherwise we will never have an overflow (which is >= to content size).
+                layoutLength: 0,
+                
+                items: [
+                    (measuredLength: 0.0, shrinkPriority: 1.0),
+                    (measuredLength: 0.0, shrinkPriority: 1.0),
+                ],
+                expectedRanges: [
+                    0...0,
+                    0...0
+                ]
+            )
+        }
 
         // Test single child for different overflow distributions, including different shrink priorities.
         do {
@@ -608,8 +647,6 @@ class StackTests: XCTestCase {
 
 
     }
-
-
 }
 
 


### PR DESCRIPTION
- Ensure NaN does not end up in frames calculated in stacks for zero size elements.
- Fix isFinite validation.
- Add tests for this case
- Add DebugDescription to the ElementPath so it's easier to figure out what's what in the debugger.