### PR TITLE
Allow ScrollView to dismiss the keyboard on tap

### DIFF
--- a/BlueprintUICommonControls/Sources/ScrollView.swift
+++ b/BlueprintUICommonControls/Sources/ScrollView.swift
@@ -17,7 +17,7 @@ public struct ScrollView: Element {
     public var showsHorizontalScrollIndicator: Bool = true
     public var showsVerticalScrollIndicator: Bool = true
     public var pullToRefreshBehavior: PullToRefreshBehavior = .disabled
-    public var shouldEndEditingOnTap = false
+    public var keyboardDismissMode = UIScrollView.KeyboardDismissMode.none
 
     public init(wrapping element: Element) {
         self.wrappedElement = element
@@ -265,7 +265,7 @@ fileprivate final class ScrollerWrapperView: UIView {
         }
 
 
-        self.scrollView.keyboardDismissMode = scrollView.shouldEndEditingOnTap ? .onDrag : .none
+        self.scrollView.keyboardDismissMode = scrollView.keyboardDismissMode
     }
 
 }

--- a/BlueprintUICommonControls/Sources/ScrollView.swift
+++ b/BlueprintUICommonControls/Sources/ScrollView.swift
@@ -17,6 +17,7 @@ public struct ScrollView: Element {
     public var showsHorizontalScrollIndicator: Bool = true
     public var showsVerticalScrollIndicator: Bool = true
     public var pullToRefreshBehavior: PullToRefreshBehavior = .disabled
+    public var shouldEndEditingOnTap = false
 
     public init(wrapping element: Element) {
         self.wrappedElement = element
@@ -264,6 +265,7 @@ fileprivate final class ScrollerWrapperView: UIView {
         }
 
 
+        self.scrollView.keyboardDismissMode = scrollView.shouldEndEditingOnTap ? .onDrag : .none
     }
 
 }

--- a/BlueprintUICommonControls/Sources/ScrollView.swift
+++ b/BlueprintUICommonControls/Sources/ScrollView.swift
@@ -239,6 +239,10 @@ fileprivate final class ScrollerWrapperView: UIView {
             self.scrollView.showsHorizontalScrollIndicator = scrollView.showsHorizontalScrollIndicator
         }
 
+        if self.scrollView.keyboardDismissMode != scrollView.keyboardDismissMode {
+            self.scrollView.keyboardDismissMode = scrollView.keyboardDismissMode
+        }
+
         var contentInset = scrollView.contentInset
 
         if case .refreshing = scrollView.pullToRefreshBehavior, let refreshControl = refreshControl {
@@ -265,7 +269,6 @@ fileprivate final class ScrollerWrapperView: UIView {
         }
 
 
-        self.scrollView.keyboardDismissMode = scrollView.keyboardDismissMode
     }
 
 }

--- a/SampleApp/Sources/ViewController.swift
+++ b/SampleApp/Sources/ViewController.swift
@@ -28,7 +28,7 @@ let posts = [
 
 final class ViewController: UIViewController {
 
-    private let blueprintView = BlueprintView(element: List(posts: posts))
+    private let blueprintView = BlueprintView(element: MainView(posts: posts))
 
     override func loadView() {
         self.view = blueprintView
@@ -36,6 +36,30 @@ final class ViewController: UIViewController {
 
 }
 
+fileprivate struct MainView: ProxyElement {
+    
+    var posts: [Post]
+    
+    var elementRepresentation: Element {
+        let col = Column { col in
+            col.horizontalAlignment = .fill
+
+            col.add(child: List(posts: posts))
+            col.add(child: CommentForm())
+        }
+        
+        var scroll = ScrollView(wrapping: col)
+        scroll.contentSize = .fittingHeight
+        scroll.alwaysBounceVertical = true
+        scroll.shouldEndEditingOnTap = true
+
+        let background = Box(
+            backgroundColor: UIColor(white: 0.95, alpha: 1.0),
+            wrapping: scroll)
+
+        return background
+    }
+}
 
 fileprivate struct List: ProxyElement {
 
@@ -51,17 +75,34 @@ fileprivate struct List: ProxyElement {
             }
         }
 
-        var scroll = ScrollView(wrapping: col)
-        scroll.contentSize = .fittingHeight
-        scroll.alwaysBounceVertical = true
-
-        let background = Box(
-            backgroundColor: UIColor(white: 0.95, alpha: 1.0),
-            wrapping: scroll)
-
-        return background
+        return col
     }
+}
 
+fileprivate struct CommentForm: ProxyElement {
+    
+    var elementRepresentation: Element {
+        let col = Column { col in
+            col.horizontalAlignment = .fill
+
+            let label = Label(text: "Add your comment:")
+            col.add(child: label)
+
+            var nameField = TextField(text: "")
+            nameField.placeholder = "Name"
+            col.add(child: nameField)
+
+            var commentField = TextField(text: "")
+            commentField.placeholder = "Comment"
+            col.add(child: commentField)
+        }
+        
+        return Box(
+            backgroundColor: .lightGray,
+            wrapping: Inset(
+                uniformInset: 16.0,
+                wrapping: col))
+    }
 }
 
 

--- a/SampleApp/Sources/ViewController.swift
+++ b/SampleApp/Sources/ViewController.swift
@@ -51,7 +51,7 @@ fileprivate struct MainView: ProxyElement {
         var scroll = ScrollView(wrapping: col)
         scroll.contentSize = .fittingHeight
         scroll.alwaysBounceVertical = true
-        scroll.shouldEndEditingOnTap = true
+        scroll.keyboardDismissMode = .onDrag
 
         let background = Box(
             backgroundColor: UIColor(white: 0.95, alpha: 1.0),


### PR DESCRIPTION
Tapping in a text field brings up the keyboard, but (on iPhone) there is no built-in way to dismiss it. This is a problem because the keyboard may cover up other UI elements, making them inaccessible.

This fixes the problem by adding a new property, shouldEndEditingOnTap, which defaults to false. Setting it to true changes the underlying UIScrollView’s keyboardDismissMode to .onDrag.

This change also demonstrates the new behavior in the SampleApp by adding a couple of text fields to it.