### PR TITLE
Implement intrinsicContentSize on BlueprintView

### DIFF
--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -39,8 +39,8 @@ public final class BlueprintView: UIView {
     /// The root element that is displayed within the view.
     public var element: Element? {
         didSet {
-            invalidateIntrinsicContentSize()
             setNeedsViewHierarchyUpdate()
+            invalidateIntrinsicContentSize()
         }
     }
 
@@ -92,7 +92,14 @@ public final class BlueprintView: UIView {
     public override var intrinsicContentSize: CGSize {
         guard let element = element else { return .zero }
         let constraint: SizeConstraint
-        if bounds.width == 0 {
+
+        // Use unconstrained when
+        // a) we need a view hierarchy update to force a loop through an
+        //    unconstrained width so we don’t end up “caching” the previous
+        //    element’s width
+        // b) the current width is zero, since constraining by zero is
+        //    nonsensical
+        if bounds.width == 0 || needsViewHierarchyUpdate {
             constraint = .unconstrained
         } else {
             constraint = SizeConstraint(width: bounds.width)

--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -39,6 +39,7 @@ public final class BlueprintView: UIView {
     /// The root element that is displayed within the view.
     public var element: Element? {
         didSet {
+            invalidateIntrinsicContentSize()
             setNeedsViewHierarchyUpdate()
         }
     }
@@ -60,6 +61,8 @@ public final class BlueprintView: UIView {
         
         self.backgroundColor = .white
         addSubview(rootController.view)
+        setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        setContentHuggingPriority(.defaultHigh, for: .vertical)
     }
 
     public override convenience init(frame: CGRect) {
@@ -83,9 +86,23 @@ public final class BlueprintView: UIView {
         }
         return element.content.measure(in: constraint)
     }
+
+    /// Returns the size of the element bound to the current width (mimicking
+    /// UILabel’s `intrinsicContentSize` behavior)
+    public override var intrinsicContentSize: CGSize {
+        guard let element = element else { return .zero }
+        let constraint: SizeConstraint
+        if bounds.width == 0 {
+            constraint = .unconstrained
+        } else {
+            constraint = SizeConstraint(width: bounds.width)
+        }
+        return element.content.measure(in: constraint)
+    }
     
     override public func layoutSubviews() {
         super.layoutSubviews()
+        invalidateIntrinsicContentSize()
         performUpdate()
     }
     


### PR DESCRIPTION
I mostly want then when making SwiftUI previews for BlueprintElements, providing a UIViewRepresentable around a BlueprintView. But it would also be useful for people putting Blueprint elements into a UI that uses auto layout.
