### PR TITLE
Rename Builder to ContentStorage

### DIFF
--- a/BlueprintUI/Sources/Element/Element.swift
+++ b/BlueprintUI/Sources/Element/Element.swift
@@ -31,10 +31,9 @@ import UIKit
 ///     // backed by a UIView instance when displayed in a `BlueprintView`.
 ///     func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
 ///         return UIView.describe { config in
-///             config.bind(backgroundColor, to: \.backgrouncColor)
+///             config.bind(backgroundColor, to: \.backgroundColor)
 ///         }
 ///     }
-///
 /// }
 /// ```
 ///

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -13,9 +13,13 @@ public protocol StackElement: Element {
 extension StackElement {
 
     public var content: ElementContent {
-        return ElementContent(layout: layout) {
+        ElementContent(layout: layout) {
             for child in self.children {
-                $0.add(traits: child.traits, key: child.key, element: child.element)
+                $0.add(
+                    element: child.element,
+                    traits: child.traits,
+                    key: child.key
+                )
             }
         }
     }

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -112,9 +112,9 @@ private struct TestContainer: Element {
     var children: [Element]
     
     var content: ElementContent {
-        return ElementContent(layout: TestLayout()) { (builder) in
+        return ElementContent(layout: TestLayout()) {
             for child in children {
-                builder.add(element: child)
+                $0.add(element: child)
             }
         }
     }

--- a/BlueprintUI/Tests/ElementContentTests.swift
+++ b/BlueprintUI/Tests/ElementContentTests.swift
@@ -13,7 +13,7 @@ class ElementContentTests: XCTestCase {
         let frame = CGRect(x: 0, y: 0, width: 20, height: 20)
 
         let container = ElementContent(layout: FrameLayout()) {
-            $0.add(traits: frame, element: SimpleElement())
+            $0.add(element: SimpleElement(), traits: frame)
         }
 
         let children = container
@@ -33,8 +33,8 @@ class ElementContentTests: XCTestCase {
         let frame2 = CGRect(x: 200, y: 300, width: 400, height: 500)
 
         let container = ElementContent(layout: FrameLayout()) {
-            $0.add(traits: frame1, element: SimpleElement())
-            $0.add(traits: frame2, element: SimpleElement())
+            $0.add(element: SimpleElement(), traits: frame1)
+            $0.add(element: SimpleElement(), traits: frame2)
         }
 
         let children = container


### PR DESCRIPTION
Builder was a weird name for this value, since it was always accessed through .storage. Rename to ContentStorage.