### PR TITLE
Remove obsolete layout rounding

### DIFF
--- a/BlueprintUI/Sources/Layout/Aligned.swift
+++ b/BlueprintUI/Sources/Layout/Aligned.swift
@@ -103,10 +103,6 @@ public struct Aligned: Element {
                 attributes.frame.size.width = size.width
             }
 
-            // TODO: screen-scale round here once that lands
-            attributes.frame.origin.x.round()
-            attributes.frame.origin.y.round()
-
             return attributes
         }
     }

--- a/BlueprintUI/Sources/Layout/AspectRatio.swift
+++ b/BlueprintUI/Sources/Layout/AspectRatio.swift
@@ -24,12 +24,10 @@ public struct AspectRatio {
     }
 
     func height(forWidth width: CGFloat) -> CGFloat {
-        // TODO: round to screen scale when that lands
-        return (width / ratio).rounded()
+        return width / ratio
     }
 
     func width(forHeight height: CGFloat) -> CGFloat {
-        // TODO: round to screen scale when that lands
-        return (height * ratio).rounded()
+        return height * ratio
     }
 }

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -454,7 +454,7 @@ extension StackLayout {
         case .justifyToStart:
             axisOrigin = 0.0
         case .justifyToCenter:
-            axisOrigin = (extraSize / 2.0).rounded() // TODO: @narenh - Add screen scale rounding
+            axisOrigin = extraSize / 2.0
         case .justifyToEnd:
             axisOrigin = extraSize
         }

--- a/BlueprintUI/Tests/CenteredTests.swift
+++ b/BlueprintUI/Tests/CenteredTests.swift
@@ -20,7 +20,7 @@ class CenteredTests: XCTestCase {
             XCTAssertEqual(
                 child.layoutAttributes.frame,
                 CGRect(
-                    x: 2439,
+                    x: 2438.5,
                     y: 2772,
                     width: 123,
                     height: 456))

--- a/BlueprintUI/Tests/StackTests.swift
+++ b/BlueprintUI/Tests/StackTests.swift
@@ -383,7 +383,7 @@ class StackTests: XCTestCase {
                     (measuredLength: 5, growPriority: 0.0)
                 ],
                 expectedRanges: [
-                    3...8
+                    2.5...7.5
                 ])
 
             test(
@@ -393,7 +393,7 @@ class StackTests: XCTestCase {
                     (measuredLength: 12, growPriority: 0.0)
                 ],
                 expectedRanges: [
-                    2...14
+                    1.5...13.5
                 ])
 
             test(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Changed [BlueprintView.sizeThatFits(:)](https://github.com/square/Blueprint/pull/92/files) to treat width and height separately when determining if measurement should be unconstrained in a given axis.
 
+- Removed layout rounding no longer needed since [#64] ([#95]).
+
 ### Added
 
 - [Added support](https://github.com/square/Blueprint/pull/88) for `SwiftUI`-style element building within `BlueprintUI` and `BlueprintUICommonControls`.
@@ -83,3 +85,4 @@ Improving readability and conciseness of your elements.
 
 [0.10.0]: https://github.com/square/Blueprint/compare/0.9.2...0.10.0
 [#64]: https://github.com/square/Blueprint/pull/64
+[#95]: https://github.com/square/Blueprint/pull/95


### PR DESCRIPTION
This rounding is counter-productive; it should be handled by the post-layout pixel boundary alignment now.