### PR TITLE
Move default values into initialzer for Image Element

### DIFF
--- a/BlueprintUICommonControls/Sources/Image.swift
+++ b/BlueprintUICommonControls/Sources/Image.swift
@@ -9,15 +9,21 @@ public struct Image: Element {
     public var image: UIImage?
 
     /// The tint color.
-    public var tintColor: UIColor? = nil
+    public var tintColor: UIColor?
 
     /// The content mode determines the layout of the image when its size does
     /// not precisely match the size that the element is assigned.
-    public var contentMode: ContentMode = .aspectFill
+    public var contentMode: ContentMode
 
     /// Initializes an image element with the given `UIImage` instance.
-    public init(image: UIImage?) {
+    public init(
+        image: UIImage?,
+        contentMode: ContentMode = .aspectFill,
+        tintColor: UIColor? = nil
+    ) {
         self.image = image
+        self.contentMode = contentMode
+        self.tintColor = tintColor
     }
 
     public var content: ElementContent {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Add support for the iPhone SE 2](https://github.com/square/Blueprint/pull/96) in `ElementPreview`.
+- Added `tintColor` and `contentMode` into the initializer for `Image`
 
 ### Removed
 


### PR DESCRIPTION
Allow the `tintColor` and `contentMode` to get passed in via the initializer for Image, similar to how `Box` works.

I found most of the time i was using image, I needed to create a local var and change one of these properties. This would retain the ability to edit them, but also pass in via initialization to get everything done in one line. 