### PR TITLE
Skip update path if element remains nil

### DIFF
--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -27,7 +27,7 @@ import UIKit
 /// ```
 public final class BlueprintView: UIView {
 
-    private var needsViewHierarchyUpdate: Bool = true
+    private(set) var needsViewHierarchyUpdate: Bool = true
     private var hasUpdatedViewHierarchy: Bool = false
     private var lastViewHierarchyUpdateBounds: CGRect = .zero
 
@@ -39,6 +39,11 @@ public final class BlueprintView: UIView {
     /// The root element that is displayed within the view.
     public var element: Element? {
         didSet {
+            // Minor performance optimization: We do not need to update anything if the element remains nil.
+            if oldValue == nil && self.element == nil {
+                return
+            }
+            
             setNeedsViewHierarchyUpdate()
             invalidateIntrinsicContentSize()
         }

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -140,7 +140,18 @@ class BlueprintViewTests: XCTestCase {
             XCTAssertEqual(node.view.tag, tags[index])
         }
     }
-
+    
+    func test_nil_element() {
+        
+        let view = BlueprintView()
+        view.layoutIfNeeded()
+        
+        XCTAssertNil(view.element)
+        XCTAssertEqual(view.needsViewHierarchyUpdate, false)
+        
+        view.element = nil
+        XCTAssertEqual(view.needsViewHierarchyUpdate, false)
+    }
 }
 
 fileprivate struct MeasurableElement : Element {


### PR DESCRIPTION
This is a minor perf optimization I noticed in Listable; in particular we'd still go through the update path even if the element for the background view or selected background view remained nil (which is usually the case). This saves a bit of time, which adds up during scroll events as cells get recycled (about 1-2ms in testing; you only get 16ms to maintain 60fps scrolling).