### PR TITLE
Add AccessibilityContainer element

### DIFF
--- a/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
@@ -48,7 +48,7 @@ extension AccessibilityContainer {
     private final class AccessibilityContainerView: UIView {
         override var accessibilityElements: [Any]? {
             get { recursiveAccessibleSubviews() }
-            set { fatalError() }
+            set { fatalError("This property is not settable") }
         }
     }
 }

--- a/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
@@ -1,0 +1,68 @@
+import BlueprintUI
+import UIKit
+
+/// Acts as an accessibility container for any accessible subviews.
+///
+/// Accessible subviews are found using the following algorithm:
+///
+/// Recurse subviews until a view is found that either
+/// - has`isAccessibilityElement` set to `true` or
+/// - returns a non-nil value from `accessibilityElements` (i.e., is a container itself)
+///
+/// If an accessibility element is found, we add it to the `accessibilityElements`
+/// and terminate the search down that branch. If a container is found,
+/// the elements returned from the container are added to the `accessibilityElements`
+/// and the search down that branch is also terminated.
+public struct AccessibilityContainer: Element {
+
+    public var wrapped: Element
+
+    /// Creates a new `AccessibilityContainer` wrapping the provided element.
+    public init(wrapping element: Element) {
+        self.wrapped = element
+    }
+
+    //
+    // MARK: Element
+    //
+
+    public var content: ElementContent {
+        ElementContent(child: wrapped)
+    }
+
+    public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
+        AccessibilityContainerView.describe { _ in }
+    }
+}
+
+public extension Element {
+
+    /// Acts as an accessibility container for any subviews
+    /// where `isAccessibilityElement == true`.
+    func accessibilityContainer() -> Element {
+        AccessibilityContainer(wrapping: self)
+    }
+}
+
+extension AccessibilityContainer {
+    private final class AccessibilityContainerView: UIView {
+        override var accessibilityElements: [Any]? {
+            get { recursiveAccessibleSubviews() }
+            set { fatalError() }
+        }
+    }
+}
+
+extension UIView {
+    fileprivate func recursiveAccessibleSubviews() -> [Any] {
+        subviews.flatMap { subview -> [Any] in
+            if let accessibilityElements = subview.accessibilityElements {
+                return accessibilityElements
+            } else if subview.isAccessibilityElement {
+                return [subview]
+            } else {
+                return subview.recursiveAccessibleSubviews()
+            }
+        }
+    }
+}

--- a/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
@@ -54,7 +54,7 @@ extension AccessibilityContainer {
 }
 
 extension UIView {
-    fileprivate func recursiveAccessibleSubviews() -> [Any] {
+    func recursiveAccessibleSubviews() -> [Any] {
         subviews.flatMap { subview -> [Any] in
             if let accessibilityElements = subview.accessibilityElements {
                 return accessibilityElements

--- a/BlueprintUICommonControls/Tests/Sources/AccessibilityContainerTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AccessibilityContainerTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+import BlueprintUI
+@testable import BlueprintUICommonControls
+
+
+class AccessibilityContainerTests: XCTestCase {
+
+    func test_recursiveAccessibleSubviewsIncludesContainedElements() {
+
+        let viewA = UIView()
+        let viewB = UIView()
+
+        let innerContainerView = UIView()
+        innerContainerView.accessibilityElements = [viewA, viewB]
+
+        let outerContainerView = UIView()
+        outerContainerView.addSubview(innerContainerView)
+
+        let accessibleSubviews = outerContainerView.recursiveAccessibleSubviews() as! [UIView]
+
+        XCTAssertEqual(accessibleSubviews.count, 2)
+        XCTAssertTrue(accessibleSubviews.contains(where: { $0 === viewA }))
+        XCTAssertTrue(accessibleSubviews.contains(where: { $0 === viewB }))
+    }
+
+    func test_nestedSubviewsAreFound() {
+
+        let accessibleView = UIView()
+        accessibleView.isAccessibilityElement = true
+
+        let wrapperView = UIView()
+        wrapperView.addSubview(accessibleView)
+
+        let containerView = UIView()
+        containerView.addSubview(wrapperView)
+
+        let accessibleSubviews = containerView.recursiveAccessibleSubviews() as! [UIView]
+
+        XCTAssertEqual(accessibleSubviews[0], accessibleView)
+    }
+
+    func test_accessibilityElementsAndContainedViewsAreFound() {
+
+        let viewA = UIView()
+
+        let innerContainerView = UIView()
+        innerContainerView.accessibilityElements = [viewA]
+
+        let accessibleView = UIView()
+        accessibleView.isAccessibilityElement = true
+
+        let outerContainerView = UIView()
+        outerContainerView.addSubview(accessibleView)
+        outerContainerView.addSubview(innerContainerView)
+
+        let accessibleSubviews = outerContainerView.recursiveAccessibleSubviews() as! [UIView]
+
+        XCTAssertEqual(accessibleSubviews.count, 2)
+        XCTAssertTrue(accessibleSubviews.contains(where: { $0 === viewA }))
+        XCTAssertTrue(accessibleSubviews.contains(where: { $0 === accessibleView }))
+    }
+
+    func test_searchIsTerminatedAtContainerOrAccessibleView() {
+        let undiscoveredViewA = UIView()
+        undiscoveredViewA.isAccessibilityElement = true
+
+        let undiscoveredViewB = UIView()
+        undiscoveredViewB.isAccessibilityElement = true
+
+        let viewA = UIView()
+
+        let innerContainerView = UIView()
+        innerContainerView.accessibilityElements = [viewA]
+        innerContainerView.addSubview(undiscoveredViewA)
+
+        let accessibleView = UIView()
+        accessibleView.isAccessibilityElement = true
+        accessibleView.addSubview(undiscoveredViewB)
+
+        let outerContainerView = UIView()
+        outerContainerView.addSubview(accessibleView)
+        outerContainerView.addSubview(innerContainerView)
+
+        let accessibleSubviews = outerContainerView.recursiveAccessibleSubviews() as! [UIView]
+
+        XCTAssertEqual(accessibleSubviews.count, 2)
+        XCTAssertFalse(accessibleSubviews.contains(where: { $0 === undiscoveredViewA }))
+        XCTAssertFalse(accessibleSubviews.contains(where: { $0 === undiscoveredViewB }))
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Introduce `AccessibilityContainer` element for wrapping an element with multiple sub-elements that should be in a voice over container.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
Adds an element that recursively searches its subviews and acts as a container for any views where `isAccessibilityElement` is true. This is useful for groups of multiple elements that are each accessible, where your layout would prevent them from being navigated in order.