### PR TITLE
Default delaysContentTouches to true

### DIFF
--- a/BlueprintUICommonControls/Sources/ScrollView.swift
+++ b/BlueprintUICommonControls/Sources/ScrollView.swift
@@ -29,7 +29,7 @@ public struct ScrollView: Element {
     public var keyboardDismissMode: UIScrollView.KeyboardDismissMode = .none
     public var keyboardAdjustmentMode: KeyboardAdjustmentMode = .adjustsWhenVisible
 
-    public var delaysContentTouches: Bool = false
+    public var delaysContentTouches: Bool = true
 
 
     public init(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Default `ScrollView.delaysContentTouches` to `true` ([#132](https://github.com/square/Blueprint/pull/132))
+
 ### Deprecated
 
 ### Security


### PR DESCRIPTION
With this set the `false`, subviews that track touches don't allow scrolling, so `true` is a much better default. It also matches the `UIScrollView` default, which seems preferable.