### PR TITLE
Window size environment key

### DIFF
--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -238,6 +238,10 @@ public final class BlueprintView: UIView {
             environment.safeAreaInsets = safeAreaInsets
         }
 
+        if let window = window {
+            environment.windowSize = window.bounds.size
+        }
+
         return environment
     }
 }

--- a/BlueprintUI/Sources/Environment/Keys/WindowSizeKey.swift
+++ b/BlueprintUI/Sources/Environment/Keys/WindowSizeKey.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+extension Environment {
+    private enum WindowSizeKey: EnvironmentKey {
+        static var defaultValue: CGSize? {
+            nil
+        }
+    }
+
+    /// The size of the window that contains the hosting `BlueprintView`.
+    /// Defaults to `nil` if the hosting view is not in a window.
+    public var windowSize: CGSize? {
+        get { self[WindowSizeKey.self] }
+        set { self[WindowSizeKey.self] = newValue }
+    }
+}


### PR DESCRIPTION
This is an environment value that holds the size of the window.

Putting this one in Blueprint allows the BlueprintView to set it automatically, like it does with display scale, which is handy.