### PR TITLE
GeometryReader

### DIFF
--- a/BlueprintUI/Sources/Blueprint View/ElementPreview.swift
+++ b/BlueprintUI/Sources/Blueprint View/ElementPreview.swift
@@ -233,7 +233,7 @@ extension ElementPreview {
         private func constrained(
             element : Element
         ) -> some View {
-            GeometryReader { info in
+            SwiftUI.GeometryReader { info in
                 return ElementView(
                     element: ConstrainedSize(
                         width: .atMost(info.size.width),

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -57,11 +57,13 @@ extension ElementContent {
     /// Initializes a new `ElementContent` that will lazily create its storage during a layout and measurement pass,
     /// based on the `Environment` passed to the `builder` closure.
     ///
-    /// - parameter measurementCachingKey: An optional key to use to cache measurement. See the `MeasurementCachingKey` documentation for more.
-    /// - parameter builder: A closure that provides the content `Element` based on the provided `Environment`.
+    /// - parameter measurementCachingKey: An optional key to use to cache measurement. See the `MeasurementCachingKey`
+    ///     documentation for more.
+    /// - parameter builder: A closure that provides the content `Element` based on the provided `SizeConstraint`
+    ///     and `Environment`.
     public init(
         measurementCachingKey : MeasurementCachingKey? = nil,
-        build builder: @escaping (Environment) -> Element
+        build builder: @escaping (SizeConstraint, Environment) -> Element
     ) {
         self.measurementCachingKey = measurementCachingKey
         self.storage = LazyStorage(builder: builder)
@@ -349,14 +351,15 @@ private struct EnvironmentAdaptingStorage: ContentStorage {
 private struct LazyStorage: ContentStorage {
     let childCount = 1
 
-    var builder: (Environment) -> Element
+    var builder: (SizeConstraint, Environment) -> Element
 
     func performLayout(
         attributes: LayoutAttributes,
         environment: Environment)
         -> [(identifier: ElementIdentifier, node: LayoutResultNode)]
     {
-        let child = buildChild(in: environment)
+        let constraint = SizeConstraint(attributes.bounds.size)
+        let child = buildChild(in: constraint, environment: environment)
         let childAttributes = LayoutAttributes(size: attributes.bounds.size)
 
         let identifier = ElementIdentifier(elementType: type(of: child), key: nil, count: 1)
@@ -371,12 +374,12 @@ private struct LazyStorage: ContentStorage {
     }
 
     func measure(in constraint: SizeConstraint, environment: Environment) -> CGSize {
-        let child = buildChild(in: environment)
+        let child = buildChild(in: constraint, environment: environment)
         return child.content.measure(in: constraint, environment: environment)
     }
 
-    private func buildChild(in environment: Environment) -> Element {
-        return builder(environment)
+    private func buildChild(in constraint: SizeConstraint, environment: Environment) -> Element {
+        return builder(constraint, environment)
     }
 }
 

--- a/BlueprintUI/Sources/Environment/EnvironmentReader.swift
+++ b/BlueprintUI/Sources/Environment/EnvironmentReader.swift
@@ -24,7 +24,9 @@ public struct EnvironmentReader: Element {
     }
 
     public var content: ElementContent {
-        return ElementContent(build: self.elementRepresentation)
+        return ElementContent { (_, environment) in
+            self.elementRepresentation(environment)
+        }
     }
 
     public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {

--- a/BlueprintUI/Sources/Layout/GeometryReader.swift
+++ b/BlueprintUI/Sources/Layout/GeometryReader.swift
@@ -1,0 +1,55 @@
+import UIKit
+
+/// An element that dynamically builds its content based on the available space.
+///
+/// Use this element to build elements whose contents may change responsively to
+/// different layouts.
+///
+/// ## Example
+/// 
+/// ```swift
+/// GeometryReader { (geometry) -> Element in
+///     let image: UIImage
+///     switch geometry.constraint.width.maximum {
+///     case ..<100:
+///         image = UIImage(named: "small")!
+///     case 100..<500:
+///         image = UIImage(named: "medium")!
+///     default:
+///         image = UIImage(named: "large")!
+///     }
+///     return Image(image: image)
+/// }
+/// ```
+///
+public struct GeometryReader: Element {
+    /// Return the contents of this element based on the current layout.
+    var elementRepresentation: (GeometryProxy) -> Element
+
+    public init(elementRepresentation: @escaping (GeometryProxy) -> Element) {
+        self.elementRepresentation = elementRepresentation
+    }
+
+    public var content: ElementContent {
+        ElementContent { (constraint, environment) -> Element in
+            self.elementRepresentation(GeometryProxy(environment: environment, constraint: constraint))
+        }
+    }
+
+    public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
+        nil
+    }
+}
+
+/// Contains information about the current layout being measured by GeometryReader
+public struct GeometryProxy {
+    var environment: Environment
+
+    /// The size constraint of the element being laid out.
+    public var constraint: SizeConstraint
+
+    /// Measure the given element, using this proxy's constraint and the current environment.
+    public func measure(element: Element) -> CGSize {
+        element.content.measure(in: constraint, environment: environment)
+    }
+}

--- a/BlueprintUI/Sources/Measuring/SizeConstraint.swift
+++ b/BlueprintUI/Sources/Measuring/SizeConstraint.swift
@@ -92,6 +92,16 @@ extension SizeConstraint {
                 return 0.0
             }
         }
+
+        /// The constraint value in this dimension, or `nil` if this dimension is unconstrained.
+        public var constrainedValue: CGFloat? {
+            switch self {
+            case .atMost(let value):
+                return value
+            case .unconstrained:
+                return nil
+            }
+        }
         
         private static var maxValue : CGFloat = .greatestFiniteMagnitude
 

--- a/BlueprintUI/Tests/GeometryReaderTests.swift
+++ b/BlueprintUI/Tests/GeometryReaderTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import BlueprintUI
+
+final class GeometryReaderTests: XCTestCase {
+
+    func test_measuring() {
+        let constrainedSize = CGSize(width: 100, height: 100)
+        let unconstrainedSize = CGSize(width: 200, height: 200)
+
+        let element = GeometryReader { (geometry) -> Element in
+            if geometry.constraint.width.isConstrained {
+                return Spacer(size: constrainedSize)
+            } else {
+                return Spacer(size: unconstrainedSize)
+            }
+        }
+
+        XCTAssertEqual(
+            element.content.measure(in: .unconstrained),
+            unconstrainedSize
+        )
+
+        XCTAssertEqual(
+            element.content.measure(in: SizeConstraint(.zero)),
+            constrainedSize
+        )
+    }
+
+    func test_layout() {
+        let element = GeometryReader { (geometry) -> Element in
+            // Create an element with half the dimensions of the available size,
+            // aligned in the bottom right.
+
+            let width = geometry.constraint.maximum.width / 2.0
+            let height = geometry.constraint.maximum.height / 2.0
+
+            return Spacer(width: width, height: height)
+                .aligned(vertically: .bottom, horizontally: .trailing)
+        }
+
+        /// Walk a node tree down each node's first child and return the frame of the first leaf node.
+        func leafChildFrame(in node: LayoutResultNode) -> CGRect {
+            if let childNode = node.children.first?.node {
+                return leafChildFrame(in: childNode)
+            }
+            return node.layoutAttributes.frame
+        }
+
+        let layoutResultNode = element.layout(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+
+        let frame = leafChildFrame(in: layoutResultNode)
+        XCTAssertEqual(frame, CGRect(x: 50, y: 50, width: 50, height: 50))
+    }
+}
+
+private extension SizeConstraint.Axis {
+    var isConstrained: Bool {
+        switch self {
+        case .atMost:
+            return true
+        case .unconstrained:
+            return false
+        }
+    }
+}

--- a/SampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		2009E82B0B9D98A685E8637B /* libPods-Tutorial 1.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 237956659E4F5F4AEE53B303 /* libPods-Tutorial 1.a */; };
 		4EE23713D657C21C6806E771 /* libPods-SampleApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADDB22E4D9B4379A15C5AF69 /* libPods-SampleApp.a */; };
 		6B58C7884AE69FA55EA64E57 /* libPods-Tutorial 2 (Completed).a in Frameworks */ = {isa = PBXBuildFile; fileRef = 187E50F5B5395EA0C0BCA8B2 /* libPods-Tutorial 2 (Completed).a */; };
+		7A4B688424DB3BE300E10D7A /* ResponsiveViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4B688324DB3BE300E10D7A /* ResponsiveViewController.swift */; };
 		97545519223C12E9003E353F /* PostsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97545510223C12E9003E353F /* PostsViewController.swift */; };
 		9754551A223C12E9003E353F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97545511223C12E9003E353F /* AppDelegate.swift */; };
 		9754551B223C12E9003E353F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97545513223C12E9003E353F /* Assets.xcassets */; };
@@ -60,6 +61,7 @@
 		5FCF8B77DD126D724029EB47 /* libPods-Tutorial 2.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tutorial 2.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6D524EC9EF929FCE2F54EC85 /* Pods-Tutorial1.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tutorial1.release.xcconfig"; path = "../../Pods/Target Support Files/Pods-Tutorial1/Pods-Tutorial1.release.xcconfig"; sourceTree = "<group>"; };
 		70E2DBB7A375C527D66B2643 /* Pods-Tutorial 1.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tutorial 1.debug.xcconfig"; path = "Target Support Files/Pods-Tutorial 1/Pods-Tutorial 1.debug.xcconfig"; sourceTree = "<group>"; };
+		7A4B688324DB3BE300E10D7A /* ResponsiveViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponsiveViewController.swift; sourceTree = "<group>"; };
 		7A5624391C38E617246C4356 /* Pods-Tutorial 2.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tutorial 2.debug.xcconfig"; path = "Target Support Files/Pods-Tutorial 2/Pods-Tutorial 2.debug.xcconfig"; sourceTree = "<group>"; };
 		7EA5EE31421ECA2CA9457450 /* Pods-Tutorial 2.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tutorial 2.release.xcconfig"; path = "Target Support Files/Pods-Tutorial 2/Pods-Tutorial 2.release.xcconfig"; sourceTree = "<group>"; };
 		8501C9E99E00354D89175E65 /* Pods-Tutorial 1.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tutorial 1.release.xcconfig"; path = "Target Support Files/Pods-Tutorial 1/Pods-Tutorial 1.release.xcconfig"; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 			children = (
 				0A50E8DA24A685DA0049705B /* RootViewController.swift */,
 				97545510223C12E9003E353F /* PostsViewController.swift */,
+				7A4B688324DB3BE300E10D7A /* ResponsiveViewController.swift */,
 				0AEA09B22428360500F9ED0C /* ScrollViewKeyboardViewController.swift */,
 				97545511223C12E9003E353F /* AppDelegate.swift */,
 				0AEF0C4D24463B880092248C /* XcodePreviewDemo.swift */,
@@ -581,6 +584,7 @@
 				9754551A223C12E9003E353F /* AppDelegate.swift in Sources */,
 				97545519223C12E9003E353F /* PostsViewController.swift in Sources */,
 				0AEA09B32428360500F9ED0C /* ScrollViewKeyboardViewController.swift in Sources */,
+				7A4B688424DB3BE300E10D7A /* ResponsiveViewController.swift in Sources */,
 				0AEF0C4E24463B880092248C /* XcodePreviewDemo.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SampleApp/Sources/ResponsiveViewController.swift
+++ b/SampleApp/Sources/ResponsiveViewController.swift
@@ -1,0 +1,58 @@
+import UIKit
+import BlueprintUI
+import BlueprintUICommonControls
+
+final class ResponsiveViewController: UIViewController {
+    let blueprintView = BlueprintView()
+
+    override func loadView() {
+        blueprintView.backgroundColor = .white
+        self.view = blueprintView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        update()
+    }
+
+    func update() {
+        blueprintView.element = element
+    }
+
+    var element: Element {
+        Column { column in
+            column.horizontalAlignment = .center
+            column.verticalUnderflow = .justifyToCenter
+
+            column.add(child: ResponsiveLabel(text: "Short text"))
+
+            column.add(child: ResponsiveLabel(text: "Long text that may not fit and will turn into an ellipsis"))
+        }
+        .box(borders: .solid(color: .gray, width: 1))
+        .constrainedTo(width: .atMost(200))
+        .centered()
+    }
+}
+
+struct ResponsiveLabel: ProxyElement {
+    var text: String
+
+    var elementRepresentation: Element {
+        GeometryReader { (geometry) -> Element in
+            let label = Label(text: self.text) { label in
+                label.numberOfLines = 1
+            }
+
+            let labelWidth = geometry.measure(element: label).width
+
+            // If the label does not fit within this constraint, replace it with "..."
+            if let maxWidth = geometry.constraint.width.constrainedValue, labelWidth > maxWidth {
+                return Label(text: "…")
+            } else {
+                return label
+            }
+        }
+        .inset(uniform: 4)
+        .box(borders: .solid(color: .red, width: 1))
+    }
+}

--- a/SampleApp/Sources/RootViewController.swift
+++ b/SampleApp/Sources/RootViewController.swift
@@ -24,6 +24,9 @@ final class RootViewController : UIViewController
             DemoItem(title: "Keyboard Scrolling", onTap: { [weak self] in
                 self?.push(ScrollViewKeyboardViewController())
             }),
+            DemoItem(title: "GeometryReader Responsive Layout", onTap: { [weak self] in
+                self?.push(ResponsiveViewController())
+            }),
         ]
     }
     


### PR DESCRIPTION
Here's an implementation of GeometryReader, which uses the existing LazyStorage mechanism, modified to include the size constraint alongside the environment.

GeometryReader makes it easy to build ad-hoc layouts, but is more powerful than that. With the Layout protocol you can change the layout of children based on the size constraint but you cannot change their contents. This allows the content itself to vary too.

With the size constraint and the environment both available, you can also measure children and vary content based on that. There's a function built into the GeometryProxy to make this easy to do. There's a new "responsive layout" screen in the demo app that demonstrates this.

Resolves #65 