### PR TITLE
Set a shadow path on Box

### DIFF
--- a/BlueprintUICommonControls/Sources/Box.swift
+++ b/BlueprintUICommonControls/Sources/Box.swift
@@ -231,6 +231,15 @@ fileprivate final class BoxView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         contentView.frame = bounds
+
+        if layer.shadowColor != nil {
+            layer.shadowPath = CGPath(
+                roundedRect: bounds,
+                cornerWidth: layer.cornerRadius,
+                cornerHeight: layer.cornerRadius,
+                transform: nil
+            )
+        }
     }
     
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Misc
 
+- Set an explicit shadow path on `Box` ([#137](https://github.com/square/Blueprint/pull/137))
+
 # Past Releases
 
 ## [0.13.1] - 07-30-2020


### PR DESCRIPTION
Setting an explicit shadow path improves performance, since the system doesn't have to draw the contents of the view offscreen first to figure out the shadow path itself. While this prevents the shadow from being applied to the view contents if the background is transparent, this seems like reasonable default behavior for `Box` since it is, well, a "box."