### PR TITLE
Release 0.14.0

### DIFF
--- a/BlueprintUI.podspec
+++ b/BlueprintUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'BlueprintUI'
-  s.version      = '0.13.1'
+  s.version      = '0.14.0'
   s.summary      = 'Swift library for declarative UI construction'
   s.homepage     = 'https://www.github.com/square/blueprint'
   s.license      = 'Apache License, Version 2.0'

--- a/BlueprintUICommonControls.podspec
+++ b/BlueprintUICommonControls.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'BlueprintUICommonControls'
-  s.version      = '0.13.1'
+  s.version      = '0.14.0'
   s.summary      = 'UIKit-backed elements for Blueprint'
   s.homepage     = 'https://www.github.com/square/blueprint'
   s.license      = 'Apache License, Version 2.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Removed
+
+### Changed
+
+### Deprecated
+
+### Security
+
+### Documentation
+
+### Misc
+
+# Past Releases
+
+## [0.14.0] - 2020-08-12
+
+### Added
+
 - Add `textColor` property on TextField ([#133](https://github.com/square/Blueprint/pull/133)).
 - Add the `windowSize` environment key. ([#134])
 
@@ -35,25 +53,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   }
   ```
 
-### Removed
-
 ### Changed
 
 - Default `ScrollView.delaysContentTouches` to `true` ([#132](https://github.com/square/Blueprint/pull/132))
-
-### Deprecated
-
-### Security
-
-### Documentation
 
 ### Misc
 
 - Set an explicit shadow path on `Box` ([#137](https://github.com/square/Blueprint/pull/137))
 
-# Past Releases
-
-## [0.13.1] - 07-30-2020
+## [0.13.1] - 2020-07-30
 
 ### Added
 
@@ -61,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `font` property on TextField ([#127](https://github.com/square/Blueprint/pull/127)).
 
-## [0.13.0] - 07-20-2020
+## [0.13.0] - 2020-07-20
 
 ### Fixed
 
@@ -103,7 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Update Demo app](https://github.com/square/Blueprint/pull/116) to support more demo screen types.
 
-## [0.12.2] - 06-08-2020
+## [0.12.2] - 2020-06-08
 
 ### Fixed
 
@@ -113,13 +121,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add [delaysContentTouches](https://github.com/square/Blueprint/pull/109) to the `ScrollView` element.
 
-## [0.12.1] - 06-05-2020
+## [0.12.1] - 2020-06-05
 
 ### Fixed
 
 - Use default environment when [measuring `BlueprintView`](https://github.com/square/Blueprint/pull/107).
 
-## [0.12.0] - 06-04-2020
+## [0.12.0] - 2020-06-04
 
 ### Fixed
 
@@ -350,7 +358,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/0.13.1...HEAD
+[main]: https://github.com/square/Blueprint/compare/0.14.0...HEAD
+[0.14.0]: https://github.com/square/Blueprint/compare/0.14.0...0.13.1
 [0.13.1]: https://github.com/square/Blueprint/compare/0.13.1...0.13.0
 [0.13.0]: https://github.com/square/Blueprint/compare/0.13.0...0.12.2
 [0.12.2]: https://github.com/square/Blueprint/compare/0.12.1...0.12.2

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,14 +2,14 @@
 
 1. You must be listed as an owner of the pods `BlueprintUI` and `BlueprintUICommonControls`.
 
-To check this run:
+   To check this run:
 
-```bash
-bundle exec pod trunk info BlueprintUI
-bundle exec pod trunk info BlueprintUICommonControls
-```
+   ```bash
+   bundle exec pod trunk info BlueprintUI
+   bundle exec pod trunk info BlueprintUICommonControls
+   ```
 
-See [the CocoaPods documentation for pod trunk](https://guides.cocoapods.org/making/getting-setup-with-trunk) for more information about setting up credentials on your device. If you need to be added as an owner, ping in #blueprint on Slack (Square only).
+   See [the CocoaPods documentation for pod trunk](https://guides.cocoapods.org/making/getting-setup-with-trunk) for more information about setting up credentials on your device. If you need to be added as an owner, ping in #blueprint on Slack (Square only).
 
 1. Make sure you're on the `main` branch, and `git pull` to get the latest commits.
 
@@ -17,7 +17,9 @@ See [the CocoaPods documentation for pod trunk](https://guides.cocoapods.org/mak
 
 1. Update the library version in both `BlueprintUI.podspec` and `BlueprintUICommonControls.podspec` if it has not already been updated (it should match the version number that you are about to release).
 
-1. Update `CHANGELOG.md` (in the root of the repo), moving current changes under `Master` to a new section under `Past Releases` for the version you are releasing.
+1. Update `CHANGELOG.md` (in the root of the repo), moving current changes under `Main` to a new section under `Past Releases` for the version you are releasing.
+  
+   The changelog uses [reference links](https://daringfireball.net/projects/markdown/syntax#link) to link each version's changes. Remember to add a link to the new version at the bottom of the file, and to update the link to `[main]`.
 
 1. Change directory into the `SampleApp` dir: `cd SampleApp`.
 
@@ -39,12 +41,11 @@ See [the CocoaPods documentation for pod trunk](https://guides.cocoapods.org/mak
 
 1. Publish to CocoaPods
 
-When linting before publishing, CocoaPods will build `BlueprintUICommonControls` using the latest published version of `BlueprintUI` (not your local version). You will need to run `pod repo update` to pull the new version of `BlueprintUI` into your local specs repo immediately after publishing it.
+   Note: You may also need to quit Xcode before running these commands in order for the linting builds to succeed.
 
-Note: You may also need to quit Xcode before running these commands in order for the linting builds to succeed.
-
-```bash
-bundle exec pod trunk push BlueprintUI.podspec
-bundle exec pod repo update
-bundle exec pod trunk push BlueprintUICommonControls.podspec
-```
+   ```bash
+   bundle exec pod trunk push BlueprintUI.podspec
+   # The --synchronous argument ensures this command builds against the
+   # version of BlueprintUI that we just published.
+   bundle exec pod trunk push --synchronous BlueprintUICommonControls.podspec
+   ```

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - BlueprintUI (0.13.1)
-  - BlueprintUI/Tests (0.13.1)
-  - BlueprintUICommonControls (0.13.1):
+  - BlueprintUI (0.14.0)
+  - BlueprintUI/Tests (0.14.0)
+  - BlueprintUICommonControls (0.14.0):
     - BlueprintUI
 
 DEPENDENCIES:
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 9fffaebdfd47d9e59b057ecfbfc2443b478c9d2e
-  BlueprintUICommonControls: 4cc5f575863dde68cd2377a11e6545e38a49b1c1
+  BlueprintUI: e6269ed71e0ca75cc81e24071c5e6bedef9b1b27
+  BlueprintUICommonControls: 02f6dfe99f6aa51f1099573e181e170e2d30755b
 
 PODFILE CHECKSUM: bef87f42e48bddbf23595cfa6a16f4bf30ae6893
 


### PR DESCRIPTION
I also changed the release instructions a bit to include:
- a reminder to update version links in the changelog
- the `--synchronous` argument in `pod trunk push`, which removes the race condition when building BlueprintUICommonControls against BlueprintUI updates hitting the CocoaPods CDN