### PR TITLE
Recursively layoutIfNeeded on backing views

### DIFF
--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -278,6 +278,12 @@ extension BlueprintView {
             layoutAttributes = node.layoutAttributes
             
             viewDescription.apply(to: view)
+
+            // After this view's children are updated, allow it to run a layout pass.
+            // This ensures backing view layout changes are contained in animation blocks.
+            defer {
+                view.layoutIfNeeded()
+            }
             
             // Bail out fast if we do not have any children to manage.
             // This is a performance optimization for leaf elements, as the below update

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -152,6 +152,50 @@ class BlueprintViewTests: XCTestCase {
         view.element = nil
         XCTAssertEqual(view.needsViewHierarchyUpdate, false)
     }
+
+    func test_recursiveLayout() {
+        let view = BlueprintView()
+
+        var layoutRecursed = false
+
+        func onLayoutSubviews() {
+            layoutRecursed = true
+        }
+
+        struct TestElement: Element {
+            var onLayoutSubviews: () -> Void
+
+            var content: ElementContent {
+                ElementContent(intrinsicSize: .zero)
+            }
+
+            func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
+                TestView.describe { (config) in
+                    config.apply { (view) in
+                        // make sure UIKit knows we want a chance for layout
+                        view.setNeedsLayout()
+                    }
+                    config[\.onLayoutSubviews] = self.onLayoutSubviews
+                }
+            }
+
+            class TestView: UIView {
+                var onLayoutSubviews: (() -> Void)?
+
+                override func layoutSubviews() {
+                    super.layoutSubviews()
+                    onLayoutSubviews?()
+                }
+            }
+        }
+
+        view.element = TestElement(onLayoutSubviews: onLayoutSubviews)
+
+        // trigger a layout pass
+        _ = view.currentNativeViewControllers
+
+        XCTAssertTrue(layoutRecursed)
+    }
 }
 
 fileprivate struct MeasurableElement : Element {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Box(cornerStyle: .capsule)
 
 ### Changed
 
+- `BlueprintView` will call `layoutIfNeeded` on backing views during its layout pass. This allows backing views' subviews that are laid out during `layoutSubviews` to participate in animations. ([#139])
+
 ### Deprecated
 
 ### Security
@@ -396,6 +398,7 @@ Box(cornerStyle: .capsule)
 [0.3.1]: https://github.com/square/Blueprint/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/square/Blueprint/compare/0.2.2...0.3.0
 [0.2.2]: https://github.com/square/Blueprint/releases/tag/0.2.2
+[#139]: https://github.com/square/Blueprint/pull/139
 [#135]: https://github.com/square/Blueprint/pull/135
 [#134]: https://github.com/square/Blueprint/pull/134
 [#120]: https://github.com/square/Blueprint/pull/120


### PR DESCRIPTION
It's common for backing views to have internally managed subviews, and to lay them out during `layoutSubviews`. Currently, such layout is not done during the containing BlueprintView's layout pass, but asynchronously whenever UIKit calls it. This can break expectations with things like animations.

Consider this composition. A row contains 1 or 3 red boxes. The row is wrapped in a box that clips its content.

```swift
let segment = Box(
    backgroundColor: .red,
    wrapping: Spacer(width: 50, height: 50))

let bar = Row { row in
    row.add(child: segment)
    row.minimumHorizontalSpacing = 5
    if expanded {
        row.add(child: segment)
        row.add(child: segment)
    }
}
.box(borders: .solid(color: .blue, width: 1), clipsContent: true)
.tappable { self.expanded.toggle() }

var container = TransitionContainer(wrapping: bar)
container.layoutTransition = .specific(.init(
    duration: 1.0,
    curve: .easeInOut,
    allowUserInteraction: true
))
```

`Box` is a typical backing view that lays out its content view during `layoutSubviews`. Its content view is not resized during the animation block, and the contents appear to overflow the blue border during the expansion transition, rather than being clipped.

![unclipped animation](https://user-images.githubusercontent.com/100192/91237500-b5ce7480-e6ef-11ea-9603-2e2ad8e74686.gif)

After this PR, the content view is laid out synchronously with the hosting BlueprintView, and the animation works as expected (at least as far as clipping goes).

![clipped animation](https://user-images.githubusercontent.com/100192/91237511-b9fa9200-e6ef-11ea-989c-08e95be727d6.gif)

This change could be a problem if a backing view does a lot of work during its layout, causing the hosting BlueprintView's layout to block the main thread for a long time.