### PR TITLE
Pass Environment to measurement-closure-based ElementContent

### DIFF
--- a/BlueprintUI/Sources/Element/UIViewElement.swift
+++ b/BlueprintUI/Sources/Element/UIViewElement.swift
@@ -109,8 +109,8 @@ public extension UIViewElement {
             MeasurementCachingKey(type: Self.self, input: $0)
         }
         
-        return ElementContent(measurementCachingKey: key) {
-            UIViewElementMeasurer.shared.measure(element: self, in: $0)
+        return ElementContent(measurementCachingKey: key) { constraint, _ in
+            UIViewElementMeasurer.shared.measure(element: self, in: constraint)
         }
     }
     

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -159,7 +159,7 @@ fileprivate struct MeasurableElement : Element {
     var validate : (SizeConstraint) -> CGSize
     
     var content: ElementContent {
-        ElementContent { constraint -> CGSize in
+        ElementContent { constraint, _ -> CGSize in
             self.validate(constraint)
         }
     }

--- a/BlueprintUI/Tests/ConstrainedSizeTests.swift
+++ b/BlueprintUI/Tests/ConstrainedSizeTests.swift
@@ -323,7 +323,7 @@ class ConstrainedSizeTests: XCTestCase {
 fileprivate struct FixedElement: Element {
 
     var content: ElementContent {
-        ElementContent { constraint -> CGSize in
+        ElementContent { constraint, _ -> CGSize in
             // Using different sizes for width and height in case
             // any internal calculations mix up x and y; we'll catch that.
             
@@ -340,7 +340,7 @@ fileprivate struct FixedElement: Element {
 fileprivate struct FlexibleElement: Element {
 
     var content: ElementContent {
-        ElementContent { constraint -> CGSize in
+        ElementContent { constraint, _ -> CGSize in
             let totalArea : CGFloat = 100 * 110
             
             let width : CGFloat

--- a/BlueprintUI/Tests/ElementContentTests.swift
+++ b/BlueprintUI/Tests/ElementContentTests.swift
@@ -78,7 +78,7 @@ fileprivate struct MeasurableElement : Element {
     static var measureCount : Int = 0
     
     var content: ElementContent {
-        ElementContent(measurementCachingKey: .init(type: Self.self, input: "element")) { constraint -> CGSize in
+        ElementContent(measurementCachingKey: .init(type: Self.self, input: "element")) { constraint, _ -> CGSize in
             Self.measureCount += 1
             return .init(width: 20.0, height: 20.0)
         }

--- a/BlueprintUI/Tests/StackTests.swift
+++ b/BlueprintUI/Tests/StackTests.swift
@@ -901,7 +901,7 @@ class StackTests: XCTestCase {
         var axis: StackLayout.Axis
 
         var content: ElementContent {
-            ElementContent { constraint -> CGSize in
+            ElementContent { constraint, _ -> CGSize in
                 switch self.axis {
                 case .horizontal:
                     let itemsPerLine = max(1, Int(constraint.width.maximum / self.itemSize.width))

--- a/BlueprintUICommonControls/Sources/TextField.swift
+++ b/BlueprintUICommonControls/Sources/TextField.swift
@@ -69,7 +69,7 @@ public struct TextField: Element {
     }
 
     public var content: ElementContent {
-        ElementContent { constraint -> CGSize in
+        ElementContent { constraint, _ -> CGSize in
             return CGSize(
                 width: max(constraint.maximum.width, 44),
                 height: 44.0)


### PR DESCRIPTION
This change is meant to help support certain cases where leaf content needs the Environment to measure correctly, and it's inconvenient to get with an EnvironmentReader.

The primary use case is a stateful element that wraps an internal BlueprintView:

```swift
struct StatefulButton: Element {
    var makeElement: (UIControl.State) -> Element

    var content: ElementContent {
        ElementContent { (constraint) -> CGSize in
            let body = self.makeElement(.normal)
            return body.content.measure(in: constraint, environment: .empty) // <-- Environment is needed here
        }
    }

    func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
        ButtonView.describe { (config) in
            config[\.makeElement] = self.makeElement
        }
    }

    private class ButtonView: UIControl {
        let blueprintView = BlueprintView()
        var makeElement: ((UIControl.State) -> Element)?

        // snip: update() gets called when state changes

        func update() {
            blueprintView.element = makeElement?(self.state)
        }
    }
}
```

To implement with EnvironmentReader would require wrapping it in an outer element.