### PR TITLE
Add convenience methods for adding children to stacks

### DIFF
--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -74,7 +74,7 @@ extension StackElement {
     ///
     ///   - child: The child element to add to this stack
     ///
-    mutating public func add(growPriority: CGFloat = 1.0, shrinkPriority: CGFloat = 1.0, key: AnyHashable? = nil, child: Element) {
+    public mutating func add(growPriority: CGFloat = 1.0, shrinkPriority: CGFloat = 1.0, key: AnyHashable? = nil, child: Element) {
         children.append((
             element: child,
             traits: StackLayout.Traits(growPriority: growPriority, shrinkPriority: shrinkPriority),
@@ -82,6 +82,24 @@ extension StackElement {
         ))
     }
 
+
+    /// Convenience method for adding a child with a grow and shrink priority of 0.0
+    ///
+    /// - parameters:
+    ///   - child: The child element to add to this stack
+    ///
+    public mutating func addFixed(child: Element) {
+        self.add(growPriority: 0, shrinkPriority: 0, child: child)
+    }
+
+    /// Convenience method for adding a child with a grow and shrink priority of 1.0
+    ///
+    /// - parameters:
+    ///   - child: The child element to add to this stack
+    ///
+    public mutating func addFlexible(child: Element) {
+        self.add(growPriority: 1, shrinkPriority: 1, child: child)
+    }
 }
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `addFixed(child:)` and `addFlexible(child:)` methods to `StackElement` for adding children with a grow & shrink priority of 0.0 and 1.0 respectively.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
We've mentioned upstreaming these in Market PRs - just copy-pasted @watt's implementation :)