### PR TITLE
Add accessibility size to AccessibilityElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ into
 Box(cornerStyle: .capsule)
 ```
 
+- Add `accessibilityFrameSize` to `AccessibilityElement` for manually specifying a size for the frame rendered by Voice Over.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
Similar to how you might want to set a `minimumTappableSize` on a button, you might want to customize the size of the frame that voice over draws around your element. This PR allows you to set a size for the frame. Open to other options here, such as a closure property that gets called with the view frame, but that seemed needlessly complex.

I used this in Market to customize the frame of a `Button` that was 16x16 since it wrapped a small image (the tap target is the default 44x44):

<img width="814" alt="Screen Shot 2020-09-11 at 10 52 55 PM" src="https://user-images.githubusercontent.com/3526783/92988575-8ce50800-f481-11ea-98a1-257686eba28d.png">
