### PR TITLE
Alignment guides

### DIFF
--- a/BlueprintUI/Sources/Layout/Alignment.swift
+++ b/BlueprintUI/Sources/Layout/Alignment.swift
@@ -1,0 +1,106 @@
+import CoreGraphics
+
+/// Types used to identify alignment guides.
+///
+/// Types conforming to `AlignmentID` have a corresponding alignment guide value,
+/// typically declared as a static constant property of `HorizontalAlignment` or 
+/// `VerticalAlignment`.
+///
+public protocol AlignmentID {
+
+    /// Returns the value of the corresponding guide, in `context`, when not
+    /// otherwise set in `context`.
+    static func defaultValue(in context: ElementDimensions) -> CGFloat
+}
+
+/// An alignment position along the horizontal axis.
+public struct HorizontalAlignment: Equatable {
+
+    var id: AlignmentID.Type
+
+    /// Creates an instance with the given ID.
+    ///
+    /// Note: each instance should have a unique ID.
+    public init(_ id: AlignmentID.Type) {
+        self.id = id
+    }
+
+    public static func == (lhs: HorizontalAlignment, rhs: HorizontalAlignment) -> Bool {
+        return lhs.id == rhs.id
+    }
+}
+
+/// An alignment position along the vertical axis.
+public struct VerticalAlignment: Equatable {
+
+    var id: AlignmentID.Type
+
+    /// Creates an instance with the given ID.
+    ///
+    /// Note: each instance should have a unique ID.
+    public init(_ id: AlignmentID.Type) {
+        self.id = id
+    }
+
+    public static func == (lhs: VerticalAlignment, rhs: VerticalAlignment) -> Bool {
+        return lhs.id == rhs.id
+    }
+}
+
+extension HorizontalAlignment {
+    enum Leading: AlignmentID {
+        static func defaultValue(in context: ElementDimensions) -> CGFloat {
+            0
+        }
+    }
+
+    /// A guide marking the leading edge of the element.
+    public static let leading = HorizontalAlignment(Leading.self)
+
+    enum Center: AlignmentID {
+        static func defaultValue(in d: ElementDimensions) -> CGFloat {
+            d.width / 2
+        }
+    }
+
+    /// A guide marking the horizontal center of the element.
+    public static let center = HorizontalAlignment(Center.self)
+
+    enum Trailing: AlignmentID {
+        static func defaultValue(in d: ElementDimensions) -> CGFloat {
+            d.width
+        }
+    }
+
+    /// A guide marking the trailing edge of the element.
+    public static let trailing = HorizontalAlignment(Trailing.self)
+}
+
+extension VerticalAlignment {
+    enum Top: AlignmentID {
+        static func defaultValue(in d: ElementDimensions) -> CGFloat {
+            0
+        }
+    }
+
+    /// A guide marking the top edge of the element.
+    public static let top = VerticalAlignment(Top.self)
+
+    enum Center: AlignmentID {
+        static func defaultValue(in d: ElementDimensions) -> CGFloat {
+            d.height / 2
+        }
+    }
+
+    /// A guide marking the vertical center of the element.
+    public static let center = VerticalAlignment(Center.self)
+
+    enum Bottom: AlignmentID {
+        static func defaultValue(in d: ElementDimensions) -> CGFloat {
+            d.height
+        }
+    }
+
+    /// A guide marking the bottom edge of the element.
+    public static let bottom = VerticalAlignment(Bottom.self)
+}

--- a/BlueprintUI/Sources/Layout/Column.swift
+++ b/BlueprintUI/Sources/Layout/Column.swift
@@ -2,10 +2,51 @@ import UIKit
 
 /// Displays a list of items in a linear vertical layout.
 public struct Column: StackElement {
+    /// Describes how the column's children will be horizontally aligned.
+    public enum ColumnAlignment: Equatable {
+        /// Children will be stretched to fit the horizontal size of the column.
+        case fill
+
+        /// Using the specified alignment, children will be aligned relatively to each other, and
+        /// then all the contents will be aligned to the column's bounding box.
+        ///
+        /// This case can be used for custom alignments. For common alignments you can use the
+        /// existing static instances`leading`, `center`, and `trailing`.
+        ///
+        case align(to: HorizontalAlignment)
+
+        /// Children will be aligned to the leading edge of the column.
+        public static let leading = ColumnAlignment.align(to: .leading)
+        /// Children will be horizontally centered in the column.
+        public static let center = ColumnAlignment.align(to: .center)
+        /// Children will be aligned to the trailing edge of the column.
+        public static let trailing = ColumnAlignment.align(to: .trailing)
+
+        init(_ stackAlignment: StackLayout.Alignment) {
+            switch stackAlignment {
+            case .fill:
+                self = .fill
+            case let .align(to: id):
+                self = .align(to: HorizontalAlignment(id))
+            }
+        }
+
+        var stackAlignment: StackLayout.Alignment {
+            switch self {
+            case .fill:
+                return .fill
+            case let .align(to: alignment):
+                return .align(to: alignment.id)
+            }
+        }
+    }
 
     public var children: [(element: Element, traits: StackLayout.Traits, key: AnyHashable?)] = []
 
-    private (set) public var layout = StackLayout(axis: .vertical)
+    private (set) public var layout = StackLayout(
+        axis: .vertical,
+        alignment: ColumnAlignment.leading.stackAlignment
+    )
 
     public init() {}
 
@@ -19,9 +60,14 @@ public struct Column: StackElement {
         set { layout.overflow = newValue }
     }
 
-    public var horizontalAlignment: StackLayout.Alignment {
-        get { return layout.alignment }
-        set { layout.alignment = newValue }
+    /// Specifies how children will be aligned horizontally.
+    public var horizontalAlignment: ColumnAlignment {
+        get {
+            ColumnAlignment(layout.alignment)
+        }
+        set {
+            layout.alignment = newValue.stackAlignment
+        }
     }
 
     public var minimumVerticalSpacing: CGFloat {

--- a/BlueprintUI/Sources/Layout/ElementDimensions.swift
+++ b/BlueprintUI/Sources/Layout/ElementDimensions.swift
@@ -1,0 +1,75 @@
+import CoreGraphics
+
+/// An element’s size and its alignment guides in its own coordinate space.
+///
+/// You can access the size of the element through the `width` and `height` properties. You can
+/// access alignment guide values by subscripting with the specific alignment.
+///
+/// These dimensions are typically used when setting an alignment guide on a stack, with
+/// `StackElement.add(...)`.
+///
+/// ## Example
+///
+/// ```
+/// // get the alignment guide value for `VerticalAlignment.center`, falling back to the default
+/// // value if no alignment guide has been set
+/// dimensions[VerticalAlignment.center]
+///
+/// // get the alignment guide value for `HorizontalAlignment.trailing`, or `nil` if none has been
+/// // set.
+/// dimensions[explicit: .trailing]
+/// ```
+///
+/// ## See Also
+/// [StackElement.add()](x-source-tag://StackElement.add)
+///
+public struct ElementDimensions: Equatable {
+
+    /// The element's width
+    public internal(set) var width: CGFloat
+
+    /// The element's height
+    public internal(set) var height: CGFloat
+
+    private var horizontalGuideValues: [ObjectIdentifier: CGFloat] = [:]
+    private var verticalGuideValues: [ObjectIdentifier: CGFloat] = [:]
+
+    init(size: CGSize) {
+        self.width = size.width
+        self.height = size.height
+    }
+
+    /// Accesses the value of the given guide, or the default value of the alignment if this
+    /// guide has not been set.
+    public internal(set) subscript(guide: HorizontalAlignment) -> CGFloat {
+        get {
+            horizontalGuideValues[ObjectIdentifier(guide.id)] ?? guide.id.defaultValue(in: self)
+        }
+        set {
+            horizontalGuideValues[ObjectIdentifier(guide.id)] = newValue
+        }
+    }
+
+    /// Accesses the value of the given guide, or the default value of the alignment if this
+    /// guide has not been set.
+    public internal(set) subscript(guide: VerticalAlignment) -> CGFloat {
+        get {
+            verticalGuideValues[ObjectIdentifier(guide.id)] ?? guide.id.defaultValue(in: self)
+        }
+        set {
+            verticalGuideValues[ObjectIdentifier(guide.id)] = newValue
+        }
+    }
+
+    /// Returns the explicit value of the given alignment guide in this view, or
+    /// `nil` if no such value exists.
+    public subscript(explicit guide: HorizontalAlignment) -> CGFloat? {
+        horizontalGuideValues[ObjectIdentifier(guide.id)]
+    }
+
+    /// Returns the explicit value of the given alignment guide in this view, or
+    /// `nil` if no such value exists.
+    public subscript(explicit guide: VerticalAlignment) -> CGFloat? {
+        verticalGuideValues[ObjectIdentifier(guide.id)]
+    }
+}

--- a/BlueprintUI/Sources/Layout/Row.swift
+++ b/BlueprintUI/Sources/Layout/Row.swift
@@ -2,10 +2,59 @@ import UIKit
 
 /// Displays a list of items in a linear horizontal layout.
 public struct Row: StackElement {
+    /// Describes how the row's children will be vertically aligned.
+    public enum RowAlignment: Equatable {
+        /// Children will be stretched to fit the vertical size of the row.
+        case fill
+
+        /// Using the specified alignment, children will be aligned relatively to each other, and
+        /// then all the contents will be aligned to the row's bounding box.
+        ///
+        /// This case can be used for custom alignments. For common alignments you can use the
+        /// existing static instances`top`, `center`, and `bottom`.
+        ///
+        case align(to: VerticalAlignment)
+
+        /// Children will be aligned to the top edge of the row.
+        public static let top = RowAlignment.align(to: .top)
+        /// Children will be vertically centered in the row.
+        public static let center = RowAlignment.align(to: .center)
+        /// Children will be aligned to the bottom edge of the row.
+        public static let bottom = RowAlignment.align(to: .bottom)
+
+        /// Children will be aligned to the top edge of the row.
+        @available(*, deprecated, renamed: "top")
+        public static let leading = RowAlignment.top
+
+        /// Children will be aligned to the bottom edge of the row.
+        @available(*, deprecated, renamed: "bottom")
+        public static let trailing = RowAlignment.bottom
+
+        init(_ stackAlignment: StackLayout.Alignment) {
+            switch stackAlignment {
+            case .fill:
+                self = .fill
+            case let .align(to: id):
+                self = .align(to: VerticalAlignment(id))
+            }
+        }
+
+        var stackAlignment: StackLayout.Alignment {
+            switch self {
+            case .fill:
+                return .fill
+            case let .align(to: alignment):
+                return .align(to: alignment.id)
+            }
+        }
+    }
 
     public var children: [(element: Element, traits: StackLayout.Traits, key: AnyHashable?)] = []
 
-    private (set) public var layout = StackLayout(axis: .horizontal)
+    private (set) public var layout = StackLayout(
+        axis: .horizontal,
+        alignment: RowAlignment.top.stackAlignment
+    )
 
     public init() {}
 
@@ -19,9 +68,14 @@ public struct Row: StackElement {
         set { layout.overflow = newValue }
     }
 
-    public var verticalAlignment: StackLayout.Alignment {
-        get { return layout.alignment }
-        set { layout.alignment = newValue }
+    /// Specifies how children will be aligned vertically.
+    public var verticalAlignment: RowAlignment {
+        get {
+            RowAlignment(layout.alignment)
+        }
+        set {
+            layout.alignment = newValue.stackAlignment
+        }
     }
 
     public var minimumHorizontalSpacing: CGFloat {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add alignment guides to stacks. ([#153])
+
+  Alignment guides let you fine-tune the cross axis alignment. You can specifying a guide value for any child in that element's coordinate space. Children are aligned relatively to each other so that the guide values line up, and then the content as a whole is aligned to the stack's bounds.
+
+  In this example, the center of one element is aligned 10 points from the bottom of another element, and the contents are collectively aligned to the bottom of the row:
+
+  ```swift
+  Row { row in
+      row.verticalAlignment = .bottom
+
+      row.add(
+          alignmentGuide: { d in d[VerticalAlignment.center] },
+          child: element1
+      )
+
+      row.add(
+          alignmentGuide: { d in d.height - 10 },
+          child: element2
+      )
+  }
+  ```
+
 ### Removed
 
 - [Removed support for iOS 10](https://github.com/square/Blueprint/pull/161). Future releases will only support iOS 11 and later.
@@ -18,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Deprecated
+
+- `Row` alignments `leading` and `trailing` are deprecated. Use `top` and `bottom` instead. ([#153])
 
 ### Security
 
@@ -444,6 +468,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#158]: https://github.com/square/Blueprint/pull/158
 [#155]: https://github.com/square/Blueprint/pull/155
 [#154]: https://github.com/square/Blueprint/pull/154
+[#153]: https://github.com/square/Blueprint/pull/153
 [#149]: https://github.com/square/Blueprint/pull/149
 [#147]: https://github.com/square/Blueprint/pull/147
 [#145]: https://github.com/square/Blueprint/pull/145

--- a/SampleApp/Sources/PostsViewController.swift
+++ b/SampleApp/Sources/PostsViewController.swift
@@ -134,7 +134,7 @@ fileprivate struct FeedItem: ProxyElement {
 
     var elementRepresentation: Element {
         Row { row in
-            row.verticalAlignment = .leading
+            row.verticalAlignment = .top
             row.minimumHorizontalSpacing = 16.0
             row.horizontalUnderflow = .growUniformly
 


### PR DESCRIPTION
This PR adds alignment guides to stacks, allowing you to fine-tune cross axis alignment. The API is inspired by SwiftUI's alignment guides.

Alignment guides are stored on the `Traits` type and are specified with a new closure parameter on the `add()` function, which takes `ElementDimensions` and returns the value of the guide in the element's own coordinate space.

```swift
Row { row in
    row.verticalAlignment = .bottom

    row.add(
        alignmentGuide: { (d: ElementDimensions) -> CGFloat in
            // Add a guide 10 points from bottom.
            d.height - 10
        },
        child: MyElement()
    )

    row.add(
        alignmentGuide: { (d: ElementDimensions) -> CGFloat in
            // Align to the center by referencing another guide.
            d[VerticalAlignment.center]
        },
        child: MyElement()
    )
    
    // Use the default alignment
    row.add(child: MyElement())
}
```

`ElementDimensions` is analogous to SwiftUI's `ViewDimensions`: you can use it to read the size of the element or get the value of another alignment.

Stack children will be relatively aligned to each other, and then the entire contents will be aligned to the bounds of the stack.

Alignment can push content outside the bounds of the stack. Stack measurement takes into account the distance from the "lowest" edge to the "highest" edge of all children, so a stack's measured size is big enough to accommodate its aligned content. Basically, it does the thing you'd expect.

The standard alignments have been converted into the new `HorizontalAlignment` and `VerticalAlignment` types, which work just like the SwiftUI types. You can define a new alignment, but it's not necessary for alignment guides.

Stacks wrap these alignments in another enum type in order to support `fill` mode, which works unlike any alignment.

`Row`'s `.leading` and `.trailing` alignments are now aliases for `.top` and `.bottom` alignments, and have been marked as deprecated.

## Differences from SwiftUI

* Alignment does not propagate — it is entirely internal to a stack.
* Because it does not propagate there is no need to specify which alignment a guide applies to. It always applies to the one being used by the stack.
* SwiftUI stacks are always the size of their content, but Blueprint stacks can be any size. This is the reason for a two-phase alignment, which aligns relatively first and then aligns the content to the stack bounds.
* There are no built-in baseline alignments, because there is no way to propagate such information from an element containing text up to the stack. You can do baseline alignment, but you must specify the values yourself.
