### PR TITLE
Remove extra call to NativeViewController.update

### DIFF
--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -263,7 +263,6 @@ extension BlueprintView {
             self.layoutAttributes = node.layoutAttributes
             self.children = []
             self.view = node.viewDescription.build()
-            update(node: node, appearanceTransitionsEnabled: false)
         }
 
         fileprivate func canUpdateFrom(node: NativeViewNode) -> Bool {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Misc
 
+- Removed some redundant work being done during rendering. ([#154])
+
 # Past Releases
 
 ## [0.15.1] - 2020-09-16
@@ -49,18 +51,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `capsule` case to `Box.CornerStyle` ([#145]). This addition sugars the following pattern:
 
-```
-GeometryReader { geometry in
-  Box(cornerStyle: .rounded(geometry.constraint.height.maximum / 2.0))
-}
-```
-
-into
-
-```
-Box(cornerStyle: .capsule)
-```
-
+  ```swift
+  GeometryReader { geometry in
+    Box(cornerStyle: .rounded(geometry.constraint.height.maximum / 2.0))
+  }
+  ```
+  
+  into
+  
+  ```swift
+  Box(cornerStyle: .capsule)
+  ```
+  
 - Add `accessibilityFrameSize` to `AccessibilityElement` for manually specifying a size for the frame rendered by Voice Over. ([#144])
 
 - Add `Opacity` element for modifying the opacity of a wrapped element. ([#147])
@@ -402,8 +404,8 @@ Box(cornerStyle: .capsule)
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/0.15.0...HEAD
-[0.15.0]: https://github.com/square/Blueprint/compare/0.15.0...0.15.1
+[main]: https://github.com/square/Blueprint/compare/0.15.1...HEAD
+[0.15.1]: https://github.com/square/Blueprint/compare/0.15.0...0.15.1
 [0.15.0]: https://github.com/square/Blueprint/compare/0.14.0...0.15.0
 [0.14.0]: https://github.com/square/Blueprint/compare/0.13.1...0.14.0
 [0.13.1]: https://github.com/square/Blueprint/compare/0.13.0...0.13.1
@@ -424,6 +426,7 @@ Box(cornerStyle: .capsule)
 [0.3.1]: https://github.com/square/Blueprint/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/square/Blueprint/compare/0.2.2...0.3.0
 [0.2.2]: https://github.com/square/Blueprint/releases/tag/0.2.2
+[#154]: https://github.com/square/Blueprint/pull/154
 [#149]: https://github.com/square/Blueprint/pull/149
 [#147]: https://github.com/square/Blueprint/pull/147
 [#145]: https://github.com/square/Blueprint/pull/145


### PR DESCRIPTION
During the view update part of a render pass, when a _new_ node is being inserted, `update(node:appearanceTransitionsEnabled:)` is called twice: first in the init of `NativeViewController`, and then a bit later after the new view has been inserted into the view hierarchy.

That's a bunch of redundant work being done for new nodes, so this PR removes one of the calls.

I chose to remove the first call, because the second one matches the time that `update` is called for existing nodes (after applying layout attributes and inserting the view).

I did some quick & dirty profiling on the POS checkout applet and found it cut the time of view hierarchy update on the first render pass down by 30-50%. No difference in functionality as far as I can tell.