### PR TITLE
[TransitionContainer] Sugar transition composition and extend initializer

### DIFF
--- a/BlueprintUI/Sources/View Description/VisibilityTransition.swift
+++ b/BlueprintUI/Sources/View Description/VisibilityTransition.swift
@@ -18,6 +18,13 @@ public struct VisibilityTransition {
         self.attributes = attributes
     }
 
+    /// Returns a `VisibilityTransition` that has no effect.
+    public static var none: VisibilityTransition {
+        return VisibilityTransition(
+            alpha: 1.0,
+            transform: CATransform3DIdentity)
+    }
+
     /// Returns a `VisibilityTransition` that scales in and out.
     public static var scale: VisibilityTransition {
         return VisibilityTransition(

--- a/BlueprintUICommonControls/Sources/TransitionContainer.swift
+++ b/BlueprintUICommonControls/Sources/TransitionContainer.swift
@@ -6,14 +6,22 @@ import UIKit
 /// disappears, or changes layout.
 public struct TransitionContainer: Element {
 
-    public var appearingTransition: VisibilityTransition = .fade
-    public var disappearingTransition: VisibilityTransition = .fade
-    public var layoutTransition: LayoutTransition = .specific(AnimationAttributes())
+    public var appearingTransition: VisibilityTransition
+    public var disappearingTransition: VisibilityTransition
+    public var layoutTransition: LayoutTransition
 
     public var wrappedElement: Element
 
-    public init(wrapping element: Element) {
+    public init(
+        wrapping element: Element,
+        appearingTransition: VisibilityTransition = .fade,
+        disappearingTransition: VisibilityTransition = .fade,
+        layoutTransition: LayoutTransition = .specific(AnimationAttributes())
+    ) {
         self.wrappedElement = element
+        self.appearingTransition = appearingTransition
+        self.disappearingTransition = disappearingTransition
+        self.layoutTransition = layoutTransition
     }
 
     public var content: ElementContent {
@@ -28,4 +36,39 @@ public struct TransitionContainer: Element {
         }
     }
 
+}
+
+public extension Element {
+
+    /// Wraps the element in a transition container to provide an animated transition.
+    ///
+    /// - Parameters:
+    ///   - appear: The transition to use when the element appears. By default, `.none`.
+    ///   - disappear: The transition to use when the element disappears. By default, `.none`.
+    ///   - layout: The animation to use when the element changes layout. By default, `.none`.
+    func transition(
+        appear: VisibilityTransition = .none,
+        disappear: VisibilityTransition = .none,
+        layout: LayoutTransition = .none
+    ) -> TransitionContainer {
+        TransitionContainer(
+            wrapping: self,
+            appearingTransition: appear,
+            disappearingTransition: disappear,
+            layoutTransition: layout
+        )
+    }
+
+    /// Wraps the element in a transition container to provide an animated transition when its visibility changes.
+    ///
+    /// - Parameters:
+    ///   - appearAndDisappear: The transition to use when the element appears and disappears.
+    func transition(appearAndDisappear: VisibilityTransition) -> TransitionContainer {
+        TransitionContainer(
+            wrapping: self,
+            appearingTransition: appearAndDisappear,
+            disappearingTransition: appearAndDisappear,
+            layoutTransition: .none
+        )
+    }
 }

--- a/BlueprintUICommonControls/Sources/TransitionContainer.swift
+++ b/BlueprintUICommonControls/Sources/TransitionContainer.swift
@@ -43,31 +43,31 @@ public extension Element {
     /// Wraps the element in a transition container to provide an animated transition.
     ///
     /// - Parameters:
-    ///   - appear: The transition to use when the element appears. By default, `.none`.
-    ///   - disappear: The transition to use when the element disappears. By default, `.none`.
-    ///   - layout: The animation to use when the element changes layout. By default, `.none`.
+    ///   - onAppear: The transition to use when the element appears. By default, `.none`.
+    ///   - onDisappear: The transition to use when the element disappears. By default, `.none`.
+    ///   - onLayout: The animation to use when the element changes layout. By default, `.none`.
     func transition(
-        appear: VisibilityTransition = .none,
-        disappear: VisibilityTransition = .none,
-        layout: LayoutTransition = .none
+        onAppear: VisibilityTransition = .none,
+        onDisappear: VisibilityTransition = .none,
+        onLayout: LayoutTransition = .none
     ) -> TransitionContainer {
         TransitionContainer(
             wrapping: self,
-            appearingTransition: appear,
-            disappearingTransition: disappear,
-            layoutTransition: layout
+            appearingTransition: onAppear,
+            disappearingTransition: onDisappear,
+            layoutTransition: onLayout
         )
     }
 
     /// Wraps the element in a transition container to provide an animated transition when its visibility changes.
     ///
     /// - Parameters:
-    ///   - appearAndDisappear: The transition to use when the element appears and disappears.
-    func transition(appearAndDisappear: VisibilityTransition) -> TransitionContainer {
+    ///   - onAppearOrDisappear: The transition to use when the element appears or disappears.
+    func transition(_ onAppearOrDisappear: VisibilityTransition) -> TransitionContainer {
         TransitionContainer(
             wrapping: self,
-            appearingTransition: appearAndDisappear,
-            disappearingTransition: appearAndDisappear,
+            appearingTransition: onAppearOrDisappear,
+            disappearingTransition: onAppearOrDisappear,
             layoutTransition: .none
         )
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Extend `TransitionContainer.init` to support further customization during initialization. ([#155])
+
+- Add `transition(appear:disappear:layout)` and `transition(appearAndDisappear:)` methods to `Element` to describe transition animations. ([#155])
+
+- Add `VisibilityTransition.none` to describe an animation with no effect. ([#155])
+
 ### Removed
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Extend `TransitionContainer.init` to support further customization during initialization. ([#155])
 
-- Add `transition(appear:disappear:layout)` and `transition(appearAndDisappear:)` methods to `Element` to describe transition animations. ([#155])
+- Add `transition(onAppear:onDisappear:onLayout)` and `transition(_:)` methods to `Element` to describe transition animations. ([#155])
 
 - Add `VisibilityTransition.none` to describe an animation with no effect. ([#155])
 


### PR DESCRIPTION
### Summary

This PR adds methods for composing an element transition. In effect, it sugars the following pattern

```swift
let element = MyElement()
    .composed()
var transitionContainer = TransitionContainer(wrapping: element)
transitionContainer.layoutTransition = .none
return transitionContainer
```

into

```swift
return MyElement()
  .composed()
  .transition(appearAndDisappear: .fade) 
```

### Discussion

- I'll defer to more experienced maintainers on matters of grammar and naming. I did my best to maintain consistency with analogous sugar, but may have fallen short.
- The addition of `VisibilityTransition.none` may be regarded by some as a smell. I'm open to alternatives, such as using an optional at these sites, which would be a more disruptive but perhaps more correct change.
- No tests exist for `TransitionContainer`. As such tests would be very thin (i.e. do we map initializer parameters to properties properly), this may be fine. If not, I can add a test suite and tests for this new functionality.

### Changes
- shifts `TransitionContainer ` default property values to default initializer values, thereby extending the initializer for greater customization
- adds `transition(appear:disappear:layout)` and `transition(appearAndDisappear:)` methods
- adds `VisibilityTransition.none`
- updates CHANGELOG
