### PR TITLE
Change TransitionContainer defaults

### DIFF
--- a/BlueprintUI/Sources/View Description/VisibilityTransition.swift
+++ b/BlueprintUI/Sources/View Description/VisibilityTransition.swift
@@ -18,13 +18,6 @@ public struct VisibilityTransition {
         self.attributes = attributes
     }
 
-    /// Returns a `VisibilityTransition` that has no effect.
-    public static var none: VisibilityTransition {
-        return VisibilityTransition(
-            alpha: 1.0,
-            transform: CATransform3DIdentity)
-    }
-
     /// Returns a `VisibilityTransition` that scales in and out.
     public static var scale: VisibilityTransition {
         return VisibilityTransition(

--- a/BlueprintUICommonControls/Sources/TransitionContainer.swift
+++ b/BlueprintUICommonControls/Sources/TransitionContainer.swift
@@ -6,22 +6,52 @@ import UIKit
 /// disappears, or changes layout.
 public struct TransitionContainer: Element {
 
-    public var appearingTransition: VisibilityTransition
-    public var disappearingTransition: VisibilityTransition
+    /// The transition to apply when the wrapped element is appearing.
+    public var appearingTransition: VisibilityTransition?
+    /// The transition to apply when the wrapped element is disappearing.
+    public var disappearingTransition: VisibilityTransition?
+    /// The transition to apply when the wrapped element's layout is changing.
     public var layoutTransition: LayoutTransition
 
+    /// The element to which transitions are being applied.
     public var wrappedElement: Element
 
-    public init(
-        wrapping element: Element,
-        appearingTransition: VisibilityTransition = .fade,
-        disappearingTransition: VisibilityTransition = .fade,
-        layoutTransition: LayoutTransition = .specific(AnimationAttributes())
-    ) {
+
+    /// Create a transition container wrapping an element.
+    ///
+    /// The created container's default transitions are:
+    /// * `appearingTransition`: `fade`
+    /// * `disappearingTransition`: `fade`
+    /// * `layoutTransition`: `.specific(AnimationAttributes())`
+    ///
+    /// - Parameters:
+    ///   - wrapping: The element to which transitions will be applied.
+    @available(*, deprecated, message: "Use TransitionContainer(transitioning:), which has better defaults")
+    public init(wrapping element: Element) {
+        self.appearingTransition = .fade
+        self.disappearingTransition = .fade
+        self.layoutTransition = .specific(AnimationAttributes())
         self.wrappedElement = element
+    }
+
+    /// Create a transition container wrapping an element.
+    /// - Parameters:
+    ///   - appearingTransition: The transition to use when the element appears. By default, no transition.
+    ///   - disappearingTransition: The transition to use when the element disappears. By default, no transition.
+    ///   - layoutTransition: The transition to use when the element's layout changes. The default value is
+    ///     `.inherited`, which means the element will participate in the same transition as its
+    ///     nearest ancestor with a specified transition.
+    ///   - transitioning: The element to which transitions will be applied.
+    public init(
+        appearingTransition: VisibilityTransition? = nil,
+        disappearingTransition: VisibilityTransition? = nil,
+        layoutTransition: LayoutTransition = .inherited,
+        transitioning element: Element
+    ) {
         self.appearingTransition = appearingTransition
         self.disappearingTransition = disappearingTransition
         self.layoutTransition = layoutTransition
+        self.wrappedElement = element
     }
 
     public var content: ElementContent {
@@ -43,19 +73,21 @@ public extension Element {
     /// Wraps the element in a transition container to provide an animated transition.
     ///
     /// - Parameters:
-    ///   - onAppear: The transition to use when the element appears. By default, `.none`.
-    ///   - onDisappear: The transition to use when the element disappears. By default, `.none`.
-    ///   - onLayout: The animation to use when the element changes layout. By default, `.none`.
+    ///   - onAppear: The transition to use when the element appears. By default, no transition.
+    ///   - onDisappear: The transition to use when the element disappears. By default, no transition.
+    ///   - onLayout: The transition to use when the element's layout changes. The default value is
+    ///     `.inherited`, which means the element will participate in the same transition as its
+    ///     nearest ancestor with a specified transition.
     func transition(
-        onAppear: VisibilityTransition = .none,
-        onDisappear: VisibilityTransition = .none,
-        onLayout: LayoutTransition = .none
+        onAppear: VisibilityTransition? = nil,
+        onDisappear: VisibilityTransition? = nil,
+        onLayout: LayoutTransition = .inherited
     ) -> TransitionContainer {
         TransitionContainer(
-            wrapping: self,
             appearingTransition: onAppear,
             disappearingTransition: onDisappear,
-            layoutTransition: onLayout
+            layoutTransition: onLayout,
+            transitioning: self
         )
     }
 
@@ -65,10 +97,9 @@ public extension Element {
     ///   - onAppearOrDisappear: The transition to use when the element appears or disappears.
     func transition(_ onAppearOrDisappear: VisibilityTransition) -> TransitionContainer {
         TransitionContainer(
-            wrapping: self,
             appearingTransition: onAppearOrDisappear,
             disappearingTransition: onAppearOrDisappear,
-            layoutTransition: .none
+            transitioning: self
         )
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Extend `TransitionContainer.init` to support further customization during initialization. ([#155])
+- Add a new `TransitionContainer.init` that supports further customization during initialization and has the same defaults as `ViewDescription`. ([#155], [#158])
 
-- Add `transition(onAppear:onDisappear:onLayout)` and `transition(_:)` methods to `Element` to describe transition animations. ([#155])
-
-- Add `VisibilityTransition.none` to describe an animation with no effect. ([#155])
+- Add `transition(onAppear:onDisappear:onLayout)` and `transition(_:)` methods to `Element` to describe transition animations. ([#155], [#158])
 
 ### Removed
 
@@ -26,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Deprecated
+
+- `TransitionContainer(wrapping:)` is deprecated. Use the new `TransitionContainer(transitioning:)` instead. ([#158])
 
 ### Security
 
@@ -426,6 +426,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.3.1]: https://github.com/square/Blueprint/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/square/Blueprint/compare/0.2.2...0.3.0
 [0.2.2]: https://github.com/square/Blueprint/releases/tag/0.2.2
+[#158]: https://github.com/square/Blueprint/pull/158
+[#155]: https://github.com/square/Blueprint/pull/155
 [#154]: https://github.com/square/Blueprint/pull/154
 [#149]: https://github.com/square/Blueprint/pull/149
 [#147]: https://github.com/square/Blueprint/pull/147


### PR DESCRIPTION
This is a follow-up to #155 that changes the defaults on TransitionContainer to match the defaults of ViewDescription.

The goal here is to make TransitionContainer not have any effect except for the transitions that you specify, so that there are no implicit changes made by simply adding a container.

Changes:
- make the visibility transitions optional with a `nil` default
- make the default layout transition `inherited`
- to maintain compatibility, these defaults come with a new `init`, and the old one is deprecated. (We could also just make these changes on the existing init and inspect each use manually, since there are not many.)
- reorder the init params to put the wrapped element last (for consistency with other container elements)
- remove `VisibilityTransition.none`, since the usage can replaced by `Optional.none`