### PR TITLE
[Layout] Add `ConstrainedSizeFraction`, a fraction-based sizing strategy

### DIFF
--- a/BlueprintUI/Sources/Layout/ConstrainedSizeFraction.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedSizeFraction.swift
@@ -6,38 +6,38 @@ public struct ConstrainedSizeFraction: Element {
     public var wrappedElement: Element
     /// The fraction of the parent's horizontal layout space the content element should occupy. `nil` if the width is
     /// unconstrained.
-    public var width: CGFloat?
+    public var fractionalWidth: CGFloat?
     /// The fraction of the parent's vertical layout space the content element should occupy. `nil` if the height is
     /// unconstrained.
-    public var height: CGFloat?
+    public var fractionalHeight: CGFloat?
 
     /// Initializes with the given properties.
     ///
     /// - parameters:
-    ///   - width: The fraction of the parent's horizontal layout space the content element should occupy. `nil` if
+    ///   - fractionalWidth: The fraction of the parent's horizontal layout space the content element should occupy. `nil` if
     ///   the width is unconstrained. By default, `nil`.
-    ///   - height: The fraction of the parent's vertical layout space the content element should occupy. `nil` if
+    ///   - fractionalHeight: The fraction of the parent's vertical layout space the content element should occupy. `nil` if
     ///   the height is unconstrained. By default, `nil`.
     ///   - wrapping: The content element.
-    public init(width: CGFloat? = nil, height: CGFloat? = nil, wrapping wrappedElement: Element) {
+    public init(fractionalWidth: CGFloat? = nil, fractionalHeight: CGFloat? = nil, wrapping wrappedElement: Element) {
         precondition(
-            width.map { $0 >= 0 && $0 <= 1} ?? true,
+            fractionalWidth.map { $0 >= 0 && $0 <= 1} ?? true,
             "The provided width fraction must be a value in the range of `0...1`."
         )
         precondition(
-            height.map { $0 >= 0 && $0 <= 1} ?? true,
+            fractionalHeight.map { $0 >= 0 && $0 <= 1} ?? true,
             "The provided height fraction must be a value in the range of `0...1`."
         )
 
-        self.width = width
-        self.height = height
+        self.fractionalWidth = fractionalWidth
+        self.fractionalHeight = fractionalHeight
         self.wrappedElement = wrappedElement
     }
 
     public var content: ElementContent {
         ElementContent(
             child: wrappedElement,
-            layout: Layout(width: width, height: height)
+            layout: Layout(width: fractionalWidth, height: fractionalHeight)
         )
     }
 
@@ -80,15 +80,15 @@ public extension Element {
     /// Constrains the element to a fraction of its parent's size.
     ///
     /// - parameters:
-    ///   - width: The fraction of the parent's horizontal layout space the element should occupy. `nil`
+    ///   - fractionalWidth: The fraction of the parent's horizontal layout space the element should occupy. `nil`
     ///   if the width is unconstrained. By default, `nil`.
-    ///   - height: The fraction of the parent's vertical layout space the element should occupy. `nil`
+    ///   - fractionalHeight: The fraction of the parent's vertical layout space the element should occupy. `nil`
     ///   if the height is unconstrained. By default, `nil`.
     func constrainedTo(
-        widthFraction width: CGFloat? = nil,
-        heightFraction height: CGFloat? = nil
+        fractionalWidth: CGFloat? = nil,
+        fractionalHeight: CGFloat? = nil
     ) -> ConstrainedSizeFraction
     {
-        ConstrainedSizeFraction(width: width, height: height, wrapping: self)
+        ConstrainedSizeFraction(fractionalWidth: fractionalWidth, fractionalHeight: fractionalHeight, wrapping: self)
     }
 }

--- a/BlueprintUI/Sources/Layout/ConstrainedSizeFraction.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedSizeFraction.swift
@@ -21,12 +21,12 @@ public struct ConstrainedSizeFraction: Element {
     ///   - wrapping: The content element.
     public init(width: CGFloat? = nil, height: CGFloat? = nil, wrapping wrappedElement: Element) {
         precondition(
-            width.map { $0 > 0 && $0 <= 1} ?? true,
-            "The provided width fraction must be greater than 0 and less than or equal to 1."
+            width.map { $0 >= 0 && $0 <= 1} ?? true,
+            "The provided width fraction must be a value in the range of `0...1`."
         )
         precondition(
-            height.map { $0 > 0 && $0 <= 1} ?? true,
-            "The provided height fraction must be greater than 0 and less than or equal to 1."
+            height.map { $0 >= 0 && $0 <= 1} ?? true,
+            "The provided height fraction must be a value in the range of `0...1`."
         )
 
         self.width = width

--- a/BlueprintUI/Sources/Layout/ConstrainedSizeFraction.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedSizeFraction.swift
@@ -1,0 +1,94 @@
+import UIKit
+
+/// Constrains the size of the content element to a fraction of the parent's layout space.
+public struct ConstrainedSizeFraction: Element {
+    /// The element being constrained.
+    public var wrappedElement: Element
+    /// The fraction of the parent's horizontal layout space the content element should occupy. `nil` if the width is
+    /// unconstrained.
+    public var width: CGFloat?
+    /// The fraction of the parent's vertical layout space the content element should occupy. `nil` if the height is
+    /// unconstrained.
+    public var height: CGFloat?
+
+    /// Initializes with the given properties.
+    ///
+    /// - parameters:
+    ///   - width: The fraction of the parent's horizontal layout space the content element should occupy. `nil` if
+    ///   the width is unconstrained. By default, `nil`.
+    ///   - height: The fraction of the parent's vertical layout space the content element should occupy. `nil` if
+    ///   the height is unconstrained. By default, `nil`.
+    ///   - wrapping: The content element.
+    public init(width: CGFloat? = nil, height: CGFloat? = nil, wrapping wrappedElement: Element) {
+        precondition(
+            width.map { $0 > 0 && $0 <= 1} ?? true,
+            "The provided width fraction must be greater than 0 and less than or equal to 1."
+        )
+        precondition(
+            height.map { $0 > 0 && $0 <= 1} ?? true,
+            "The provided height fraction must be greater than 0 and less than or equal to 1."
+        )
+
+        self.width = width
+        self.height = height
+        self.wrappedElement = wrappedElement
+    }
+
+    public var content: ElementContent {
+        ElementContent(
+            child: wrappedElement,
+            layout: Layout(width: width, height: height)
+        )
+    }
+
+    public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
+        return nil
+    }
+
+    private struct Layout: SingleChildLayout {
+        var width: CGFloat?
+        var height: CGFloat?
+
+        func measure(in sizeConstraint: SizeConstraint, child: Measurable) -> CGSize {
+            /// Get the target layout space, constraining it by the specified fractions.
+            let targetWidth = width.map { $0 * sizeConstraint.width.maximum }
+            let targetHeight = height.map { $0 * sizeConstraint.height.maximum }
+
+            let constraint = SizeConstraint(
+                width: targetWidth.map { .atMost($0) } ?? .unconstrained,
+                height: targetHeight.map { .atMost($0) } ?? .unconstrained
+            )
+
+            /// Measure the child in the constrained layout space.
+            let measurement = child.measure(in: constraint)
+
+            /// Override the child's measurement with a target dimension if one exists.
+            return CGSize(
+                width: targetWidth ?? measurement.width,
+                height: targetHeight ?? measurement.height
+            )
+        }
+
+        func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
+            return LayoutAttributes(size: size)
+        }
+    }
+}
+
+
+public extension Element {
+    /// Constrains the element to a fraction of its parent's size.
+    ///
+    /// - parameters:
+    ///   - width: The fraction of the parent's horizontal layout space the element should occupy. `nil`
+    ///   if the width is unconstrained. By default, `nil`.
+    ///   - height: The fraction of the parent's vertical layout space the element should occupy. `nil`
+    ///   if the height is unconstrained. By default, `nil`.
+    func constrainedTo(
+        widthFraction width: CGFloat? = nil,
+        heightFraction height: CGFloat? = nil
+    ) -> ConstrainedSizeFraction
+    {
+        ConstrainedSizeFraction(width: width, height: height, wrapping: self)
+    }
+}

--- a/BlueprintUI/Sources/Layout/Overlay.swift
+++ b/BlueprintUI/Sources/Layout/Overlay.swift
@@ -2,7 +2,7 @@ import UIKit
 
 /// Stretches all of its child elements to fill the layout area, stacked on top of each other.
 ///
-/// During a layout pass, measurent is calculated as the max size (in both x and y dimensions)
+/// During a layout pass, measurement is calculated as the max size (in both x and y dimensions)
 /// produced by measuring all of the child elements.
 ///
 /// View-backed descendents will be z-ordered from back to front in the order of this element's

--- a/BlueprintUI/Tests/ConstrainedSizeFractionTests.swift
+++ b/BlueprintUI/Tests/ConstrainedSizeFractionTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import BlueprintUI
+
+class ConstrainedSizeFractionTests: XCTestCase {
+    func test_unconstrainedHeight() {
+        let element = ConstrainedSizeFraction(
+            width: 0.5,
+            wrapping: TestElement()
+        )
+        let size = element.content.measure(in: .init(width: .atMost(300), height: .atMost(400)))
+        XCTAssertEqual(size, CGSize(width: 150, height: TestElement.size.height))
+    }
+
+    func test_unconstrainedWidth() {
+        let element = ConstrainedSizeFraction(
+            height: 0.5,
+            wrapping: TestElement()
+        )
+        let size = element.content.measure(in: .init(width: .atMost(300), height: .atMost(400)))
+        XCTAssertEqual(size, CGSize(width: TestElement.size.width, height: 200))
+    }
+
+    func test_fullyConstrained() {
+        let element = ConstrainedSizeFraction(
+            width: 0.5,
+            height: 0.25,
+            wrapping: TestElement()
+        )
+        let size = element.content.measure(in: .init(width: .atMost(300), height: .atMost(400)))
+        XCTAssertEqual(size, CGSize(width: 150, height: 100))
+    }
+}
+
+private struct TestElement: Element {
+    static let size = CGSize(width: 100, height: 110)
+
+    var content: ElementContent {
+        ElementContent { _ in TestElement.size }
+    }
+
+    func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
+        nil
+    }
+}

--- a/BlueprintUI/Tests/ConstrainedSizeFractionTests.swift
+++ b/BlueprintUI/Tests/ConstrainedSizeFractionTests.swift
@@ -4,7 +4,7 @@ import BlueprintUI
 class ConstrainedSizeFractionTests: XCTestCase {
     func test_unconstrainedHeight() {
         let element = ConstrainedSizeFraction(
-            width: 0.5,
+            fractionalWidth: 0.5,
             wrapping: TestElement()
         )
         let size = element.content.measure(in: .init(width: .atMost(300), height: .atMost(400)))
@@ -13,7 +13,7 @@ class ConstrainedSizeFractionTests: XCTestCase {
 
     func test_unconstrainedWidth() {
         let element = ConstrainedSizeFraction(
-            height: 0.5,
+            fractionalHeight: 0.5,
             wrapping: TestElement()
         )
         let size = element.content.measure(in: .init(width: .atMost(300), height: .atMost(400)))
@@ -22,8 +22,8 @@ class ConstrainedSizeFractionTests: XCTestCase {
 
     func test_fullyConstrained() {
         let element = ConstrainedSizeFraction(
-            width: 0.5,
-            height: 0.25,
+            fractionalWidth: 0.5,
+            fractionalHeight: 0.25,
             wrapping: TestElement()
         )
         let size = element.content.measure(in: .init(width: .atMost(300), height: .atMost(400)))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     ...
 
-    row.addFixed(child: element.constrainedTo(widthFraction: 0.25))
+    row.addFixed(child: element.constrainedTo(fractionalWidth: 0.25))
   }
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   }
   ```
 
+- Add a fraction-based sizing strategy. ([#168])
+
+  `ConstrainedSizeFraction` describes the layout of children which occupy a fraction of their parents' layout space. 
+
+  Previously, this effect could be achieved by composing a `ConstrainedSize` layout as a child of a `GeometryReader`.
+
+  ```swift
+  GeometryReader { geometry in
+    Row { row in 
+
+      ...
+
+      let availableWidth = geometry.constraint.width.maximum
+      row.addFixed(child: self.element.constrainedTo(width: .absolute(width * 0.25)))
+    }
+  }
+  ```
+
+  `ConstrainedSizeFraction` allows the following alternative:
+
+  ```swift
+  Row { row in
+
+    ...
+
+    row.addFixed(child: element.constrainedTo(fractionOfWidth: 0.25))
+  }
+  ```
+
 ### Removed
 
 - [Removed support for iOS 10](https://github.com/square/Blueprint/pull/161). Future releases will only support iOS 11 and later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     ...
 
-    row.addFixed(child: element.constrainedTo(fractionOfWidth: 0.25))
+    row.addFixed(child: element.constrainedTo(widthFraction: 0.25))
   }
   ```
 


### PR DESCRIPTION
#60 
### Summary

`ConstrainedSizeFraction ` describes the layout of children which occupy a fraction of their parents' layout space. 

Previously, this effect could be achieved by composing a `ConstrainedSize` layout as a child of a `GeometryReader`.

```swift
GeometryReader { geometry in
  Row { row in 
    ...
    let availableWidth = geometry.constraint.width.maximum
    row.addFixed(child: self.element.constrainedTo(width: .absolute(width * 0.25)))
  }
}
```

`ConstrainedPercent` allows the following alternative:

```swift
Row { row in
  ...
  row.addFixed(child: element.constrainedTo(widthFraction: 0.25))
}
```

### Alternatives

It seemed tidy and semantically correct to add a `.fraction(width:height:)` case to `ConstrainedSize`, but the [layout strategy](https://github.com/square/Blueprint/blob/main/BlueprintUI/Sources/Layout/ConstrainedSize.swift#L126-L141) would require special casing much like that found [here](https://github.com/square/Blueprint/pull/168/files#diff-fa05a4a771a01f26a2434eb090466ebaaaabd36db6221e8d2766e812a333c0c3R43-R60). 

Perhaps someone has a special insight here about how we could make `apply` idempotent in the `percent` case (akin to `.absolute`), but such insight eluded me.

### Additional considerations

If there's a need, we should consider adding an API parallel to that of `ConstrainedSize` (e.g. `.absolute`, `.atLeast`, `.atMost`). Since I've only ever personally found a need for the `.absolute` case, I decided to start with it exclusively. 

### Looking for help

As always, I defer to the group's best judgment when it comes to naming, as I'm still finding my way.

Additionally, I should note that I'm a bit out of my element when it comes to understanding the layout system, but I've tested this on production code to positive results. In one case, a `Row` with a `minimumHorizontalSpacing`, percentage-based elements, fixed elements, and flexible elements maintained the exact layout it had previously, down to the coordinate point.

Please let me know if there's anything I can do to build further confidence in these changes.