### PR TITLE
Create NativeViewController without animations

### DIFF
--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -342,17 +342,21 @@ extension BlueprintView {
                         controller.update(node: child, appearanceTransitionsEnabled: true)
                     }
                 } else {
-                    let controller = NativeViewController(node: child)
-                    newChildren.append((path: path, node: controller))
-                    
-                    UIView.performWithoutAnimation {
-                        child.layoutAttributes.apply(to: controller.view)
-                    }
-                    
-                    contentView.insertSubview(controller.view, at: index)
+                    var controller: NativeViewController!
 
-                    controller.update(node: child, appearanceTransitionsEnabled: false)
-                    
+                    // Building the view and applying the initial layout and update need to be wrapped in
+                    // performWithoutAnimation so they're not caught up inside an occuring transition.
+                    UIView.performWithoutAnimation {
+                        controller = NativeViewController(node: child)
+                        child.layoutAttributes.apply(to: controller.view)
+
+                        contentView.insertSubview(controller.view, at: index)
+
+                        controller.update(node: child, appearanceTransitionsEnabled: false)
+                    }
+
+                    newChildren.append((path: path, node: controller))
+
                     if appearanceTransitionsEnabled {
                         child.viewDescription.appearingTransition?.performAppearing(view: controller.view, layoutAttributes: child.layoutAttributes, completion: {})
                     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed pull-to-refresh inset for iOS 13+. ([#176](https://github.com/square/Blueprint/pull/176))
+- Fixes an issue where view descriptions were applied with unintentional animations while creating backing views. This could happen if an element was added during a transition. ([#175])
+
+- Fixed pull-to-refresh inset for iOS 13+. ([#176])
 
 ### Added
 
@@ -476,6 +478,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.3.1]: https://github.com/square/Blueprint/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/square/Blueprint/compare/0.2.2...0.3.0
 [0.2.2]: https://github.com/square/Blueprint/releases/tag/0.2.2
+[#176]: https://github.com/square/Blueprint/pull/176
+[#175]: https://github.com/square/Blueprint/pull/175
 [#158]: https://github.com/square/Blueprint/pull/158
 [#155]: https://github.com/square/Blueprint/pull/155
 [#154]: https://github.com/square/Blueprint/pull/154


### PR DESCRIPTION
When creating a `NativeViewController` from a new, the layout attributes are applied with animations disabled. However, other attributes might be applied while building the view, which happens in the `NativeViewController` initializer - in order to prevent unintended animations, we also need to build the view with disabled animations. The node is also updated outside of `performWithoutAnimations`, and even though it does so with `appearanceTransitionsEnabled: false`, applying the update can be caught in an existing transition.

This is a little awkward, since line 359 needs to be outside of the `performWithoutAnimations` but also needs a reference to the controller; open to suggestions on how to do that without the IUO 😬

Example videos shared in slack.