### PR TITLE
Fix pull-to-refresh inset for iOS 13+

### DIFF
--- a/BlueprintUICommonControls/Sources/ScrollView.swift
+++ b/BlueprintUICommonControls/Sources/ScrollView.swift
@@ -401,12 +401,17 @@ extension ScrollView
             finalContentInset.bottom -= safeAreaInsets.bottom
         }
         
-        // The refresh control lives above the content and adjusts the
-        // content inset for itself when visible and refreshing.
-        // Do the same adjustment to our expected content inset.
-        
-        if case .refreshing = refreshControlState {
-            finalContentInset.top += refreshControlBounds?.size.height ?? 0.0
+        if #available(iOS 13, *) {
+            // rdar://35866834
+            // On iOS 13, `UIRefreshControl` will change `adjustedContentInset` automatically as needed.
+            // No need to add extra `contentInset` manually.
+        } else {
+            // The refresh control lives above the content and adjusts the
+            // content inset for itself when visible and refreshing.
+            // Do the same adjustment to our expected content inset.
+            if case .refreshing = refreshControlState {
+                finalContentInset.top += refreshControlBounds?.size.height ?? 0.0
+            }
         }
         
         return finalContentInset

--- a/BlueprintUICommonControls/Tests/Sources/ScrollViewTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/ScrollViewTests.swift
@@ -46,9 +46,17 @@ class ScrollViewTests : XCTestCase {
         )
         
         // Keyboard Inset and refreshing state
-        
+        let expectedTopInset: CGFloat
+        if #available(iOS 13, *) {
+            // rdar://35866834
+            // On iOS 13, `UIRefreshControl` will change `adjustedContentInset` automatically as needed.
+            // No need to add extra `contentInset` manually.
+            expectedTopInset = 10.0
+        } else {
+            expectedTopInset = 35.0
+        }
         XCTAssertEqual(
-            UIEdgeInsets(top: 35.0, left: 11.0, bottom:50.0, right: 13.0),
+            UIEdgeInsets(top: expectedTopInset, left: 11.0, bottom:50.0, right: 13.0),
             
             ScrollView.calculateContentInset(
                 scrollViewInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed pull-to-refresh inset for iOS 13+. ([#176](https://github.com/square/Blueprint/pull/176))
+
 ### Added
 
 ### Removed


### PR DESCRIPTION
On iOS 13, `UIRefreshControl` will change `adjustedContentInset` automatically as needed.
No need to add extra `contentInset` manually.

Related radar: http://www.openradar.appspot.com/35866834

Before on iOS 13:
![before-fix](https://user-images.githubusercontent.com/6780049/97757497-1a27fe80-1aba-11eb-8091-a32600b197d9.gif)

After on iOS 13:
![after-fix](https://user-images.githubusercontent.com/6780049/97757522-2613c080-1aba-11eb-8fbe-68dd6f9dd2ad.gif)
