### PR TITLE
Add `AccessibilityContainer.identifier`

### DIFF
--- a/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
@@ -15,10 +15,13 @@ import UIKit
 /// and the search down that branch is also terminated.
 public struct AccessibilityContainer: Element {
 
+    /// An optional `accessibilityIdentifier` to give the container. Defaults to `nil`.
+    public var identifier: String?
     public var wrapped: Element
 
     /// Creates a new `AccessibilityContainer` wrapping the provided element.
-    public init(wrapping element: Element) {
+    public init(identifier: String? = nil, wrapping element: Element) {
+        self.identifier = identifier
         self.wrapped = element
     }
 
@@ -31,7 +34,9 @@ public struct AccessibilityContainer: Element {
     }
 
     public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
-        AccessibilityContainerView.describe { _ in }
+        AccessibilityContainerView.describe { config in
+            config[\.accessibilityIdentifier] = identifier
+        }
     }
 }
 
@@ -39,8 +44,8 @@ public extension Element {
 
     /// Acts as an accessibility container for any subviews
     /// where `isAccessibilityElement == true`.
-    func accessibilityContainer() -> Element {
-        AccessibilityContainer(wrapping: self)
+    func accessibilityContainer(identifier: String? = nil) -> Element {
+        AccessibilityContainer(identifier: identifier, wrapping: self)
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `AccessibilityContainer.identifier` ([#180])
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
While accessibility containers themselves are generally not
accessibility elements, giving them an `accessibilityIdentifier` can be
useful in KIF tests to disambiguate distinct instances with similar
element subtrees. Since accessibility identifiers are not consumer
facing, this will have no impact on Voice Over.

For example, in an app that displays a collection of todo lists, two
lists may share the same todo text causing rows with the same
`accessibilityLabel`. Creating a test that could pic a specific todo
item when the text appears across multiple items would be difficult, but
by adding a unique `accessibilityIdentifier` to each todo list a test
could first search for the containing view then only search for the todo
item within that root view.