### PR TITLE
Some changes to the ElementPreview type to use it within Market's preview element

### DIFF
--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -125,7 +125,9 @@ public final class BlueprintView: UIView {
     /// Returns the size of the element bound to the current width (mimicking
     /// UILabel’s `intrinsicContentSize` behavior)
     public override var intrinsicContentSize: CGSize {
+        
         guard let element = element else { return .zero }
+        
         let constraint: SizeConstraint
 
         // Use unconstrained when

--- a/BlueprintUI/Sources/Layout/ConstrainedSize.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedSize.swift
@@ -96,6 +96,26 @@ public extension Element {
     {
         ConstrainedSize(width: width, height: height, wrapping: self)
     }
+    
+    /// Constrains the measured size of the element to the provided `SizeConstraint`.
+    func constrained(to sizeConstraint : SizeConstraint) -> ConstrainedSize
+    {
+        ConstrainedSize(
+            width: {
+                switch sizeConstraint.width {
+                case .atMost(let value): return .atMost(value)
+                case .unconstrained: return .unconstrained
+                }
+            }(),
+            height: {
+                switch sizeConstraint.height {
+                case .atMost(let value): return .atMost(value)
+                case .unconstrained: return .unconstrained
+                }
+            }(),
+            wrapping: self
+        )
+    }
 }
 
 

--- a/SampleApp/Sources/XcodePreviewDemo.swift
+++ b/SampleApp/Sources/XcodePreviewDemo.swift
@@ -16,7 +16,7 @@ struct TestElement : ProxyElement {
             $0.verticalUnderflow = .justifyToStart
             
             for index in 1...12 {
-                $0.add(child: Label(text: "Hello, World") {
+                $0.add(child: Label(text: "Hello, World!") {
                     $0.font = .boldSystemFont(ofSize: 10.0 + CGFloat(index * 4))
                     $0.color = .init(
                         red: CGFloat.random(in: 0...1),
@@ -37,7 +37,7 @@ import SwiftUI
 @available(iOS 13.0, *)
 struct TestingView_Preview: PreviewProvider {
     static var previews: some View {
-        ElementPreview(with: .thatFits(padding: 20)) {
+        ElementPreview(with: .thatFits(padding: 5)) {
             TestElement()
         }
     }


### PR DESCRIPTION
I started writing up a `MarketXcodePreview` to let us more easily test Market elements within Xcode's previews, and I had to expose a few previously private values on `ElementPreview` to make this doable. I also added an easier way to convert `SizeConstraint` into `ConstrainedSize`.