### PR TITLE
[DRAFT] [DNR] Smarter element paths

### DIFF
--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -302,8 +302,8 @@ extension BlueprintView {
             var newChildren: [(path: ElementPath, node: NativeViewController)] = []
             newChildren.reserveCapacity(node.children.count)
             
-            let newPaths : [ElementPath] = node.children.map { $0.path.resolved }
-            
+            let newPaths : [ElementPath] = node.children.map { $0.path }
+                        
             var usedKeys: Set<ElementPath> = []
             usedKeys.reserveCapacity(node.children.count)
             

--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -302,7 +302,7 @@ extension BlueprintView {
             var newChildren: [(path: ElementPath, node: NativeViewController)] = []
             newChildren.reserveCapacity(node.children.count)
             
-            let newPaths : [ElementPath] = node.children.map { $0.path }
+            let newPaths : [ElementPath] = node.children.map { $0.path.resolved }
             
             var usedKeys: Set<ElementPath> = []
             usedKeys.reserveCapacity(node.children.count)

--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -302,7 +302,7 @@ extension BlueprintView {
             var newChildren: [(path: ElementPath, node: NativeViewController)] = []
             newChildren.reserveCapacity(node.children.count)
             
-            let newPaths : [ElementPath] = node.children.map { $0.path }
+            let newPaths : [ElementPath] = node.children.map { $0.path.filteredToViewBacked() }
                         
             var usedKeys: Set<ElementPath> = []
             usedKeys.reserveCapacity(node.children.count)

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -278,7 +278,8 @@ extension ElementContent {
 
                 let identifier = identifierFactory.nextIdentifier(
                     for: type(of: currentChild.element),
-                    key: currentChild.key
+                    key: currentChild.key,
+                    isViewBacked: currentChild.element.backingViewDescription(bounds: .zero, subtreeExtent: nil) != nil
                 )
 
                 result.append((identifier: identifier, node: resultNode))
@@ -322,7 +323,12 @@ private struct EnvironmentAdaptingStorage: ContentStorage {
 
         let childAttributes = LayoutAttributes(size: attributes.bounds.size)
 
-        let identifier = ElementIdentifier(elementType: type(of: child), key: nil, count: 1)
+        let identifier = ElementIdentifier(
+            elementType: type(of: child),
+            key: nil,
+            count: 1,
+            isViewBacked: child.backingViewDescription(bounds: .zero, subtreeExtent: nil) != nil
+        )
 
         let node = LayoutResultNode(
             element: child,
@@ -362,7 +368,12 @@ private struct LazyStorage: ContentStorage {
         let child = buildChild(in: constraint, environment: environment)
         let childAttributes = LayoutAttributes(size: attributes.bounds.size)
 
-        let identifier = ElementIdentifier(elementType: type(of: child), key: nil, count: 1)
+        let identifier = ElementIdentifier(
+            elementType: type(of: child),
+            key: nil,
+            count: 1,
+            isViewBacked: child.backingViewDescription(bounds: .zero, subtreeExtent: nil) != nil
+        )
 
         let node = LayoutResultNode(
             element: child,

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -279,7 +279,7 @@ extension ElementContent {
                 let identifier = identifierFactory.nextIdentifier(
                     for: type(of: currentChild.element),
                     key: currentChild.key,
-                    isViewBacked: currentChild.element.backingViewDescription(bounds: .zero, subtreeExtent: nil) != nil
+                    isViewBacked: currentChild.element.isViewBacked(with: resultNode.layoutAttributes)
                 )
 
                 result.append((identifier: identifier, node: resultNode))
@@ -327,7 +327,7 @@ private struct EnvironmentAdaptingStorage: ContentStorage {
             elementType: type(of: child),
             key: nil,
             count: 1,
-            isViewBacked: child.backingViewDescription(bounds: .zero, subtreeExtent: nil) != nil
+            isViewBacked: child.isViewBacked(with: childAttributes)
         )
 
         let node = LayoutResultNode(
@@ -372,7 +372,7 @@ private struct LazyStorage: ContentStorage {
             elementType: type(of: child),
             key: nil,
             count: 1,
-            isViewBacked: child.backingViewDescription(bounds: .zero, subtreeExtent: nil) != nil
+            isViewBacked: child.isViewBacked(with: childAttributes)
         )
 
         let node = LayoutResultNode(
@@ -448,4 +448,14 @@ fileprivate struct MeasurableLayout: Layout {
         return []
     }
 
+}
+
+
+fileprivate extension Element {
+    func isViewBacked(with attributes : LayoutAttributes) -> Bool {
+        self.backingViewDescription(
+            bounds: attributes.bounds,
+            subtreeExtent: nil
+        ) != nil
+    }
 }

--- a/BlueprintUI/Sources/Internal/ElementIdentifier.swift
+++ b/BlueprintUI/Sources/Internal/ElementIdentifier.swift
@@ -62,9 +62,9 @@ struct ElementIdentifier: Hashable, CustomDebugStringConvertible {
     
     var debugDescription: String {
         if let key = self.key {
-            return "\(self.elementType).\(String(describing: key)).\(self.count)"
+            return "\(self.elementType).\(String(describing: key)).\(self.count).\(self.isViewBacked ? "true" : "false")"
         } else {
-            return "\(self.elementType).\(self.count)"
+            return "\(self.elementType).\(self.count).\(self.isViewBacked ? "true" : "false")"
         }
     }
     

--- a/BlueprintUI/Sources/Internal/ElementIdentifier.swift
+++ b/BlueprintUI/Sources/Internal/ElementIdentifier.swift
@@ -47,13 +47,17 @@ struct ElementIdentifier: Hashable, CustomDebugStringConvertible {
     let key : AnyHashable?
 
     let count : Int
+    
+    let isViewBacked : Bool
 
-    init(elementType : Element.Type, key : AnyHashable?, count : Int) {
+    init(elementType : Element.Type, key : AnyHashable?, count : Int, isViewBacked : Bool) {
         
         self.elementType = ObjectIdentifier(elementType)
         self.key = key
         
         self.count = count
+        
+        self.isViewBacked = isViewBacked
     }
     
     var debugDescription: String {
@@ -73,14 +77,15 @@ struct ElementIdentifier: Hashable, CustomDebugStringConvertible {
             self.countsByKey = Dictionary(minimumCapacity: elementCount)
         }
                 
-        mutating func nextIdentifier(for type : Element.Type, key : AnyHashable?) -> ElementIdentifier {
+        mutating func nextIdentifier(for type : Element.Type, key : AnyHashable?, isViewBacked : Bool) -> ElementIdentifier {
             
             let count = self.nextCount(for: type, key: key)
             
             return ElementIdentifier(
                 elementType: type,
                 key: key,
-                count: count
+                count: count,
+                isViewBacked: isViewBacked
             )
         }
         

--- a/BlueprintUI/Sources/Internal/ElementPath.swift
+++ b/BlueprintUI/Sources/Internal/ElementPath.swift
@@ -49,7 +49,7 @@ struct ElementPath: Hashable, CustomDebugStringConvertible {
         hasher.combine(identifiersHash)
     }
     
-    var resolved : ElementPath {
+    func filteredToViewBacked() -> ElementPath {
         ElementPath(identifiers: self.identifiers.filter { $0.isViewBacked })
     }
     

--- a/BlueprintUI/Sources/Internal/ElementPath.swift
+++ b/BlueprintUI/Sources/Internal/ElementPath.swift
@@ -4,7 +4,7 @@ struct ElementPath: Hashable, CustomDebugStringConvertible {
     
     private var identifiersHash : Int? = nil
 
-    private(set) var identifiers: [ElementIdentifier] = []
+    private(set) var identifiers: [ElementIdentifier]
     
     private mutating func setIdentifiersHash()
     {
@@ -12,6 +12,10 @@ struct ElementPath: Hashable, CustomDebugStringConvertible {
         hasher.combine(identifiers)
         
         identifiersHash = hasher.finalize()
+    }
+    
+    init(identifiers : [ElementIdentifier] = []) {
+        self.identifiers = identifiers
     }
     
     mutating func prepend(identifier: ElementIdentifier) {
@@ -43,6 +47,10 @@ struct ElementPath: Hashable, CustomDebugStringConvertible {
     
     func hash(into hasher: inout Hasher) {
         hasher.combine(identifiersHash)
+    }
+    
+    var resolved : ElementPath {
+        ElementPath(identifiers: self.identifiers.filter { $0.isViewBacked })
     }
     
     // MARK: CustomDebugStringConvertible


### PR DESCRIPTION
- Allow element paths which reference view backed elements only, for better view reuse in case a non-view backed element in the tree goes away but an inner one remains.