### PR TITLE
Introduce LayoutWriter

### DIFF
--- a/BlueprintUI/Sources/Layout/ConstrainedSize.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedSize.swift
@@ -97,22 +97,44 @@ public extension Element {
         ConstrainedSize(width: width, height: height, wrapping: self)
     }
     
+    /// Constrains the measured size of the element to the provided width and height.
+    func constrainedTo(
+        width: CGFloat,
+        height: CGFloat
+    ) -> ConstrainedSize
+    {
+        ConstrainedSize(
+            width: .absolute(width),
+            height: .absolute(height),
+            wrapping: self
+        )
+    }
+    
+    /// Constrains the measured size of the element to the provided size.
+    func constrainedTo(
+        size : CGSize
+    ) -> ConstrainedSize
+    {
+        ConstrainedSize(
+            width: .absolute(size.width),
+            height: .absolute(size.height),
+            wrapping: self
+        )
+    }
+    
     /// Constrains the measured size of the element to the provided `SizeConstraint`.
     func constrained(to sizeConstraint : SizeConstraint) -> ConstrainedSize
     {
-        ConstrainedSize(
-            width: {
-                switch sizeConstraint.width {
-                case .atMost(let value): return .atMost(value)
-                case .unconstrained: return .unconstrained
-                }
-            }(),
-            height: {
-                switch sizeConstraint.height {
-                case .atMost(let value): return .atMost(value)
-                case .unconstrained: return .unconstrained
-                }
-            }(),
+        func toConstrainedSize(_ axis : SizeConstraint.Axis) -> ConstrainedSize.Constraint {
+            switch axis {
+            case .atMost(let value): return .atMost(value)
+            case .unconstrained: return .unconstrained
+            }
+        }
+        
+        return ConstrainedSize(
+            width: toConstrainedSize(sizeConstraint.width),
+            height: toConstrainedSize(sizeConstraint.height),
             wrapping: self
         )
     }

--- a/BlueprintUI/Sources/Layout/LayoutWriter.swift
+++ b/BlueprintUI/Sources/Layout/LayoutWriter.swift
@@ -49,7 +49,7 @@ public struct LayoutWriter : Element {
     public var content: ElementContent {
         ElementContent { size, env in
             var builder = Builder()
-            self.build(Context(size: size, environment: env), &builder)
+            self.build(Context(size: size), &builder)
             return InnerElement(builder: builder)
         }
     }
@@ -98,25 +98,6 @@ extension LayoutWriter {
             self.children.append(.init(frame: frame, element: child))
         }
         
-        /// Adds a new child element to the layout with the provided frame.
-        /// The frame is passed to the child provider.
-        public mutating func add(
-            with frame: CGRect,
-            child : (CGRect) -> Element
-        ) {
-            self.add(with: frame, child: child(frame))
-        }
-        
-        /// Adds a new child element to the layout with the provided frame.
-        /// The frame is passed to the child provider.
-        public mutating func add(
-            with frame: () -> CGRect,
-            child : (CGRect) -> Element
-        ) {
-            let frame = frame()
-            self.add(with: frame, child: child(frame))
-        }
-        
         /// Adds a new child element to the layout.
         /// Using this method is helpful if you need to calculate both the frame and the element content in a single pass.
         public mutating func add(_ child : () -> (CGRect, Element)) {
@@ -140,19 +121,50 @@ extension LayoutWriter {
         
         /// The size constraint the layout is occurring in.
         public var size : SizeConstraint
-        
-        /// The environment the layout is occurring in.
-        public var environment : Environment
     }
     
     /// Controls the sizing calculation of the custom layout.
     public enum Sizing : Equatable {
         
         /// Ensures that the final size of element is large enough to fit all children, starting from (0,0).
+        ///
+        /// Negative origins of rects are not considered in this calculation. If you have the following layout:
+        /// ```
+        ///  ┌──────┐
+        ///  │      ├─────────┐
+        ///  │      │*********│
+        ///  └─┬────┘**┌──────┤
+        ///    │*******│      │
+        ///    │*******│      │
+        /// ┌──┴───┐***│      │
+        /// │      │***│      │
+        /// │      │***└──────┤
+        /// └──────┴──────────┘
+        /// ```
+        /// The large rect will be the calculated size / bounds of the layout, starting at (0,0). Any rects with
+        /// negative origins will overhang the layout to the top or left, respectively.
         case unionOfChildren
         
-        /// Fixes the layout size to the provided size.
+        /// Fixes the layout size to the provided size. Children are positioned within this size, starting at (0,0)
+        /// Any rects with negative origins will overhang the layout to the top or left, respectively.
         case fixed(CGSize)
+        
+        /// Measures the size of the content within the builder.
+        func measure(with builder : Builder) -> CGSize {
+            switch self {
+            case .unionOfChildren:
+                return CGSize(
+                    width: builder.children.reduce(0.0) { width, child in
+                        max(width, child.frame.maxX)
+                    },
+                    height: builder.children.reduce(0.0) { height, child in
+                        max(height, child.frame.maxY)
+                    }
+                )
+            case .fixed(let size):
+                return size
+            }
+        }
     }
     
     /// A child of the custom layout, providing its frame and element.
@@ -178,7 +190,6 @@ extension LayoutWriter {
 
 extension LayoutWriter {
     
-    /// We bounce to an inner element so we can provide the environment.
     private struct InnerElement : Element {
         var builder : Builder
         
@@ -202,15 +213,7 @@ extension LayoutWriter {
             var builder : Builder
             
             func measure(in constraint: SizeConstraint, items: [(traits: (), content: Measurable)]) -> CGSize {
-                switch builder.sizing {
-                case .unionOfChildren:
-                    return builder.children.reduce(CGRect.zero) { rect, child in
-                        rect.union(child.frame)
-                    }.size
-                    
-                case .fixed(let size):
-                    return size
-                }
+                self.builder.sizing.measure(with: self.builder)
             }
             
             func layout(size: CGSize, items: [(traits: (), content: Measurable)]) -> [LayoutAttributes] {
@@ -221,3 +224,4 @@ extension LayoutWriter {
         }
     }
 }
+

--- a/BlueprintUI/Sources/Layout/LayoutWriter.swift
+++ b/BlueprintUI/Sources/Layout/LayoutWriter.swift
@@ -5,6 +5,8 @@
 //  Created by Kyle Van Essen on 10/7/20.
 //
 
+import UIKit
+
 
 /// A parent element which allows arbitrary, custom layout and positioning of its children.
 ///

--- a/BlueprintUI/Sources/Layout/LayoutWriter.swift
+++ b/BlueprintUI/Sources/Layout/LayoutWriter.swift
@@ -50,7 +50,8 @@ public struct LayoutWriter : Element {
         ElementContent { size, env in
             var builder = Builder()
             self.build(Context(size: size), &builder)
-            return InnerElement(builder: builder)
+            
+            return Content(builder: builder)
         }
     }
     
@@ -190,7 +191,7 @@ extension LayoutWriter {
 
 extension LayoutWriter {
     
-    private struct InnerElement : Element {
+    private struct Content : Element {
         var builder : Builder
         
         // MARK: Element

--- a/BlueprintUI/Sources/Layout/LayoutWriter.swift
+++ b/BlueprintUI/Sources/Layout/LayoutWriter.swift
@@ -1,0 +1,221 @@
+//
+//  LayoutWriter.swift
+//  BlueprintUI
+//
+//  Created by Kyle Van Essen on 10/7/20.
+//
+
+
+/// A parent element which allows arbitrary, custom layout and positioning of its children.
+///
+/// Instead of creating a custom `Element` with a custom `Layout`, you might use
+/// this element to create a customized layout in a more lightweight way.
+///
+/// ```
+/// LayoutWriter { context, layout in
+///     layout.add(with: myFrame, child: myElement)
+///     layout.add(with: myOtherFrame, child: myOtherElement)
+///
+///     layout.sizing = .unionOfChildren
+/// }
+/// ```
+public struct LayoutWriter : Element {
+    
+    //
+    // MARK: Initialization
+    //
+    
+    /// Creates a new instance of the LayoutWriter with the custom layout provided by the builder.
+    ///
+    /// The parameters to the closure are the `Context`, which provides information about
+    /// the environment and sizing of the layout, and the `Builder` itself, which you use to
+    /// add child elements to the layout.
+    public init(_ build : @escaping Build) {
+        self.build = build
+    }
+    
+    /// The builder type passed to the `LayoutWriter` initializer.
+    public typealias Build = (Context, inout Builder) -> ()
+    
+    /// The builder used to create the custom layout.
+    public let build : Build
+    
+    //
+    // MARK: Element
+    //
+    
+    public var content: ElementContent {
+        ElementContent { size, env in
+            var builder = Builder()
+            self.build(Context(size: size, environment: env), &builder)
+            return InnerElement(builder: builder)
+        }
+    }
+    
+    public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
+        nil
+    }
+}
+
+
+extension LayoutWriter {
+    
+    /// The builder is the primary surface area you interact with when using a `LayoutWriter`.
+    ///
+    /// It provides you the ability to manage the sizing and measurement of the final layout,
+    /// alongside methods to add and manage the children of the layout.
+    public struct Builder {
+        
+        //
+        // MARK: Managing Sizing
+        //
+        
+        /// How the size of the layout should be calculated. Defaults to `.unionOfChildren`,
+        /// which means the size will be big enough to contain the frames of all contained children.
+        public var sizing : Sizing = .unionOfChildren
+        
+        //
+        // MARK: Managing Children
+        //
+        
+        /// The children of the custom layout, which specifies the child element and its frame.
+        ///
+        /// Note
+        /// ----
+        /// You rarely need to access this property directly. Instead, add children via
+        /// the various provided `add(...)` methods. However, if you're `map`-ing over an array
+        /// or other collection of content, using this property directly is useful.
+        ///
+        public var children : [Child] = []
+        
+        /// Adds a new child element to the layout with the provided frame.
+        public mutating func add(
+            with frame: CGRect,
+            child : Element
+        ) {
+            self.children.append(.init(frame: frame, element: child))
+        }
+        
+        /// Adds a new child element to the layout with the provided frame.
+        /// The frame is passed to the child provider.
+        public mutating func add(
+            with frame: CGRect,
+            child : (CGRect) -> Element
+        ) {
+            self.add(with: frame, child: child(frame))
+        }
+        
+        /// Adds a new child element to the layout with the provided frame.
+        /// The frame is passed to the child provider.
+        public mutating func add(
+            with frame: () -> CGRect,
+            child : (CGRect) -> Element
+        ) {
+            let frame = frame()
+            self.add(with: frame, child: child(frame))
+        }
+        
+        /// Adds a new child element to the layout.
+        /// Using this method is helpful if you need to calculate both the frame and the element content in a single pass.
+        public mutating func add(_ child : () -> (CGRect, Element)) {
+            let result = child()
+            self.add(with: result.0, child: result.1)
+        }
+        
+        /// Enumerates each of the children, allowing you to modify them in place,
+        /// eg to align them all along a common alignment axis or to set a uniform size.
+        public mutating func modifyEach(using change : (inout Child) -> ()) {
+            self.children = children.map {
+                var updated = $0
+                change(&updated)
+                return updated
+            }
+        }
+    }
+    
+    /// Provides the relevant information about the context in which the layout is occurring.
+    public struct Context {
+        
+        /// The size constraint the layout is occurring in.
+        public var size : SizeConstraint
+        
+        /// The environment the layout is occurring in.
+        public var environment : Environment
+    }
+    
+    /// Controls the sizing calculation of the custom layout.
+    public enum Sizing : Equatable {
+        
+        /// Ensures that the final size of element is large enough to fit all children, starting from (0,0).
+        case unionOfChildren
+        
+        /// Fixes the layout size to the provided size.
+        case fixed(CGSize)
+    }
+    
+    /// A child of the custom layout, providing its frame and element.
+    public struct Child {
+        
+        /// The frame of the element in the coordinate space of the custom layout.
+        public var frame : CGRect
+        
+        /// The element to be displayed.
+        public var element : Element
+        
+        /// Creates a new child element.
+        public init(
+            frame : CGRect,
+            element : Element
+        ) {
+            self.frame = frame
+            self.element = element
+        }
+    }
+}
+
+
+extension LayoutWriter {
+    
+    /// We bounce to an inner element so we can provide the environment.
+    private struct InnerElement : Element {
+        var builder : Builder
+        
+        // MARK: Element
+        
+        var content: ElementContent {
+            ElementContent(layout: Layout(builder: self.builder)) { builder in
+                for child in self.builder.children {
+                    builder.add(element: child.element)
+                }
+            }
+        }
+        
+        func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
+            nil
+        }
+        
+        // MARK: Layout
+        
+        private struct Layout : BlueprintUI.Layout {
+            var builder : Builder
+            
+            func measure(in constraint: SizeConstraint, items: [(traits: (), content: Measurable)]) -> CGSize {
+                switch builder.sizing {
+                case .unionOfChildren:
+                    return builder.children.reduce(CGRect.zero) { rect, child in
+                        rect.union(child.frame)
+                    }.size
+                    
+                case .fixed(let size):
+                    return size
+                }
+            }
+            
+            func layout(size: CGSize, items: [(traits: (), content: Measurable)]) -> [LayoutAttributes] {
+                self.builder.children.map { child in
+                    .init(frame: child.frame)
+                }
+            }
+        }
+    }
+}

--- a/BlueprintUI/Tests/LayoutWriterTests.swift
+++ b/BlueprintUI/Tests/LayoutWriterTests.swift
@@ -1,0 +1,76 @@
+//
+//  LayoutWriterTests.swift
+//  BlueprintUI-Unit-Tests
+//
+//  Created by Kyle Van Essen on 12/8/20.
+//
+
+import XCTest
+@testable import BlueprintUI
+
+
+class LayoutWriterTests : XCTestCase {
+    
+    func test_measurement() {
+        
+        /// `.unionOfChildren`
+        
+        do {
+            let writer = LayoutWriter { context, layout in
+                layout.add(with: CGRect(x: 10, y: 20, width: 50, height: 50), child: TestElement())
+                layout.add(with: CGRect(x: 20, y: 10, width: 20, height: 100), child: TestElement())
+                
+                layout.sizing = .unionOfChildren
+            }
+            
+            XCTAssertEqual(writer.content.measure(in: .unconstrained), CGSize(width: 60, height: 110))
+        }
+        
+        
+        /// `.fixed`
+        
+        do {
+            let writer = LayoutWriter { context, layout in
+                layout.add(with: CGRect(x: 10, y: 20, width: 50, height: 50), child: TestElement())
+                
+                layout.sizing = .fixed(CGSize(width: 100, height: 100))
+            }
+            
+            XCTAssertEqual(writer.content.measure(in: .unconstrained), CGSize(width: 100, height: 100))
+        }
+
+    }
+    
+    func test_layout() {
+        let writer = LayoutWriter { context, layout in
+            layout.add(with: CGRect(x: 10, y: 20, width: 50, height: 50), child: TestElement())
+            layout.add(with: CGRect(x: 20, y: 10, width: 20, height: 100), child: TestElement())
+        }
+    
+        let layoutResult = writer.content.performLayout(attributes: LayoutAttributes(size: CGSize(width: 100, height: 100)), environment: .empty)
+        let innerElement = layoutResult[0]
+        
+        let nodes = innerElement.node.children.map(\.node)
+        
+        XCTAssertEqual(nodes.count, 2)
+        
+        let first = nodes[0]
+        let second = nodes[1]
+
+        XCTAssertEqual(first.layoutAttributes.frame, CGRect(x: 10, y: 20, width: 50, height: 50))
+        XCTAssertEqual(second.layoutAttributes.frame, CGRect(x: 20, y: 10, width: 20, height: 100))
+    }
+}
+
+
+fileprivate struct TestElement : Element {
+    
+    var content: ElementContent {
+        ElementContent { $0.maximum }
+    }
+    
+    func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
+        UIView.describe { _ in }
+    }
+    
+}

--- a/BlueprintUI/Tests/LayoutWriterTests.swift
+++ b/BlueprintUI/Tests/LayoutWriterTests.swift
@@ -14,7 +14,7 @@ class LayoutWriterTests : XCTestCase {
     
     func test_measurement() {
         
-        /// `.unionOfChildren`
+        /// `.unionOfChildren`, positive frames.
         
         do {
             let writer = LayoutWriter { context, layout in
@@ -25,6 +25,20 @@ class LayoutWriterTests : XCTestCase {
             }
             
             XCTAssertEqual(writer.content.measure(in: .unconstrained), CGSize(width: 60, height: 110))
+        }
+        
+        /// `.unionOfChildren`, positive & negative frames.
+        
+        do {
+            let writer = LayoutWriter { context, layout in
+                layout.add(with: CGRect(x: -10, y: -10, width: 50, height: 50), child: TestElement())
+                layout.add(with: CGRect(x: -20, y: 50, width: 20, height: 60), child: TestElement())
+                layout.add(with: CGRect(x: 50, y: 25, width: 50, height: 60), child: TestElement())
+                
+                layout.sizing = .unionOfChildren
+            }
+            
+            XCTAssertEqual(writer.content.measure(in: .unconstrained), CGSize(width: 100, height: 110))
         }
         
         

--- a/BlueprintUI/Tests/LayoutWriterTests.swift
+++ b/BlueprintUI/Tests/LayoutWriterTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import UIKit
 @testable import BlueprintUI
 
 

--- a/BlueprintUI/Tests/LayoutWriterTests.swift
+++ b/BlueprintUI/Tests/LayoutWriterTests.swift
@@ -12,6 +12,28 @@ import UIKit
 
 class LayoutWriterTests : XCTestCase {
     
+    func test_buildCount() {
+        
+        // Performance – should only build the layout once during a layout pass.
+        
+        var buildCount : Int = 0
+        
+        let writer = LayoutWriter { _, layout in
+            buildCount += 1
+        }
+        
+        let view = BlueprintView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        
+        view.element = writer.centered()
+        
+        XCTAssertEqual(buildCount, 0)
+        
+        view.layoutIfNeeded()
+        
+        // Two calls: Once for measurement, and once for layout.
+        XCTAssertEqual(buildCount, 2)
+    }
+    
     func test_measurement() {
         
         /// `.unionOfChildren`, positive frames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `AccessibilityContainer.identifier` ([#180])
 
+- [Add `LayoutWriter`](https://github.com/square/Blueprint/pull/187), which makes creating custom / arbitrary layouts much simpler. You no longer need to define a custom `Layout` type; instead, you can just utilize `LayoutWriter` and configure and place your children within its builder initializer.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
Introduce LayoutWriter, for easier custom layouts without needing to use the Layout protocol. Check out the added swift file for the documentation – but the idea here is to support easier custom arbitrary layouts. I pulled this over from the second https://github.com/squareup/market/pull/549 navigation controller PR.