### PR TITLE
Fix empty environment referencing a forever-living MeasurementCache

### DIFF
--- a/BlueprintUI/Sources/Environment/Environment.swift
+++ b/BlueprintUI/Sources/Environment/Environment.swift
@@ -34,9 +34,18 @@ import Foundation
 ///         }
 ///     }
 public struct Environment {
+    
     /// A default "empty" environment, with no values overridden.
     /// Each key will return its default value.
-    public static let empty = Environment(measurementCache: .init())
+    public static var empty : Environment {
+        
+        /// Intentionally a derived value instead of a `static let empty = ...`. because `MeasurementCache`
+        /// is a `class` type (needed due to implementation constraints – the `MeasurementCache` is passed around during layout),
+        /// we want to ensure that each new environment that we ask for has a new `measurementCache` to avoid "leaking" / retaining
+        /// all the contained keys for the lifetime of the application, as a `static let` would cause.
+        
+        Environment(measurementCache: MeasurementCache())
+    }
 
     private init(measurementCache : MeasurementCache) {
         self.measurementCache = measurementCache


### PR DESCRIPTION
See the added comment for full details; but I noticed this bug today. TL;DR is because the `MeasurementCache` is a reference type and this was a `static let`, any added keys chill around in memory for the lifetime of the application.