### PR TITLE
Protect LayoutWriter against empty frames

### DIFF
--- a/BlueprintUI/Sources/Layout/LayoutWriter.swift
+++ b/BlueprintUI/Sources/Layout/LayoutWriter.swift
@@ -49,7 +49,10 @@ public struct LayoutWriter : Element {
     public var content: ElementContent {
         ElementContent { size, env in
             var builder = Builder()
-            self.build(Context(size: size), &builder)
+            
+            if size.maximum.width > 0 && size.maximum.height > 0 {
+                self.build(Context(size: size), &builder)
+            }
             
             return Content(builder: builder)
         }

--- a/BlueprintUI/Tests/LayoutWriterTests.swift
+++ b/BlueprintUI/Tests/LayoutWriterTests.swift
@@ -34,6 +34,42 @@ class LayoutWriterTests : XCTestCase {
         XCTAssertEqual(buildCount, 2)
     }
     
+    func test_zeroSize_does_no_layout() {
+        
+        // Trying to perform a layout with a zero size doesn't really mean anything.
+        // In these cases, we should skip the layout to avoid NaN calculations
+        // and other otherwise weird edge cases.
+        
+        var callCount : Int = 0
+        
+        let writer = LayoutWriter { _, layout in
+            callCount += 1
+        }
+        
+        let view = BlueprintView(element: writer)
+        
+        XCTAssertEqual(callCount, 0)
+        
+        view.layoutIfNeeded()
+        
+        XCTAssertEqual(callCount, 0)
+        
+        view.frame.size = CGSize(width: 0, height: 100)
+        view.layoutIfNeeded()
+        
+        XCTAssertEqual(callCount, 0)
+        
+        view.frame.size = CGSize(width: 100, height: 0)
+        view.layoutIfNeeded()
+        
+        XCTAssertEqual(callCount, 0)
+        
+        view.frame.size = CGSize(width: 100, height: 100)
+        view.layoutIfNeeded()
+        
+        XCTAssertEqual(callCount, 1)
+    }
+    
     func test_measurement() {
         
         /// `.unionOfChildren`, positive frames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [When `LayoutWriter` receives an empty frame, skip the layout process](https://github.com/square/Blueprint/pull/199). This avoids likely calculations against 0, which can easily result in NaN later on in the layout pass. 
+
 ### Added
 
 ### Removed


### PR DESCRIPTION
- Skip layout when LayoutWriter has no area; these layouts don't mean anything and are likely to cause NaN layouts due to a zero width or height.