### PR TITLE
[UserInteractionEnabled] Introduce component for declaring interactivity

### DIFF
--- a/BlueprintUICommonControls/Sources/UserInteractionEnabled.swift
+++ b/BlueprintUICommonControls/Sources/UserInteractionEnabled.swift
@@ -32,17 +32,10 @@ public struct UserInteractionEnabled: Element {
 }
 
 public extension Element {
-    /// Conditionally disable user interaction of the wrapped element.
-    ///
-    /// - Note: When user interaction is disabled, any elements within the wrapped element will become non-interactive.
-    func disabled(_ disabled: Bool = true) -> UserInteractionEnabled {
-        UserInteractionEnabled(!disabled, wrapping: self)
-    }
-
     /// Conditionally enable user interaction of the wrapped element.
     ///
     /// - Note: When user interaction is disabled, any elements within the wrapped element will become non-interactive.
-    func enabled(_ enabled: Bool = true) -> UserInteractionEnabled {
+    func userInteractionEnabled(_ enabled: Bool = true) -> UserInteractionEnabled {
         UserInteractionEnabled(enabled, wrapping: self)
     }
 }

--- a/BlueprintUICommonControls/Sources/UserInteractionEnabled.swift
+++ b/BlueprintUICommonControls/Sources/UserInteractionEnabled.swift
@@ -1,0 +1,48 @@
+//
+//  UserInteractionEnabled.swift
+//  BlueprintUICommonControls
+//
+//  Created by Noah Blake on 3/15/21.
+//
+
+import BlueprintUI
+import UIKit
+
+/// `UserInteractionEnabled` conditionally enables user interaction of its wrapped element.
+///
+/// - Note: When user interaction is disabled, any elements within the wrapped element will become non-interactive.
+public struct UserInteractionEnabled: Element {
+    public var isEnabled: Bool
+    public var wrappedElement: Element
+
+    public init(_ isEnabled: Bool, wrapping element: Element) {
+        self.isEnabled = isEnabled
+        self.wrappedElement = element
+    }
+
+    public var content: ElementContent {
+        ElementContent(child: wrappedElement)
+    }
+
+    public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
+        UIView.describe { config in
+            config[\.isUserInteractionEnabled] = isEnabled
+        }
+    }
+}
+
+public extension Element {
+    /// Conditionally disable user interaction of the wrapped element.
+    ///
+    /// - Note: When user interaction is disabled, any elements within the wrapped element will become non-interactive.
+    func disabled(_ disabled: Bool = true) -> UserInteractionEnabled {
+        UserInteractionEnabled(!disabled, wrapping: self)
+    }
+
+    /// Conditionally enable user interaction of the wrapped element.
+    ///
+    /// - Note: When user interaction is disabled, any elements within the wrapped element will become non-interactive.
+    func enabled(_ enabled: Bool = true) -> UserInteractionEnabled {
+        UserInteractionEnabled(enabled, wrapping: self)
+    }
+}

--- a/BlueprintUICommonControls/Tests/Sources/UserInteractionEnabledTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/UserInteractionEnabledTests.swift
@@ -1,0 +1,26 @@
+//
+//  UserInteractionEnabledTests.swift
+//  BlueprintUICommonControls-Unit-Tests
+//
+//  Created by Noah Blake on 3/15/20.
+//
+
+import XCTest
+import BlueprintUI
+import BlueprintUICommonControls
+
+final class UserInteractionEnabledTests: XCTestCase {
+    func test() throws {
+        func makeView(enabled: Bool) throws -> UIView {
+            let wrapped = UserInteractionEnabled(enabled, wrapping: Box())
+            let description = try XCTUnwrap(wrapped.backingViewDescription(bounds: .zero, subtreeExtent: nil))
+            let view = UIView()
+            view.isUserInteractionEnabled = !enabled
+            description.apply(to: view)
+            return view
+        }
+
+        XCTAssertTrue(try makeView(enabled: true).isUserInteractionEnabled)
+        XCTAssertFalse(try makeView(enabled: false).isUserInteractionEnabled)
+    }
+}

--- a/BlueprintUICommonControls/Tests/Sources/UserInteractionEnabledTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/UserInteractionEnabledTests.swift
@@ -11,16 +11,35 @@ import BlueprintUICommonControls
 
 final class UserInteractionEnabledTests: XCTestCase {
     func test() throws {
-        func makeView(enabled: Bool) throws -> UIView {
-            let wrapped = UserInteractionEnabled(enabled, wrapping: Box())
-            let description = try XCTUnwrap(wrapped.backingViewDescription(bounds: .zero, subtreeExtent: nil))
-            let view = UIView()
-            view.isUserInteractionEnabled = !enabled
-            description.apply(to: view)
-            return view
-        }
+        let enabled = UserInteractionEnabled(true, wrapping: Box())
+        XCTAssertTrue(try view(from: enabled).isUserInteractionEnabled)
 
-        XCTAssertTrue(try makeView(enabled: true).isUserInteractionEnabled)
-        XCTAssertFalse(try makeView(enabled: false).isUserInteractionEnabled)
+        let disabled = UserInteractionEnabled(false, wrapping: Box())
+        XCTAssertFalse(try view(from: disabled).isUserInteractionEnabled)
+    }
+
+    func test_disabled() throws {
+        let enabled = Box().disabled(false)
+        XCTAssertTrue(try view(from: enabled).isUserInteractionEnabled)
+
+        let disabled = Box().disabled()
+        XCTAssertFalse(try view(from: disabled).isUserInteractionEnabled)
+    }
+
+    func test_enabled() throws {
+        let enabled = Box().enabled()
+        XCTAssertTrue(try view(from: enabled).isUserInteractionEnabled)
+
+        let disabled =  Box().enabled(false)
+        XCTAssertFalse(try view(from: disabled).isUserInteractionEnabled)
+    }
+
+    // MARK: - helpers -
+    func view(from element: UserInteractionEnabled) throws -> UIView {
+        let description = try XCTUnwrap(element.backingViewDescription(bounds: .zero, subtreeExtent: nil))
+        let view = UIView()
+        view.isUserInteractionEnabled = !element.isEnabled
+        description.apply(to: view)
+        return view
     }
 }

--- a/BlueprintUICommonControls/Tests/Sources/UserInteractionEnabledTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/UserInteractionEnabledTests.swift
@@ -18,19 +18,11 @@ final class UserInteractionEnabledTests: XCTestCase {
         XCTAssertFalse(try view(from: disabled).isUserInteractionEnabled)
     }
 
-    func test_disabled() throws {
-        let enabled = Box().disabled(false)
+    func test_convenience() throws {
+        let enabled = Box().userInteractionEnabled()
         XCTAssertTrue(try view(from: enabled).isUserInteractionEnabled)
 
-        let disabled = Box().disabled()
-        XCTAssertFalse(try view(from: disabled).isUserInteractionEnabled)
-    }
-
-    func test_enabled() throws {
-        let enabled = Box().enabled()
-        XCTAssertTrue(try view(from: enabled).isUserInteractionEnabled)
-
-        let disabled =  Box().enabled(false)
+        let disabled = Box().userInteractionEnabled(false)
         XCTAssertFalse(try view(from: disabled).isUserInteractionEnabled)
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [Introduce `Decorate`](https://github.com/square/Blueprint/pull/178) to allow placing a decoration element in front or behind of an `Element`, without affecting its layout. This is useful for rendering tap or selection states which should overflow the natural bounds of the `Element`, similar to a shadow, or useful for adding a badge to an `Element`.
+
 - [Introduce `UserInteractionEnabled`](https://github.com/square/Blueprint/pull/203), an element which conditionally enables user interaction of wrapped elements.
 
 ```swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [Introduce `Decorate`](https://github.com/square/Blueprint/pull/178) to allow placing a decoration element in front or behind of an `Element`, without affecting its layout. This is useful for rendering tap or selection states which should overflow the natural bounds of the `Element`, similar to a shadow, or useful for adding a badge to an `Element`.
-
 - [Introduce `UserInteractionEnabled`](https://github.com/square/Blueprint/pull/203), an element which conditionally enables user interaction of wrapped elements.
 
 ```swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [Introduce `UserInteractionEnabled`](https://github.com/square/Blueprint/pull/203), an element which conditionally enables user interaction of wrapped elements.
+
+```swift
+searchField
+    .enabled(canBeginSearch)
+```
+
 ### Removed
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ```swift
 searchField
-    .enabled(canBeginSearch)
+    .userInteractionEnabled(canBeginSearch)
 ```
 
 ### Removed


### PR DESCRIPTION
### Summary

This PR introduces `UserInteractionEnabled`, an element for configuring whether or not a wrapped element is interactive.

@kyleve defined this component during a conversation, and mostly, this PR is a transcription of that description.

Usage:

```swift
searchField
    .userInteractionEnabled(canBeginSearch)
```

### Changes
- add `UserInteractionEnabled` and convenience method 
- test `UserInteractionEnabled` and its convenience method