### PR TITLE
Change backing view of `TransitionContainer` to passthrough touches

### DIFF
--- a/BlueprintUICommonControls/Sources/Internal/PassthroughView.swift
+++ b/BlueprintUICommonControls/Sources/Internal/PassthroughView.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+/// View which does not personally receive touches but allows its subviews to receive touches.
+final class PassthroughView: UIView {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let result = super.hitTest(point, with: event)
+        return result == self ? nil : result
+    }
+}

--- a/BlueprintUICommonControls/Sources/TransitionContainer.swift
+++ b/BlueprintUICommonControls/Sources/TransitionContainer.swift
@@ -59,7 +59,7 @@ public struct TransitionContainer: Element {
     }
 
     public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
-        return UIView.describe { config in
+        return PassthroughView.describe { config in
             config.appearingTransition = appearingTransition
             config.disappearingTransition = disappearingTransition
             config.layoutTransition = layoutTransition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ searchField
 
 ### Changed
 
+- [Change backing view of `TransitionContainer`](https://github.com/square/Blueprint/pull/205) to not directly receive touches while still allowing subviews to do so.
+
 ### Deprecated
 
 ### Security


### PR DESCRIPTION
This change modifies the backing view of the `TransitionContainer` to be
a new `PassthroughView` internal type which ignores touches that hit the
view itself but allow those touches to hit subviews for finer grained
control than `userInteractionEnabled`.