### PR TITLE
Measurement caching and performance improvements

### DIFF
--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -1,5 +1,4 @@
 import UIKit
-import os.log
 
 /// A view that is responsible for displaying an `Element` hierarchy.
 ///

--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -44,6 +44,8 @@ public final class BlueprintView: UIView {
             if oldValue == nil && self.element == nil {
                 return
             }
+
+            logElementAssigned()
             
             setNeedsViewHierarchyUpdate()
             invalidateIntrinsicContentSize()
@@ -125,7 +127,8 @@ public final class BlueprintView: UIView {
         
         return element.content.measure(
             in: measurementConstraint(with: size),
-            environment: self.makeEnvironment()
+            environment: self.makeEnvironment(),
+            cache: CacheFactory.makeCache(name: "sizeThatFits:\(type(of: element))")
         )
     }
 
@@ -151,7 +154,8 @@ public final class BlueprintView: UIView {
         
         return element.content.measure(
             in: constraint,
-            environment: self.makeEnvironment()
+            environment: self.makeEnvironment(),
+            cache: CacheFactory.makeCache(name: "intrinsicContentSize:\(type(of: element))")
         )
     }
 
@@ -473,6 +477,19 @@ extension BlueprintView {
                 log: .blueprint,
                 name: "View Update",
                 signpostID: OSSignpostID(log: .blueprint, object: self)
+            )
+        }
+    }
+
+    private func logElementAssigned() {
+        if #available(iOS 12.0, *) {
+            os_signpost(
+                .event,
+                log: .blueprint,
+                name: "Element assigned",
+                signpostID: OSSignpostID(log: .blueprint, object: self),
+                "Element assigned to %{public}s",
+                name ?? "BlueprintView"
             )
         }
     }

--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -52,7 +52,7 @@ public final class BlueprintView: UIView {
         }
     }
 
-    /// A name to help identify this view when profiling or debugging
+    /// An optional name to help identify this view
     public var name: String?
     
     /// Provides performance metrics about the duration of layouts, updates, etc.

--- a/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
+++ b/BlueprintUI/Sources/Blueprint View/BlueprintView.swift
@@ -45,7 +45,7 @@ public final class BlueprintView: UIView {
                 return
             }
 
-            logElementAssigned()
+            Logger.logElementAssigned(view: self)
             
             setNeedsViewHierarchyUpdate()
             invalidateIntrinsicContentSize()
@@ -205,7 +205,7 @@ public final class BlueprintView: UIView {
         lastViewHierarchyUpdateBounds = bounds
         
         let start = Date()
-        logLayoutStart()
+        Logger.logLayoutStart(view: self)
 
         /// Grab view descriptions
         let viewNodes = element?
@@ -213,7 +213,7 @@ public final class BlueprintView: UIView {
             .resolve() ?? []
         
         let measurementEndDate = Date()
-        logLayoutEnd()
+        Logger.logLayoutEnd(view: self)
 
         rootController.view.frame = bounds
         
@@ -226,11 +226,11 @@ public final class BlueprintView: UIView {
         let scale = window?.screen.scale ?? UIScreen.main.scale
         rootNode.round(from: .zero, correction: .zero, scale: scale)
 
-        logViewUpdateStart()
+        Logger.logViewUpdateStart(view: self)
 
         rootController.update(node: rootNode, appearanceTransitionsEnabled: hasUpdatedViewHierarchy)
 
-        logViewUpdateEnd()
+        Logger.logViewUpdateEnd(view: self)
         let viewUpdateEndDate = Date()
         
         hasUpdatedViewHierarchy = true
@@ -428,69 +428,6 @@ extension BlueprintView {
             }
             
             children = newChildren
-        }
-    }
-}
-
-extension BlueprintView {
-    private func logLayoutStart() {
-        if #available(iOS 12.0, *) {
-            os_signpost(
-                .begin,
-                log: .blueprint,
-                name: "Layout",
-                signpostID: OSSignpostID(log: .blueprint, object: self),
-                "%{public}s",
-                name ?? "BlueprintView"
-            )
-        }
-    }
-
-    private func logLayoutEnd() {
-        if #available(iOS 12.0, *) {
-            os_signpost(
-                .end,
-                log: .blueprint,
-                name: "Layout",
-                signpostID: OSSignpostID(log: .blueprint, object: self)
-            )
-        }
-    }
-
-    private func logViewUpdateStart() {
-        if #available(iOS 12.0, *) {
-            os_signpost(
-                .begin,
-                log: .blueprint,
-                name: "View Update",
-                signpostID: OSSignpostID(log: .blueprint, object: self),
-                "%{public}s",
-                name ?? "BlueprintView"
-            )
-        }
-    }
-
-    private func logViewUpdateEnd() {
-        if #available(iOS 12.0, *) {
-            os_signpost(
-                .end,
-                log: .blueprint,
-                name: "View Update",
-                signpostID: OSSignpostID(log: .blueprint, object: self)
-            )
-        }
-    }
-
-    private func logElementAssigned() {
-        if #available(iOS 12.0, *) {
-            os_signpost(
-                .event,
-                log: .blueprint,
-                name: "Element assigned",
-                signpostID: OSSignpostID(log: .blueprint, object: self),
-                "Element assigned to %{public}s",
-                name ?? "BlueprintView"
-            )
         }
     }
 }

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -1,5 +1,4 @@
 import UIKit
-import os.log
 
 /// Represents the content of an element.
 public struct ElementContent {
@@ -248,8 +247,12 @@ extension ElementContent {
             cache: CacheTree
         ) -> CGSize {
             return cache.get(constraint) { (constraint) -> CGSize in
-                logMeasureStart(object: cache.signpostRef, description: cache.name, constraint: constraint)
-                defer { logMeasureEnd(object: cache.signpostRef) }
+                Logger.logMeasureStart(
+                    object: cache.signpostRef,
+                    description: cache.name,
+                    constraint: constraint
+                )
+                defer { Logger.logMeasureEnd(object: cache.signpostRef) }
 
                 let layoutItems = self.layoutItems(in: environment, cache: cache)
                 return layout.measure(in: constraint, items: layoutItems)
@@ -496,34 +499,5 @@ struct Measurer: Measurable {
     var _measure: (SizeConstraint) -> CGSize
     func measure(in constraint: SizeConstraint) -> CGSize {
         return _measure(constraint)
-    }
-}
-
-extension ContentStorage {
-    func logMeasureStart(object: AnyObject, description: String, constraint: SizeConstraint) {
-        if #available(iOS 12.0, *) {
-            os_signpost(
-                .begin,
-                log: .blueprint,
-                name: "Measuring",
-                signpostID: OSSignpostID(log: .blueprint, object: object),
-                // nb: os_signpost seems to ignore precision specifiers
-                "%{public}s in %.1f×%.1f",
-                description,
-                constraint.width.constrainedValue ?? .infinity,
-                constraint.height.constrainedValue ?? .infinity
-            )
-        }
-    }
-
-    func logMeasureEnd(object: AnyObject) {
-        if #available(iOS 12.0, *) {
-            os_signpost(
-                .end,
-                log: .blueprint,
-                name: "Measuring",
-                signpostID: OSSignpostID(log: .blueprint, object: object)
-            )
-        }
     }
 }

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -276,6 +276,11 @@ extension ElementContent {
             for index in 0..<children.count {
                 let currentChildLayoutAttributes = childAttributes[index]
                 let currentChild = children[index]
+                let currentChildCache = cache.subcache(
+                    index: index,
+                    of: children.count,
+                    element: currentChild.element
+                )
 
                 let resultNode = LayoutResultNode(
                     element: currentChild.element,
@@ -283,7 +288,7 @@ extension ElementContent {
                     children: currentChild.content.performLayout(
                         attributes: currentChildLayoutAttributes,
                         environment: environment,
-                        cache: cache.subcache(index: index, element: currentChild.element)
+                        cache: currentChildCache
                     )
                 )
 
@@ -302,15 +307,13 @@ extension ElementContent {
             in environment: Environment,
             cache: CacheTree
         ) -> [(LayoutType.Traits, Measurable)] {
-
-            let isSingleton = children.count == 1
-
             return zip(children.indices, children).map { index, child in
+                let childContent = child.content
                 let childCache = cache.subcache(
-                    key: isSingleton ? .singleton : SubcacheKey(rawValue: index),
+                    index: index,
+                    of: children.count,
                     element: child.element
                 )
-                let childContent = child.content
                 let measurable = Measurer { (constraint) -> CGSize in
                     childContent.measure(
                         in: constraint,

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -1,4 +1,5 @@
 import UIKit
+import os.log
 
 /// Represents the content of an element.
 public struct ElementContent {
@@ -439,4 +440,29 @@ fileprivate struct MeasurableLayout: Layout {
         return []
     }
 
+}
+extension ContentStorage {
+    func logMeasureStart(object: AnyObject, description: String) {
+        if #available(iOS 12.0, *) {
+            os_signpost(
+                .begin,
+                log: .blueprint,
+                name: "Measuring",
+                signpostID: OSSignpostID(log: .blueprint, object: object),
+                "%{public}s",
+                description
+            )
+        }
+    }
+
+    func logMeasureEnd(object: AnyObject) {
+        if #available(iOS 12.0, *) {
+            os_signpost(
+                .end,
+                log: .blueprint,
+                name: "Measuring",
+                signpostID: OSSignpostID(log: .blueprint, object: object)
+            )
+        }
+    }
 }

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -310,7 +310,7 @@ extension ElementContent {
             in environment: Environment,
             cache: CacheTree
         ) -> [(LayoutType.Traits, Measurable)] {
-            return zip(children.indices, children).map { index, child in
+            return children.enumerated().map { index, child in
                 let childContent = child.content
                 let childCache = cache.subcache(
                     index: index,

--- a/BlueprintUI/Sources/Internal/CacheFactory.swift
+++ b/BlueprintUI/Sources/Internal/CacheFactory.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum CacheFactory {
+    static func makeCache(name: String, signpostRef: AnyObject = SignpostToken()) -> CacheTree {
+        // to disable caching, use this instead:
+        // FakeCache(name: name, signpostRef: signpostRef)
+
+        RenderPassCache(name: name, signpostRef: signpostRef)
+    }
+}
+
+private final class SignpostToken { }

--- a/BlueprintUI/Sources/Internal/CacheFactory.swift
+++ b/BlueprintUI/Sources/Internal/CacheFactory.swift
@@ -9,4 +9,5 @@ enum CacheFactory {
     }
 }
 
+/// A token reference type that can be used to group associated signpost logs using `OSSignpostID`.
 private final class SignpostToken { }

--- a/BlueprintUI/Sources/Internal/CacheTree.swift
+++ b/BlueprintUI/Sources/Internal/CacheTree.swift
@@ -17,12 +17,7 @@ protocol CacheTree: AnyObject {
     func subcache(key: SubcacheKey, name: @autoclosure () -> String) -> CacheTree
 }
 
-struct SubcacheKey: RawRepresentable, Hashable {
-    /// A key indicating that this will be the only subcache
-    static let singleton = SubcacheKey(rawValue: -1)
-
-    let rawValue: Int
-}
+typealias SubcacheKey = Int
 
 extension CacheTree {
     /// Convenience method to get a cached size, or compute and store one if it is not in the cache.
@@ -36,17 +31,17 @@ extension CacheTree {
     }
 
     /// Gets a subcache for an element with siblings.
-    func subcache(index: Int, element: Element) -> CacheTree {
-        subcache(key: SubcacheKey(rawValue: index), element: element)
+    func subcache(index: Int, of childCount: Int, element: Element) -> CacheTree {
+        return subcache(
+            key: index,
+            name: childCount == 1
+                ? "\(self.name).\(type(of: element))"
+                : "\(self.name)[\(index)].\(type(of: element))"
+        )
     }
 
-    /// Gets a subcache for an element.
-    func subcache(key: SubcacheKey = .singleton, element: Element) -> CacheTree {
-        subcache(
-            key: key,
-            name: key == .singleton
-                ? "\(self.name).\(type(of: element))"
-                : "\(self.name)[\(key.rawValue)].\(type(of: element))"
-        )
+    /// Gets a subcache for an element with no siblings.
+    func subcache(element: Element) -> CacheTree {
+        subcache(index: 0, of: 1, element: element)
     }
 }

--- a/BlueprintUI/Sources/Internal/CacheTree.swift
+++ b/BlueprintUI/Sources/Internal/CacheTree.swift
@@ -4,6 +4,8 @@ import os.log
 /// A size cache that also holds subcaches.
 protocol CacheTree: AnyObject {
 
+    typealias SubcacheKey = Int
+
     /// The name of this cache
     var name: String { get }
 
@@ -16,8 +18,6 @@ protocol CacheTree: AnyObject {
     /// Gets a subcache identified by the given key, or creates a new one.
     func subcache(key: SubcacheKey, name: @autoclosure () -> String) -> CacheTree
 }
-
-typealias SubcacheKey = Int
 
 extension CacheTree {
     /// Convenience method to get a cached size, or compute and store one if it is not in the cache.

--- a/BlueprintUI/Sources/Internal/CacheTree.swift
+++ b/BlueprintUI/Sources/Internal/CacheTree.swift
@@ -1,0 +1,52 @@
+import CoreGraphics
+import os.log
+
+/// A size cache that also holds subcaches.
+protocol CacheTree: AnyObject {
+
+    /// The name of this cache
+    var name: String { get }
+
+    /// A reference to use for logging
+    var signpostRef: AnyObject { get }
+
+    /// The sizes that are contained in this cache, keyed by size constraint.
+    subscript(constraint: SizeConstraint) -> CGSize? { get set }
+
+    /// Gets a subcache identified by the given key, or creates a new one.
+    func subcache(key: SubcacheKey, name: @autoclosure () -> String) -> CacheTree
+}
+
+struct SubcacheKey: RawRepresentable, Hashable {
+    /// A key indicating that this will be the only subcache
+    static let singleton = SubcacheKey(rawValue: -1)
+
+    let rawValue: Int
+}
+
+extension CacheTree {
+    /// Convenience method to get a cached size, or compute and store one if it is not in the cache.
+    func get(_ constraint: SizeConstraint, orStore calculation: (SizeConstraint) -> CGSize) -> CGSize {
+        if let size = self[constraint] {
+            return size
+        }
+        let size = calculation(constraint)
+        self[constraint] = size
+        return size
+    }
+
+    /// Gets a subcache for an element with siblings.
+    func subcache(index: Int, element: Element) -> CacheTree {
+        subcache(key: SubcacheKey(rawValue: index), element: element)
+    }
+
+    /// Gets a subcache for an element.
+    func subcache(key: SubcacheKey = .singleton, element: Element) -> CacheTree {
+        subcache(
+            key: key,
+            name: key == .singleton
+                ? "\(self.name).\(type(of: element))"
+                : "\(self.name)[\(key.rawValue)].\(type(of: element))"
+        )
+    }
+}

--- a/BlueprintUI/Sources/Internal/FakeCache.swift
+++ b/BlueprintUI/Sources/Internal/FakeCache.swift
@@ -1,0 +1,22 @@
+import CoreGraphics
+
+/// A fake cache that can be used to disable caching.
+final class FakeCache: CacheTree {
+
+    var name: String
+    var signpostRef: AnyObject
+
+    init(name: String, signpostRef: AnyObject) {
+        self.name = name
+        self.signpostRef = signpostRef
+    }
+
+    subscript(constraint: SizeConstraint) -> CGSize? {
+        get { nil }
+        set { }
+    }
+
+    func subcache(key: SubcacheKey, name: @autoclosure () -> String) -> CacheTree {
+        return FakeCache(name: name(), signpostRef: signpostRef)
+    }
+}

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -11,10 +11,10 @@ extension Element {
     /// - Returns: A layout result
     func layout(layoutAttributes: LayoutAttributes, environment: Environment) -> LayoutResultNode {
         return LayoutResultNode(
-            element: self,
+            root: self,
             layoutAttributes: layoutAttributes,
-            content: content,
-            environment: environment)
+            environment: environment
+        )
     }
 
 }
@@ -24,43 +24,34 @@ struct LayoutResultNode {
     
     /// The element that was laid out
     var element: Element
-    
-    /// Diagnostic information about the layout process.
-    var diagnosticInfo: DiagnosticInfo
-    
+
     /// The layout attributes for the element
     var layoutAttributes: LayoutAttributes
 
     /// The element's children.
     var children: [(identifier: ElementIdentifier, node: LayoutResultNode)]
-    
-    init(element: Element, layoutAttributes: LayoutAttributes, content: ElementContent, environment: Environment) {
 
+    init(element: Element, layoutAttributes: LayoutAttributes, children: [(identifier: ElementIdentifier, node: LayoutResultNode)]) {
         self.element = element
         self.layoutAttributes = layoutAttributes
+        self.children = children
+    }
 
-        let layoutBeginTime = DispatchTime.now()
-        children = content.performLayout(attributes: layoutAttributes, environment: environment)
-        let layoutEndTime = DispatchTime.now()
-        let layoutDuration = layoutEndTime.uptimeNanoseconds - layoutBeginTime.uptimeNanoseconds
-        diagnosticInfo = LayoutResultNode.DiagnosticInfo(layoutDuration: layoutDuration)
-
+    init(root: Element, layoutAttributes: LayoutAttributes, environment: Environment) {
+        let cache = CacheFactory.makeCache(name: "\(type(of: root))")
+        self.init(
+            element: root,
+            layoutAttributes: layoutAttributes,
+            children: root.content.performLayout(
+                attributes: layoutAttributes,
+                environment: environment,
+                cache: cache
+            )
+        )
     }
 
 }
 
-extension LayoutResultNode {
-    
-    struct DiagnosticInfo {
-        
-        var layoutDuration: UInt64
-        
-        init(layoutDuration: UInt64) {
-            self.layoutDuration = layoutDuration
-        }
-    }
-    
-}
 
 extension LayoutResultNode {
 

--- a/BlueprintUI/Sources/Internal/Logger.swift
+++ b/BlueprintUI/Sources/Internal/Logger.swift
@@ -1,0 +1,100 @@
+import Foundation
+import os.log
+
+/// Namespace for logging helpers
+enum Logger { }
+
+/// BlueprintView signposts
+extension Logger {
+    static func logLayoutStart(view: BlueprintView) {
+        if #available(iOS 12.0, *) {
+            os_signpost(
+                .begin,
+                log: .blueprint,
+                name: "Layout",
+                signpostID: OSSignpostID(log: .blueprint, object: view),
+                "%{public}s",
+                view.name ?? "BlueprintView"
+            )
+        }
+    }
+
+    static func logLayoutEnd(view: BlueprintView) {
+        if #available(iOS 12.0, *) {
+            os_signpost(
+                .end,
+                log: .blueprint,
+                name: "Layout",
+                signpostID: OSSignpostID(log: .blueprint, object: view)
+            )
+        }
+    }
+
+    static func logViewUpdateStart(view: BlueprintView) {
+        if #available(iOS 12.0, *) {
+            os_signpost(
+                .begin,
+                log: .blueprint,
+                name: "View Update",
+                signpostID: OSSignpostID(log: .blueprint, object: view),
+                "%{public}s",
+                view.name ?? "BlueprintView"
+            )
+        }
+    }
+
+    static func logViewUpdateEnd(view: BlueprintView) {
+        if #available(iOS 12.0, *) {
+            os_signpost(
+                .end,
+                log: .blueprint,
+                name: "View Update",
+                signpostID: OSSignpostID(log: .blueprint, object: view)
+            )
+        }
+    }
+
+    static func logElementAssigned(view: BlueprintView) {
+        if #available(iOS 12.0, *) {
+            os_signpost(
+                .event,
+                log: .blueprint,
+                name: "Element assigned",
+                signpostID: OSSignpostID(log: .blueprint, object: view),
+                "Element assigned to %{public}s",
+                view.name ?? "BlueprintView"
+            )
+        }
+    }
+}
+
+/// Measuring signposts
+extension Logger {
+    static func logMeasureStart(object: AnyObject, description: String, constraint: SizeConstraint) {
+        if #available(iOS 12.0, *) {
+            os_signpost(
+                .begin,
+                log: .blueprint,
+                name: "Measuring",
+                signpostID: OSSignpostID(log: .blueprint, object: object),
+                // nb: os_signpost seems to ignore precision specifiers
+                "%{public}s in %.1f×%.1f",
+                description,
+                constraint.width.constrainedValue ?? .infinity,
+                constraint.height.constrainedValue ?? .infinity
+            )
+        }
+    }
+
+    static func logMeasureEnd(object: AnyObject) {
+        if #available(iOS 12.0, *) {
+            os_signpost(
+                .end,
+                log: .blueprint,
+                name: "Measuring",
+                signpostID: OSSignpostID(log: .blueprint, object: object)
+            )
+        }
+    }
+}
+

--- a/BlueprintUI/Sources/Internal/Logger.swift
+++ b/BlueprintUI/Sources/Internal/Logger.swift
@@ -10,9 +10,9 @@ extension Logger {
         if #available(iOS 12.0, *) {
             os_signpost(
                 .begin,
-                log: .blueprint,
+                log: .active,
                 name: "Layout",
-                signpostID: OSSignpostID(log: .blueprint, object: view),
+                signpostID: OSSignpostID(log: .active, object: view),
                 "%{public}s",
                 view.name ?? "BlueprintView"
             )
@@ -23,9 +23,9 @@ extension Logger {
         if #available(iOS 12.0, *) {
             os_signpost(
                 .end,
-                log: .blueprint,
+                log: .active,
                 name: "Layout",
-                signpostID: OSSignpostID(log: .blueprint, object: view)
+                signpostID: OSSignpostID(log: .active, object: view)
             )
         }
     }
@@ -34,9 +34,9 @@ extension Logger {
         if #available(iOS 12.0, *) {
             os_signpost(
                 .begin,
-                log: .blueprint,
+                log: .active,
                 name: "View Update",
-                signpostID: OSSignpostID(log: .blueprint, object: view),
+                signpostID: OSSignpostID(log: .active, object: view),
                 "%{public}s",
                 view.name ?? "BlueprintView"
             )
@@ -47,9 +47,9 @@ extension Logger {
         if #available(iOS 12.0, *) {
             os_signpost(
                 .end,
-                log: .blueprint,
+                log: .active,
                 name: "View Update",
-                signpostID: OSSignpostID(log: .blueprint, object: view)
+                signpostID: OSSignpostID(log: .active, object: view)
             )
         }
     }
@@ -58,9 +58,9 @@ extension Logger {
         if #available(iOS 12.0, *) {
             os_signpost(
                 .event,
-                log: .blueprint,
+                log: .active,
                 name: "Element assigned",
-                signpostID: OSSignpostID(log: .blueprint, object: view),
+                signpostID: OSSignpostID(log: .active, object: view),
                 "Element assigned to %{public}s",
                 view.name ?? "BlueprintView"
             )
@@ -74,9 +74,9 @@ extension Logger {
         if #available(iOS 12.0, *) {
             os_signpost(
                 .begin,
-                log: .blueprint,
+                log: .active,
                 name: "Measuring",
-                signpostID: OSSignpostID(log: .blueprint, object: object),
+                signpostID: OSSignpostID(log: .active, object: object),
                 // nb: os_signpost seems to ignore precision specifiers
                 "%{public}s in %.1f×%.1f",
                 description,
@@ -90,11 +90,10 @@ extension Logger {
         if #available(iOS 12.0, *) {
             os_signpost(
                 .end,
-                log: .blueprint,
+                log: .active,
                 name: "Measuring",
-                signpostID: OSSignpostID(log: .blueprint, object: object)
+                signpostID: OSSignpostID(log: .active, object: object)
             )
         }
     }
 }
-

--- a/BlueprintUI/Sources/Internal/OSLog+Blueprint.swift
+++ b/BlueprintUI/Sources/Internal/OSLog+Blueprint.swift
@@ -1,0 +1,6 @@
+import Foundation
+import os.log
+
+extension OSLog {
+    static let blueprint = OSLog(subsystem: "com.squareup.Blueprint", category: "Blueprint")
+}

--- a/BlueprintUI/Sources/Internal/OSLog+Blueprint.swift
+++ b/BlueprintUI/Sources/Internal/OSLog+Blueprint.swift
@@ -2,5 +2,25 @@ import Foundation
 import os.log
 
 extension OSLog {
+    /// When logging is enabled, `active` is set to this log.
     static let blueprint = OSLog(subsystem: "com.squareup.Blueprint", category: "Blueprint")
+
+    /// The log to be used for `os_log` and `os_signpost` logging.
+    static var active: OSLog = OSLog.disabled
+}
+
+/// Namespace for logging config.
+public enum BlueprintLogging {
+    /// If enabled, Blueprint will emit signpost logs. You can view these logs in Instruments to
+    /// aid in debugging or performance tuning.
+    ///
+    /// Signpost logging is disabled by default.
+    public static var enabled: Bool {
+        get {
+            OSLog.active === OSLog.blueprint
+        }
+        set {
+            OSLog.active = newValue ? .blueprint : .disabled
+        }
+    }
 }

--- a/BlueprintUI/Sources/Internal/RenderPassCache.swift
+++ b/BlueprintUI/Sources/Internal/RenderPassCache.swift
@@ -1,0 +1,35 @@
+import CoreGraphics
+
+/// A cache implementation suitable for the lifetime of a single render pass or measurement.
+final class RenderPassCache: CacheTree {
+
+    let name: String
+    let signpostRef: AnyObject
+
+    private var subcaches: [SubcacheKey: RenderPassCache] = [:]
+    private var measurements: [SizeConstraint: CGSize] = [:]
+
+    init(name: String, signpostRef: AnyObject) {
+        self.name = name
+        self.signpostRef = signpostRef
+    }
+
+    subscript(constraint: SizeConstraint) -> CGSize? {
+        get {
+            measurements[constraint]
+        }
+        set {
+            measurements[constraint] = newValue
+        }
+    }
+
+    func subcache(key: SubcacheKey, name: @autoclosure () -> String) -> CacheTree {
+        if let subcache = subcaches[key] {
+            return subcache
+        }
+
+        let subcache = RenderPassCache(name: name(), signpostRef: signpostRef)
+        subcaches[key] = subcache
+        return subcache
+    }
+}

--- a/BlueprintUI/Sources/Layout/ConstrainedSize.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedSize.swift
@@ -157,6 +157,11 @@ extension ConstrainedSize {
         var height: Constraint
 
         func measure(in constraint: SizeConstraint, child: Measurable) -> CGSize {
+
+            // If both height & width are absolute, we can avoid measuring entirely.
+            if case let .absolute(width) = width, case let .absolute(height) = height {
+                return CGSize(width: width, height: height)
+            }
                         
             /// 1) Measure how big the element should be by constraining the passed in
             /// `SizeConstraint` to not be larger than our maximum size. This ensures

--- a/BlueprintUI/Tests/Element+Testing.swift
+++ b/BlueprintUI/Tests/Element+Testing.swift
@@ -22,4 +22,14 @@ extension ElementContent {
     func measure(in constraint: SizeConstraint) -> CGSize {
         return measure(in: constraint, environment: .empty)
     }
+
+    /// A convenience wrapper to perform layout during testing, using an default `Environment` and
+    /// a new cache.
+    func testLayout(attributes: LayoutAttributes) -> [(identifier: ElementIdentifier, node: LayoutResultNode)] {
+        self.performLayout(
+            attributes: attributes,
+            environment: .empty,
+            cache: CacheFactory.makeCache(name: "test")
+        )
+    }
 }

--- a/BlueprintUI/Tests/Element+Testing.swift
+++ b/BlueprintUI/Tests/Element+Testing.swift
@@ -23,7 +23,7 @@ extension ElementContent {
         return measure(in: constraint, environment: .empty)
     }
 
-    /// A convenience wrapper to perform layout during testing, using an default `Environment` and
+    /// A convenience wrapper to perform layout during testing, using a default `Environment` and
     /// a new cache.
     func testLayout(attributes: LayoutAttributes) -> [(identifier: ElementIdentifier, node: LayoutResultNode)] {
         self.performLayout(

--- a/BlueprintUI/Tests/ElementContentTests.swift
+++ b/BlueprintUI/Tests/ElementContentTests.swift
@@ -35,7 +35,7 @@ class ElementContentTests: XCTestCase {
         }
 
         let children = container
-            .performLayout(attributes: LayoutAttributes(frame: .zero), environment: .empty)
+            .testLayout(attributes: LayoutAttributes(frame: .zero))
             .map { $0.node }
 
         XCTAssertEqual(children.count, 1)
@@ -58,7 +58,7 @@ class ElementContentTests: XCTestCase {
         }
 
         let children = container
-            .performLayout(attributes: LayoutAttributes(frame: .zero), environment: .empty)
+            .testLayout(attributes: LayoutAttributes(frame: .zero))
             .map { $0.node }
 
         XCTAssertEqual(children.count, 2)

--- a/BlueprintUI/Tests/GeometryReaderTests.swift
+++ b/BlueprintUI/Tests/GeometryReaderTests.swift
@@ -51,6 +51,42 @@ final class GeometryReaderTests: XCTestCase {
         let frame = leafChildFrame(in: layoutResultNode)
         XCTAssertEqual(frame, CGRect(x: 50, y: 50, width: 50, height: 50))
     }
+
+    func test_nestedMeasuring() {
+
+        enum TestKey: EnvironmentKey {
+            static let defaultValue: CGFloat = 10
+        }
+
+        let layoutExpectation = expectation(description: "layout performed")
+
+        let element = GeometryReader { geometry in
+
+            let adaptiveElement = EnvironmentReader { environment in
+                Spacer(environment[TestKey.self])
+            }
+
+            XCTAssertEqual(
+                geometry.measure(element: adaptiveElement),
+                CGSize(width: 10, height: 10)
+            )
+
+            XCTAssertEqual(
+                geometry.measure(
+                    element: adaptiveElement.adaptedEnvironment(key: TestKey.self, value: 5)
+                ),
+                CGSize(width: 5, height: 5)
+            )
+
+            layoutExpectation.fulfill()
+
+            return Empty()
+        }
+
+        _ = element.layout(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
+
+        wait(for: [layoutExpectation], timeout: 5)
+    }
 }
 
 private extension SizeConstraint.Axis {

--- a/BlueprintUI/Tests/LayoutWriterTests.swift
+++ b/BlueprintUI/Tests/LayoutWriterTests.swift
@@ -84,7 +84,7 @@ class LayoutWriterTests : XCTestCase {
             layout.add(with: CGRect(x: 20, y: 10, width: 20, height: 100), child: TestElement())
         }
     
-        let layoutResult = writer.content.performLayout(attributes: LayoutAttributes(size: CGSize(width: 100, height: 100)), environment: .empty)
+        let layoutResult = writer.content.testLayout(attributes: LayoutAttributes(size: CGSize(width: 100, height: 100)))
         let innerElement = layoutResult[0]
         
         let nodes = innerElement.node.children.map(\.node)

--- a/BlueprintUI/Tests/RenderPassCacheTests.swift
+++ b/BlueprintUI/Tests/RenderPassCacheTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import BlueprintUI
+
+final class RenderPassCacheTests: XCTestCase {
+    func test_caching() {
+        let cache = RenderPassCache(name: "test", signpostRef: self)
+
+        XCTAssertEqual(cache.name, "test")
+        XCTAssert(cache.signpostRef === self)
+        XCTAssertNil(cache[SizeConstraint.unconstrained])
+
+        cache[SizeConstraint.unconstrained] = CGSize(width: 1, height: 1)
+        cache[SizeConstraint(CGSize(width: 2, height: 2))] = CGSize(width: 2, height: 2)
+        cache[SizeConstraint(height: 3)] = CGSize(width: 3, height: 3)
+        cache[SizeConstraint(width: 4)] = CGSize(width: 4, height: 4)
+
+        XCTAssertEqual(
+            cache[SizeConstraint.unconstrained],
+            CGSize(width: 1, height: 1)
+        )
+        XCTAssertEqual(
+            cache[SizeConstraint(CGSize(width: 2, height: 2))],
+            CGSize(width: 2, height: 2)
+        )
+        XCTAssertEqual(
+            cache[SizeConstraint(height: 3)],
+            CGSize(width: 3, height: 3)
+        )
+        XCTAssertEqual(
+            cache[SizeConstraint(width: 4)],
+            CGSize(width: 4, height: 4)
+        )
+        XCTAssertNil(cache[SizeConstraint(CGSize(width: 9, height: 9))])
+    }
+
+    func test_subcaches() {
+        let cache = RenderPassCache(name: "test", signpostRef: self)
+
+        let subcache1 = cache.subcache(key: 0, name: "1")
+        let subcache2 = cache.subcache(key: 1, name: "2")
+
+        XCTAssertEqual(subcache1.name, "1")
+        XCTAssert(subcache1.signpostRef === self)
+
+        XCTAssertEqual(subcache2.name, "2")
+        XCTAssert(subcache2.signpostRef === self)
+
+        let size1 = CGSize(width: 1, height: 1)
+        let size2 = CGSize(width: 2, height: 2)
+        let size3 = CGSize(width: 3, height: 3)
+        
+        cache[SizeConstraint(size1)] = size1
+        subcache1[SizeConstraint(size2)] = size2
+        subcache2[SizeConstraint(size3)] = size3
+
+        XCTAssertEqual(cache[SizeConstraint(size1)], size1)
+        XCTAssertNil(subcache1[SizeConstraint(size1)])
+        XCTAssertNil(subcache2[SizeConstraint(size1)])
+
+        XCTAssertEqual(subcache1[SizeConstraint(size2)], size2)
+        XCTAssertNil(cache[SizeConstraint(size2)])
+        XCTAssertNil(subcache2[SizeConstraint(size2)])
+
+        XCTAssertEqual(subcache2[SizeConstraint(size3)], size3)
+        XCTAssertNil(subcache1[SizeConstraint(size3)])
+        XCTAssertNil(cache[SizeConstraint(size3)])
+    }
+
+    /// Test the get(_: orStore:) convenience method
+    func test_getOrStore() {
+        let cache = RenderPassCache(name: "test", signpostRef: self)
+
+        let size1 = CGSize(width: 1, height: 1)
+
+        var measureCount = 0
+
+        var val = cache.get(SizeConstraint(size1)) { (constraint) -> CGSize in
+            XCTAssertEqual(constraint, SizeConstraint(size1))
+            measureCount += 1
+            return size1
+        }
+        XCTAssertEqual(val, size1)
+
+        val = cache.get(SizeConstraint(size1)) { (constraint) -> CGSize in
+            XCTAssertEqual(constraint, SizeConstraint(size1))
+            measureCount += 1
+            return size1
+        }
+        XCTAssertEqual(val, size1)
+
+        XCTAssertEqual(measureCount, 1)
+    }
+
+    /// Test the convenience methods for subcaches
+    func test_elementSubcaches() {
+        func unusedName() -> String {
+            XCTFail("Cache name should only be evaluated on creation")
+            return "unused"
+        }
+
+        do {
+            let cache = RenderPassCache(name: "test", signpostRef: self)
+
+            let singletonSubcache = cache.subcache(element: Empty())
+            XCTAssertEqual(singletonSubcache.name, "test.Empty")
+            XCTAssert(cache.subcache(key: 0, name: unusedName()) === singletonSubcache)
+        }
+
+        do {
+            let cache = RenderPassCache(name: "test", signpostRef: self)
+
+            let singletonSubcache = cache.subcache(index: 0, of: 1, element: Empty())
+            XCTAssertEqual(singletonSubcache.name, "test.Empty")
+            XCTAssert(cache.subcache(key: 0, name: unusedName()) === singletonSubcache)
+        }
+
+        do {
+            let cache = RenderPassCache(name: "test", signpostRef: self)
+
+            let subcache1 = cache.subcache(index: 0, of: 2, element: Empty())
+            let subcache2 = cache.subcache(index: 1, of: 2, element: Empty())
+
+            XCTAssertEqual(subcache1.name, "test[0].Empty")
+            XCTAssertEqual(subcache2.name, "test[1].Empty")
+
+            XCTAssert(cache.subcache(key: 0, name: unusedName()) === subcache1)
+            XCTAssert(cache.subcache(key: 1, name: unusedName()) === subcache2)
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   
   - [Added support to `LayoutWriter` to allow specifying keys for child `Element`s](https://github.com/square/Blueprint/pull/216).
 
+- Blueprint now emits [signpost logs](https://developer.apple.com/documentation/os/logging/recording_performance_data) during its render pass, which you use for performance tuning. ([#209])
+
 ### Removed
 
 ### Changed
+
+- The layout system now uses a caching system to improve performance by eliminating redundant measurements. ([#209])
 
 ### Deprecated
 
@@ -576,6 +580,7 @@ searchField
 [0.3.1]: https://github.com/square/Blueprint/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/square/Blueprint/compare/0.2.2...0.3.0
 [0.2.2]: https://github.com/square/Blueprint/releases/tag/0.2.2
+[#209]: https://github.com/square/Blueprint/pull/209
 [#176]: https://github.com/square/Blueprint/pull/176
 [#175]: https://github.com/square/Blueprint/pull/175
 [#158]: https://github.com/square/Blueprint/pull/158

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   
   - [Added support to `LayoutWriter` to allow specifying keys for child `Element`s](https://github.com/square/Blueprint/pull/216).
 
-- Blueprint now emits [signpost logs](https://developer.apple.com/documentation/os/logging/recording_performance_data) during its render pass, which you use for performance tuning. ([#209])
+- Blueprint can now emit [signpost logs](https://developer.apple.com/documentation/os/logging/recording_performance_data) during its render pass, which you can use for performance tuning. ([#209])
+  
+  Signpost logs are disabled by default. To enable them, set `BlueprintLogging.enabled = true`.
 
 ### Removed
 


### PR DESCRIPTION
This PR adds a couple of performance-related features. Happy to split this up into multiple PRs if folks prefer that.

# Signpost Logging

Signpost intervals are generated for:
1. Layout
2. View Updates
3. Individual element measurements

The first two are nice to get a high level view of rendering, and the third one provides a pretty nice visualization of the way elements are recursively measured.

<img width="1254" alt="Screen Shot 2021-04-01 at 6 45 40 PM" src="https://user-images.githubusercontent.com/100192/113371158-85e8ee80-931a-11eb-849c-ed84d9d2c775.png">

This fixes #173.

# Layout pass measurement caching

This is a new caching mechanism that caches every measured size during a layout pass. The cache structure mirrors the element tree itself, so it is able to cache measurements for every element, without any requirements on the element itself.

This cache's lifetime is only a single layout pass. Because of the way Blueprint repeatedly measures each subtree as it lays out each element, this prevents a lot of duplicate work from re-measuring, especially in deep trees. It does not cache the layout results returned by `performLayout`, because that is only called once per element per layout pass.

The cache is also used during measurement outside of layout (such as from `sizeThatFits` or a direct call to `element.content.measure()`), but it's less useful in that scenario since most elements do not re-measure children.

# Shortcuts

1. When laying out stacks, if the alignment is `fill` and the constraint is `exact`, we can skip the entire second measurement for cross axis sizes.
2. We can skip measurement in `ConstrainedSize` if both axes are `absolute` constraints.

# Potential follow-up work

1. We can't persist this new cache if the element changes, but we might be able to persist it between layout passes on the same element. If we make that change, we should persist the values returned by `performLayout` too.
2. We should consider merging the previous `MeasurementCache` functionality into this one, or removing it.
3. Additional logging during view updates, to visualize view churn.

# Todo

- [x] Tests
- [x] Update changelog
- [x] Move signpost logging into a helper
- [x] doc SignpostToken