### PR TITLE
[GridRow] Tidy up docs and remove unnecessary sizing check

### DIFF
--- a/BlueprintUI/Sources/Layout/GridRow.swift
+++ b/BlueprintUI/Sources/Layout/GridRow.swift
@@ -275,16 +275,19 @@ extension GridRow {
             items: [IndexedProportionalItem]
         ) -> [IndexedSize] {
             var scale: CGFloat = 0
+            var measuredSizes: [CGSize] = []
+
             items.forEach { (_, proportion, content) in
-                let width = content.measure(in: constraint).width
-                scale = max(scale, width / proportion)
+                let size = content.measure(in: constraint)
+                measuredSizes.append(size)
+                scale = max(scale, size.width / proportion)
             }
 
-            return items.map { (index, proportion, content) in
-                let width = scale * proportion
-                let fixedWidthConstraint = SizeConstraint(width: .atMost(width), height: constraint.height)
-                let size = CGSize(width: width, height: content.measure(in: fixedWidthConstraint).height)
-                return (index, size)
+            return zip(items, measuredSizes).map { (item, measuredSize) in
+                let width = scale * item.proportion
+                // As this width is at least as wide as the one measured above,
+                // the height requirement should not change.
+                return (item.index, CGSize(width: width, height: measuredSize.height))
             }
         }
 

--- a/BlueprintUI/Tests/GridRowTests.swift
+++ b/BlueprintUI/Tests/GridRowTests.swift
@@ -238,7 +238,7 @@ class GridRowTests: XCTestCase {
         }
 
         do {
-            // #3: Absolutely-sized children can overlflow. In these cases, proportionally-sized children are sized
+            // #3: Absolutely-sized children can overflow. In these cases, proportionally-sized children are sized
             // to a width of 0.
             let gridRow = GridRow { row in
                 row.add(width: .absolute(50), child: TestElement())


### PR DESCRIPTION
### Summary

This PR removes an unnecessary measurement discussed in [this thread](https://github.com/square/Blueprint/pull/208#discussion_r608303335) and cleans up a documentation typo.

Note that tests against the behavior of unconstrained measurement continue to pass without updates.