### PR TITLE
Coordinate space emitter

### DIFF
--- a/BlueprintUICommonControls/Sources/CoordinateSpaceEmitter.swift
+++ b/BlueprintUICommonControls/Sources/CoordinateSpaceEmitter.swift
@@ -1,0 +1,69 @@
+//
+//  CoordinateSpaceEmitter.swift
+//  BlueprintUICommonControls
+//
+//  Created by Andrew Watt on 2/4/21.
+//
+
+import UIKit
+import BlueprintUI
+
+public struct CoordinateSpaceEmitter: Element {
+    public typealias CoordinateSpaceEmitted = (UICoordinateSpace) -> Void
+
+    public var wrapped: Element
+    public var onCoordinateSpaceEmitted: CoordinateSpaceEmitted
+
+    public init(onCoordinateSpaceEmitted: @escaping CoordinateSpaceEmitted, wrapping wrapped: Element) {
+        self.onCoordinateSpaceEmitted = onCoordinateSpaceEmitted
+        self.wrapped = wrapped
+    }
+
+    public var content: ElementContent {
+        ElementContent(child: wrapped)
+    }
+
+    public func backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription? {
+        View.describe { config in
+            config[\.onCoordinateSpaceEmitted] = onCoordinateSpaceEmitted
+        }
+    }
+}
+
+extension Element {
+    public func emitCoordinateSpace(_ onCoordinateSpaceEmitted: @escaping CoordinateSpaceEmitter.CoordinateSpaceEmitted) -> CoordinateSpaceEmitter {
+        CoordinateSpaceEmitter(onCoordinateSpaceEmitted: onCoordinateSpaceEmitted, wrapping: self)
+    }
+}
+
+extension CoordinateSpaceEmitter {
+    class View: UIView {
+
+        var onCoordinateSpaceEmitted: CoordinateSpaceEmitted?
+
+        private var displayLink: CADisplayLink?
+        private var previousGlobalFrame: CGRect?
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+
+            displayLink = CADisplayLink(target: self, selector: #selector(emitCoordinateSpaceIfNeeded))
+            displayLink?.add(to: .main, forMode: .common)
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        @objc private func emitCoordinateSpaceIfNeeded() {
+            guard let window = self.window else { return }
+
+            let globalFrame = convert(bounds, to: window)
+
+            if globalFrame != previousGlobalFrame {
+                previousGlobalFrame = globalFrame
+                onCoordinateSpaceEmitted?(self)
+            }
+        }
+    }
+}

--- a/SampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		979F49EE224D1BD300A3C5D4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97545514223C12E9003E353F /* LaunchScreen.storyboard */; };
 		979F49F4224D1BF200A3C5D4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 979F49E4224D1B6C00A3C5D4 /* AppDelegate.swift */; };
 		A7611DAC06D59DA383B1870E /* libPods-Tutorial 1 (Completed).a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B42C382728D022D1B556802 /* libPods-Tutorial 1 (Completed).a */; };
+		C2D401B526373F8500C6C739 /* BlueprintScrollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D401B426373F8500C6C739 /* BlueprintScrollViewController.swift */; };
 		D72C504447FA36584122770B /* libPods-Tutorial 2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FCF8B77DD126D724029EB47 /* libPods-Tutorial 2.a */; };
 /* End PBXBuildFile section */
 
@@ -88,6 +89,7 @@
 		979F49F2224D1BD300A3C5D4 /* Tutorial 1.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Tutorial 1.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D59D92E955A10C9F7EF0730 /* Pods-Tutorial 2 (Completed).release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tutorial 2 (Completed).release.xcconfig"; path = "Target Support Files/Pods-Tutorial 2 (Completed)/Pods-Tutorial 2 (Completed).release.xcconfig"; sourceTree = "<group>"; };
 		ADDB22E4D9B4379A15C5AF69 /* libPods-SampleApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SampleApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C2D401B426373F8500C6C739 /* BlueprintScrollViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlueprintScrollViewController.swift; sourceTree = "<group>"; };
 		CC5FC85BE57034BE39916388 /* Pods-Tutorial 1 (Completed).debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tutorial 1 (Completed).debug.xcconfig"; path = "Target Support Files/Pods-Tutorial 1 (Completed)/Pods-Tutorial 1 (Completed).debug.xcconfig"; sourceTree = "<group>"; };
 		F211AAFE0FF4DC614FC65630 /* Pods-Tutorial 1 (Completed).release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tutorial 1 (Completed).release.xcconfig"; path = "Target Support Files/Pods-Tutorial 1 (Completed)/Pods-Tutorial 1 (Completed).release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -179,6 +181,7 @@
 			isa = PBXGroup;
 			children = (
 				0A50E8DA24A685DA0049705B /* RootViewController.swift */,
+				C2D401B426373F8500C6C739 /* BlueprintScrollViewController.swift */,
 				97545510223C12E9003E353F /* PostsViewController.swift */,
 				7A4B688324DB3BE300E10D7A /* ResponsiveViewController.swift */,
 				0AEA09B22428360500F9ED0C /* ScrollViewKeyboardViewController.swift */,
@@ -583,6 +586,7 @@
 				0A50E8DB24A685DA0049705B /* RootViewController.swift in Sources */,
 				9754551A223C12E9003E353F /* AppDelegate.swift in Sources */,
 				97545519223C12E9003E353F /* PostsViewController.swift in Sources */,
+				C2D401B526373F8500C6C739 /* BlueprintScrollViewController.swift in Sources */,
 				0AEA09B32428360500F9ED0C /* ScrollViewKeyboardViewController.swift in Sources */,
 				7A4B688424DB3BE300E10D7A /* ResponsiveViewController.swift in Sources */,
 				0AEF0C4E24463B880092248C /* XcodePreviewDemo.swift in Sources */,

--- a/SampleApp/Sources/AppDelegate.swift
+++ b/SampleApp/Sources/AppDelegate.swift
@@ -9,7 +9,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         window = UIWindow(frame: UIScreen.main.bounds)
         
-        window?.rootViewController = UINavigationController(rootViewController: RootViewController())
+        window?.rootViewController = UINavigationController(rootViewController: BlueprintScrollViewController())
         
         window?.makeKeyAndVisible()
 

--- a/SampleApp/Sources/BlueprintScrollViewController.swift
+++ b/SampleApp/Sources/BlueprintScrollViewController.swift
@@ -1,0 +1,52 @@
+//
+//  BlueprintScrollViewController.swift
+//  SampleApp
+//
+//  Created by Kyle Bashour on 4/26/21.
+//  Copyright © 2021 Square. All rights reserved.
+//
+
+import UIKit
+import BlueprintUI
+import BlueprintUICommonControls
+
+class BlueprintScrollViewController: UIViewController {
+
+    let bp = BlueprintView()
+
+    private var labelCoordinate: UICoordinateSpace?
+
+    override func loadView() {
+        view = bp
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        render()
+    }
+
+    func render() {
+        bp.element = Overlay(elements: [
+            Label(text: "Hello world!")
+                .emitCoordinateSpace {
+                    self.labelCoordinate = $0
+                    self.render()
+                }
+                .aligned(vertically: .center, horizontally: .leading)
+                .inset(uniform: 20)
+                .scrollable {
+                    $0.alwaysBounceVertical = true
+                },
+
+            LayoutWriter { context, builder in
+                if let anchor = self.labelCoordinate {
+                    let labelFrame = anchor.convert(anchor.bounds, to: self.bp)
+                    let badgeFrame = CGRect(x: labelFrame.maxX + 10, y: labelFrame.minY - 10, width: 10, height: 10)
+
+                    builder.add(.init(frame: badgeFrame, element: Box(backgroundColor: .purple)))
+                }
+            }
+        ])
+    }
+}
+


### PR DESCRIPTION
This element emits the coordinate space of its view, using a `CADisplayLink` to track changes the views position relative to its window and re-emitting the coordinate space if the position changes. You can see this in action in the example, which uses a layout write to position a badge relative to a label - the badge follows the label around as it moves when you scroll.

This is just a draft as I'm still exploring other options for this feature. 

![Kapture 2021-04-27 at 11 57 53](https://user-images.githubusercontent.com/3526783/116297333-03ecb980-a750-11eb-819a-17f47b0b8c73.gif)

