### PR TITLE
Improve ConstrainedAspectRatio content modes

### DIFF
--- a/BlueprintUI/Sources/Layout/AspectRatio.swift
+++ b/BlueprintUI/Sources/Layout/AspectRatio.swift
@@ -30,4 +30,12 @@ public struct AspectRatio {
     func width(forHeight height: CGFloat) -> CGFloat {
         return height * ratio
     }
+
+    func size(forHeight height: CGFloat) -> CGSize {
+        return CGSize(width: width(forHeight: height), height: height)
+    }
+
+    func size(forWidth width: CGFloat) -> CGSize {
+        return CGSize(width: width, height: height(forWidth: width))
+    }
 }

--- a/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
@@ -2,19 +2,18 @@ import UIKit
 
 /// Constrains the size of the content element to an aspect ratio.
 public struct ConstrainedAspectRatio: Element {
-    /// Represents whether the content element's size should be expanded to fill its parent
-    /// or shrunk to fit it.
+    /// Represents how the content should size itself relative to its parent.
     public enum ContentMode: Equatable {
-        /// The content will be sized to fill its parents largest dimension, while maintaining the
-        /// specified aspect ratio.
+        /// The content will be sized to fill its parent while maintaining the specified aspect
+        /// ratio.
         ///
         /// If the parent is unconstrained in all dimensions, the content size will be used for
         /// measurement and will behave like `fitContent`. If the parent is unconstrained in one
         /// dimension, the element will fill the constrained dimension.
         case fillParent
 
-        /// The content will be sized to fit its parents smallest dimension, while maintaining the
-        /// specified aspect ratio.
+        /// The content will be sized to fit within its parent while maintaining the specified
+        /// aspect ratio.
         ///
         /// If the parent is unconstrained in all dimensions, the content size will be used for
         /// measurement and will behave like `fitContent`. If the parent is unconstrained in one
@@ -168,8 +167,7 @@ public extension Element {
     ///
     /// - parameters:
     ///   - aspectRatio: The aspect ratio that the content size should match.
-    ///   - contentMode: Whether the aspect ratio should be reached by expanding the content
-    ///     element's size to fill its parent or shrinking it to fit.
+    ///   - contentMode: How the content should size itself relative to its parent.
     ///
     func constrainedTo(
         aspectRatio: AspectRatio,

--- a/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
+++ b/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
@@ -5,7 +5,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
     func test_expandWide() {
         let element = ConstrainedAspectRatio(
             aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fill,
+            contentMode: .fitContent,
             wrapping: TestElement())
 
         let size = element.content.measure(in: .unconstrained)
@@ -15,7 +15,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
     func test_expandTall() {
         let element = ConstrainedAspectRatio(
             aspectRatio: AspectRatio(width: 1, height: 2),
-            contentMode: .fill,
+            contentMode: .fitContent,
             wrapping: TestElement())
 
         let size = element.content.measure(in: .unconstrained)
@@ -25,7 +25,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
     func test_expandSquare() {
         let element = ConstrainedAspectRatio(
             aspectRatio: .square,
-            contentMode: .fill,
+            contentMode: .fitContent,
             wrapping: TestElement())
 
         let size = element.content.measure(in: .unconstrained)
@@ -35,7 +35,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
     func test_shrinkWide() {
         let element = ConstrainedAspectRatio(
             aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fit,
+            contentMode: .shrinkContent,
             wrapping: TestElement())
 
         let size = element.content.measure(in: .unconstrained)
@@ -45,7 +45,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
     func test_shrinkTall() {
         let element = ConstrainedAspectRatio(
             aspectRatio: AspectRatio(width: 1, height: 2),
-            contentMode: .fit,
+            contentMode: .shrinkContent,
             wrapping: TestElement())
 
         let size = element.content.measure(in: .unconstrained)
@@ -55,11 +55,177 @@ class ConstrainedAspectRatioTests: XCTestCase {
     func test_shrinkSquare() {
         let element = ConstrainedAspectRatio(
             aspectRatio: .square,
-            contentMode: .fit,
+            contentMode: .shrinkContent,
             wrapping: TestElement())
 
         let size = element.content.measure(in: .unconstrained)
         XCTAssertEqual(size, CGSize(width: 100, height: 100))
+    }
+
+    func test_expandWideFillParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 2, height: 1),
+            contentMode: .fillParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(
+            in: SizeConstraint(CGSize(width: 300, height: 400)))
+        XCTAssertEqual(size, CGSize(width: 800, height: 400))
+    }
+
+    func test_expandWideFitParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 2, height: 1),
+            contentMode: .fitParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(
+            in: SizeConstraint(CGSize(width: 300, height: 400)))
+        XCTAssertEqual(size, CGSize(width: 200, height: 400))
+    }
+
+    func test_expandTallFillParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 1, height: 2),
+            contentMode: .fillParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(
+            in: SizeConstraint(CGSize(width: 300, height: 400)))
+        XCTAssertEqual(size, CGSize(width: 400, height: 800))
+    }
+
+    func test_expandTallFitParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 1, height: 2),
+            contentMode: .fitParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(
+            in: SizeConstraint(CGSize(width: 300, height: 400)))
+        XCTAssertEqual(size, CGSize(width: 200, height: 400))
+    }
+
+    func test_expandSquareFillParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: .square,
+            contentMode: .fillParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(
+            in: SizeConstraint(CGSize(width: 300, height: 400)))
+        XCTAssertEqual(size, CGSize(width: 400, height: 400))
+    }
+
+    func test_expandSquareFitParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: .square,
+            contentMode: .fitParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(
+            in: SizeConstraint(CGSize(width: 300, height: 400)))
+        XCTAssertEqual(size, CGSize(width: 300, height: 300))
+    }
+
+    func test_unconstrainedFillParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 2, height: 1),
+            contentMode: .fillParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: .unconstrained)
+        XCTAssertEqual(size, CGSize(width: 200, height: 100))
+    }
+
+    func test_unconstrainedFitParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 2, height: 1),
+            contentMode: .fitParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: .unconstrained)
+        XCTAssertEqual(size, CGSize(width: 120, height: 60))
+    }
+
+    func test_unconstrainedHeightFillLargerParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 2, height: 1),
+            contentMode: .fillParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: SizeConstraint(width: 300))
+        XCTAssertEqual(size, CGSize(width: 300, height: 150))
+    }
+
+    func test_unconstrainedHeightFillSmallerParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 2, height: 1),
+            contentMode: .fillParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: SizeConstraint(width: 50))
+        XCTAssertEqual(size, CGSize(width: 200, height: 100))
+    }
+
+    func test_unconstrainedHeightFitLargerParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 2, height: 1),
+            contentMode: .fitParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: SizeConstraint(width: 300))
+        XCTAssertEqual(size, CGSize(width: 300, height: 150))
+    }
+
+    func test_unconstrainedHeightFitSmallerParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 2, height: 1),
+            contentMode: .fitParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: SizeConstraint(width: 50))
+        XCTAssertEqual(size, CGSize(width: 50, height: 25))
+    }
+
+    func test_unconstrainedWidthFillLargerParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 2, height: 1),
+            contentMode: .fillParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: SizeConstraint(height: 300))
+        XCTAssertEqual(size, CGSize(width: 600, height: 300))
+    }
+
+    func test_unconstrainedWidthFillSmallerParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 2, height: 1),
+            contentMode: .fillParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: SizeConstraint(height: 50))
+        XCTAssertEqual(size, CGSize(width: 200, height: 100))
+    }
+
+    func test_unconstrainedWidthFitLargerParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 2, height: 1),
+            contentMode: .fitParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: SizeConstraint(height: 300))
+        XCTAssertEqual(size, CGSize(width: 600, height: 300))
+    }
+
+    func test_unconstrainedWidthFitSmallerParent() {
+        let element = ConstrainedAspectRatio(
+            aspectRatio: AspectRatio(width: 2, height: 1),
+            contentMode: .fitParent,
+            wrapping: TestElement())
+
+        let size = element.content.measure(in: SizeConstraint(height: 50))
+        XCTAssertEqual(size, CGSize(width: 100, height: 50))
     }
 }
 

--- a/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
+++ b/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
@@ -81,7 +81,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
 
         let size = element.content.measure(
             in: SizeConstraint(CGSize(width: 300, height: 400)))
-        XCTAssertEqual(size, CGSize(width: 200, height: 400))
+        XCTAssertEqual(size, CGSize(width: 300, height: 150))
     }
 
     func test_expandTallFillParent() {
@@ -92,7 +92,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
 
         let size = element.content.measure(
             in: SizeConstraint(CGSize(width: 300, height: 400)))
-        XCTAssertEqual(size, CGSize(width: 400, height: 800))
+        XCTAssertEqual(size, CGSize(width: 300, height: 600))
     }
 
     func test_expandTallFitParent() {
@@ -145,7 +145,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
             wrapping: TestElement())
 
         let size = element.content.measure(in: .unconstrained)
-        XCTAssertEqual(size, CGSize(width: 120, height: 60))
+        XCTAssertEqual(size, CGSize(width: 200, height: 100))
     }
 
     func test_unconstrainedHeightFillLargerParent() {
@@ -165,7 +165,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
             wrapping: TestElement())
 
         let size = element.content.measure(in: SizeConstraint(width: 50))
-        XCTAssertEqual(size, CGSize(width: 200, height: 100))
+        XCTAssertEqual(size, CGSize(width: 50, height: 25))
     }
 
     func test_unconstrainedHeightFitLargerParent() {
@@ -205,7 +205,7 @@ class ConstrainedAspectRatioTests: XCTestCase {
             wrapping: TestElement())
 
         let size = element.content.measure(in: SizeConstraint(height: 50))
-        XCTAssertEqual(size, CGSize(width: 200, height: 100))
+        XCTAssertEqual(size, CGSize(width: 100, height: 50))
     }
 
     func test_unconstrainedWidthFitLargerParent() {


### PR DESCRIPTION
This PR improves the content modes of `ConstrainedAspectRatio` by renaming `fill` and `fit` to `fitContent` and `shrinkContent` respectively (which more accurately describe their behavior) and adding a `fillParent` and `fitParent` content mode, which are a common use case. The default content mode is `fitContent` ( e.g., the same behavior as it was before).