### PR TITLE
Bump version to 0.27.0

### DIFF
--- a/BlueprintUI.podspec
+++ b/BlueprintUI.podspec
@@ -1,6 +1,8 @@
+require_relative 'version'
+
 Pod::Spec.new do |s|
   s.name         = 'BlueprintUI'
-  s.version      = '0.26.0'
+  s.version      = BLUEPRINT_VERSION
   s.summary      = 'Swift library for declarative UI construction'
   s.homepage     = 'https://www.github.com/square/blueprint'
   s.license      = 'Apache License, Version 2.0'

--- a/BlueprintUICommonControls.podspec
+++ b/BlueprintUICommonControls.podspec
@@ -1,6 +1,8 @@
+require_relative 'version'
+
 Pod::Spec.new do |s|
   s.name         = 'BlueprintUICommonControls'
-  s.version      = '0.26.0'
+  s.version      = BLUEPRINT_VERSION
   s.summary      = 'UIKit-backed elements for Blueprint'
   s.homepage     = 'https://www.github.com/square/blueprint'
   s.license      = 'Apache License, Version 2.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The signature of `Element.backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription?` has changed to `backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription?` (https://github.com/square/Blueprint/pull/231). This is a large breaking change, but is worth it as it allows us to pass additional context to `backingViewDescription` in the future in a non-breaking way. The `ViewDescriptionContext` contains the `bounds` and `subtreeExtent`, as well as the `Environment` the element is rendered in.
-
 ### Deprecated
 
 ### Security
@@ -26,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Misc
 
 # Past Releases
+
+## [0.27.0] - 2021-06-22
+
+### Changed
+
+- The signature of `Element.backingViewDescription(bounds: CGRect, subtreeExtent: CGRect?) -> ViewDescription?` has changed to `backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription?` (https://github.com/square/Blueprint/pull/231). This is a large breaking change, but is worth it as it allows us to pass additional context to `backingViewDescription` in the future in a non-breaking way. The `ViewDescriptionContext` contains the `bounds` and `subtreeExtent`, as well as the `Environment` the element is rendered in.
 
 ## [0.26.0] - 2021-06-02
 
@@ -571,7 +575,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/0.26.0...HEAD
+[main]: https://github.com/square/Blueprint/compare/0.27.0...HEAD
+[0.27.0]: https://github.com/square/Blueprint/compare/0.26.0...0.27.0
 [0.26.0]: https://github.com/square/Blueprint/compare/0.25.0...0.26.0
 [0.25.0]: https://github.com/square/Blueprint/compare/0.24.0...0.25.0
 [0.24.0]: https://github.com/square/Blueprint/compare/0.23.0...0.24.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@
 
 1. Create a branch off `main` to update the version numbers and `Podfile.lock`. An example name would be `your-username/release-0.1.0`.
 
-1. Update the library version in both `BlueprintUI.podspec` and `BlueprintUICommonControls.podspec` if it has not already been updated (it should match the version number that you are about to release).
+1. Update the library version in `version.rb` if it has not already been updated (it should match the version number that you are about to release).
 
 1. Update `CHANGELOG.md` (in the root of the repo), moving current changes under `Main` to a new section under `Past Releases` for the version you are releasing.
   

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - BlueprintUI (0.26.0)
-  - BlueprintUI/Tests (0.26.0)
-  - BlueprintUICommonControls (0.26.0):
+  - BlueprintUI (0.27.0)
+  - BlueprintUI/Tests (0.27.0)
+  - BlueprintUICommonControls (0.27.0):
     - BlueprintUI
 
 DEPENDENCIES:
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 8d08c67d3e599dca9317cd3c0bc9db37e22802c9
-  BlueprintUICommonControls: b168bdfe608048f13067623dfb71954542557cfc
+  BlueprintUI: 0fe7dfb34d43c8ff1b6b69ca1bce853fa1eda084
+  BlueprintUICommonControls: e228bcd0a6918d52465d300a0dbce0bceaab4674
 
 PODFILE CHECKSUM: a01a59366bcd21b6f7030cb454d88867c7b2cf25
 

--- a/version.rb
+++ b/version.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+BLUEPRINT_VERSION ||= '0.27.0'


### PR DESCRIPTION
Release `0.27.0` and use our trick from Market for keeping both podfiles in sync, since I was sick of updating them both