### PR TITLE
Automatically propagate inherited environment to child blueprint views

### DIFF
--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -95,8 +95,11 @@ extension LayoutResultNode {
         if let viewDescription = viewDescription {
             let node = NativeViewNode(
                 content: viewDescription,
+                environment: environment,
                 layoutAttributes: layoutAttributes,
-                children: resolvedChildContent)
+                children: resolvedChildContent
+            )
+            
             return [(path: .empty, node: node)]
         } else {
             return resolvedChildContent.map { (path, node) -> (path: ElementPath, node: NativeViewNode) in

--- a/BlueprintUI/Sources/Internal/NativeViewNode.swift
+++ b/BlueprintUI/Sources/Internal/NativeViewNode.swift
@@ -23,6 +23,9 @@ struct NativeViewNode {
     /// The view description returned by this node
     var viewDescription: ViewDescription
     
+    /// The environment at this node in the tree.
+    var environment : Environment
+    
     /// The layout attributes for this content (relative to the parent's layout
     /// attributes).
     var layoutAttributes: LayoutAttributes
@@ -32,10 +35,12 @@ struct NativeViewNode {
     
     init(
         content: ViewDescription,
+        environment : Environment,
         layoutAttributes: LayoutAttributes,
         children: [(path: ElementPath, node: NativeViewNode)]) {
         
         self.viewDescription = content
+        self.environment = environment
         self.layoutAttributes = layoutAttributes
         self.children = children
     }

--- a/BlueprintUI/Tests/PixelBoundaryTests.swift
+++ b/BlueprintUI/Tests/PixelBoundaryTests.swift
@@ -10,6 +10,7 @@ class PixelBoundaryTests: XCTestCase {
 
         var rootNode = NativeViewNode(
             content: UIView.describe { _ in },
+            environment: .empty,
             layoutAttributes: LayoutAttributes(frame: frame),
             children: layoutResultNode.resolve())
 
@@ -36,6 +37,7 @@ class PixelBoundaryTests: XCTestCase {
 
         var rootNode = NativeViewNode(
             content: UIView.describe { _ in },
+            environment: .empty,
             layoutAttributes: LayoutAttributes(frame: frame),
             children: layoutResultNode.resolve())
 
@@ -62,6 +64,7 @@ class PixelBoundaryTests: XCTestCase {
 
         var rootNode = NativeViewNode(
             content: UIView.describe { _ in },
+            environment: .empty,
             layoutAttributes: LayoutAttributes(frame: frame),
             children: layoutResultNode.resolve())
 
@@ -88,6 +91,7 @@ class PixelBoundaryTests: XCTestCase {
 
         var rootNode = NativeViewNode(
             content: UIView.describe { _ in },
+            environment: .empty,
             layoutAttributes: LayoutAttributes(frame: frame),
             children: layoutResultNode.resolve())
 
@@ -114,6 +118,7 @@ class PixelBoundaryTests: XCTestCase {
 
         var rootNode = NativeViewNode(
             content: UIView.describe { _ in },
+            environment: .empty,
             layoutAttributes: LayoutAttributes(frame: frame),
             children: layoutResultNode.resolve())
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [The `Environment` is now automatically propagated through to nested `BlueprintViews` within a displayed `Element` hierarchy](https://github.com/square/Blueprint/pull/234). This means that if your view-backed `Elements` themselves contain a `BlueprintView` (eg to manage their own state), that nested view will now automatically receive the correct `Environment` across `BlueprintView` boundaries. If you were previously manually propagating `Environment` values you may remove this code. If you would like to opt-out of this behavior; you can set `view.automaticallyInheritsEnvironmentFromContainingBlueprintViews = false` on your `BlueprintView`.
+
 ### Removed
 
 ### Changed

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - BlueprintUI (0.27.0)
   - BlueprintUI/Tests (0.27.0)
   - BlueprintUICommonControls (0.27.0):
-    - BlueprintUI
+    - BlueprintUI (= 0.27.0)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   BlueprintUI: 0fe7dfb34d43c8ff1b6b69ca1bce853fa1eda084
-  BlueprintUICommonControls: e228bcd0a6918d52465d300a0dbce0bceaab4674
+  BlueprintUICommonControls: d852ecc315896740739f4e44a387321a66d2111c
 
 PODFILE CHECKSUM: a01a59366bcd21b6f7030cb454d88867c7b2cf25
 


### PR DESCRIPTION
This PR introduces automatic propagation of `Environment` through to arbitrarily nested `BlueprintViews`. This is useful, eg in `Market`, where in many places we nest additional `BlueprintViews` within stateful controls such as buttons – previously `Environment` values either would not flow down to these nested views, or we would have to manually flow the `Environment` down to these views.

We accomplish this propagation through updates to `NativeViewNode` and `NativeViewController`. When we create a `NativeViewNode`, we now record its `Environment`. Then, when the `NativeViewController` goes to update the `node`'s associated `UIView`, we assign the `UIView`'s `nativeViewNodeBlueprintEnvironment` (added via associated objects). This means that the `UIView` in the view hierarchy now has the correct `Environment`, which corresponds to its `Element`'s environment at measurement / layout time. 

To fetch our inherited `Environment`, when it comes time for a `BlueprintView` to layout its `Element` hierarchy; it asks for its own `inheritedBlueprintEnvironment` – this walks up the superview hierarchy until we find a `nativeViewNodeBlueprintEnvironment`, signaling that we are inside a parent `BlueprintView`; and uses this `Environment` to seed the `makeEnvironment()` function.