### PR TITLE
Collapse nested AdaptedEnvironments

### DIFF
--- a/BlueprintUI/Sources/Environment/AdaptedEnvironment.swift
+++ b/BlueprintUI/Sources/Environment/AdaptedEnvironment.swift
@@ -6,20 +6,30 @@ import CoreGraphics
 /// will automatically inherit those values automatically. Values can be changed
 /// anywhere in a sub-tree by inserting another `AdaptedEnvironment` element.
 public struct AdaptedEnvironment: Element {
-    var wrappedElement: Element
-    var environmentAdapter: (inout Environment) -> Void
+    
+    /// Takes in a mutable `Environment` which can be mutated to add or override values.
+    public typealias Adapter = (inout Environment) -> Void
+    
+    var wrapped: Element
+    var adapters: [Adapter]
 
     /// Wraps an element with an environment that is modified using the given
     /// configuration block.
+    ///
     /// - Parameters:
     ///   - by: A block that will set environmental values.
     ///   - wrapping: The element to be wrapped.
     public init(
-        by environmentAdapter: @escaping (inout Environment) -> Void,
-        wrapping wrappedElement: Element)
-    {
-        self.wrappedElement = wrappedElement
-        self.environmentAdapter = environmentAdapter
+        by adapt: @escaping Adapter,
+        wrapping wrapped: Element
+    ) {
+        if var adapter = wrapped as? AdaptedEnvironment {
+            adapter.adapters.append(adapt)
+            self = adapter
+        } else {
+            self.wrapped = wrapped
+            self.adapters = [adapt]
+        }
     }
 
     /// Wraps an element with an environment that is modified for a single key and value.
@@ -27,7 +37,12 @@ public struct AdaptedEnvironment: Element {
     ///   - key: The environment key to modify.
     ///   - value: The new environment value to cascade.
     ///   - wrapping: The element to be wrapped.
-    public init<Key>(key: Key.Type, value: Key.Value, wrapping child: Element) where Key: EnvironmentKey {
+    public init<Key>(
+        key: Key.Type,
+        value: Key.Value,
+        wrapping child: Element
+    ) where Key: EnvironmentKey
+    {
         self.init(by: { $0[key] = value }, wrapping: child)
     }
 
@@ -36,21 +51,34 @@ public struct AdaptedEnvironment: Element {
     ///   - keyPath: The keypath of the environment value to modify.
     ///   - value: The new environment value to cascade.
     ///   - wrapping: The element to be wrapped.
-    public init<Value>(keyPath: WritableKeyPath<Environment, Value>, value: Value, wrapping child: Element) {
+    public init<Value>(
+        keyPath: WritableKeyPath<Environment, Value>,
+        value: Value,
+        wrapping child: Element
+    ) {
         self.init(by: { $0[keyPath: keyPath] = value }, wrapping: child)
     }
 
     public var content: ElementContent {
-        return ElementContent(child: wrappedElement, environment: environmentAdapter)
+        ElementContent(
+            child: wrapped,
+            environment: { env in
+                for adapter in self.adapters.reversed() {
+                    adapter(&env)
+                }
+            }
+        )
     }
 
     public func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
-        return nil
+        nil
     }
 }
 
+
 public extension Element {
-    /// Wraps this element in an `AdaptedEnvironment` with the given enviroment key and value.
+    
+    /// Wraps this element in an `AdaptedEnvironment` with the given environment key and value.
     func adaptedEnvironment<Key>(key: Key.Type, value: Key.Value) -> Element where Key: EnvironmentKey {
         AdaptedEnvironment(key: key, value: value, wrapping: self)
     }

--- a/BlueprintUI/Tests/AdaptedEnvironmentTests.swift
+++ b/BlueprintUI/Tests/AdaptedEnvironmentTests.swift
@@ -1,0 +1,74 @@
+//
+//  AdaptedEnvironmentTests.swift
+//  BlueprintUI-Unit-Tests
+//
+//  Created by Kyle Van Essen on 6/28/21.
+//
+
+@testable import BlueprintUI
+import XCTest
+
+
+class AdaptedEnvironmentTests : XCTestCase {
+    
+    func test_adapting() {
+        let view = BlueprintView()
+        
+        var environment : Environment? = nil
+        
+        view.element = TestElement { environment = $0 }
+        .adaptedEnvironment(key: TestingKey1.self, value: "adapted1")
+        
+        view.layoutIfNeeded()
+        
+        XCTAssertEqual(environment?[TestingKey1], "adapted1")
+    }
+    
+    func test_wrapping_multiple() {
+        let view = BlueprintView()
+        
+        var environment : Environment? = nil
+        
+        let element = TestElement { environment = $0 }
+        .adaptedEnvironment(key: TestingKey1.self, value: "adapted1.1")
+        .adaptedEnvironment(key: TestingKey1.self, value: "adapted1.2")
+        .adaptedEnvironment(key: TestingKey2.self, value: "adapted2.1")
+        .adaptedEnvironment(key: TestingKey1.self, value: "adapted1.3")
+        .adaptedEnvironment(key: TestingKey2.self, value: "adapted2.2")
+        
+        view.element = element
+        
+        view.layoutIfNeeded()
+        
+        // The inner-most change; the one closest to the element; should be the value we get.
+        XCTAssertEqual(environment?[TestingKey1], "adapted1.1")
+        XCTAssertEqual(environment?[TestingKey2], "adapted2.1")
+        
+        // Ensure we collapsed the AdaptedEnvironments down to one level of wrapping.
+        XCTAssertTrue((element as? AdaptedEnvironment)?.wrapped is TestElement)
+    }
+}
+
+
+fileprivate enum TestingKey1 : EnvironmentKey {
+    static let defaultValue: String? = nil
+}
+
+
+fileprivate enum TestingKey2 : EnvironmentKey {
+    static let defaultValue: String? = nil
+}
+
+
+fileprivate struct TestElement : ProxyElement {
+    
+    var read : (Environment) -> ()
+    
+    var elementRepresentation: Element {
+        EnvironmentReader { env in
+            read(env)
+            
+            return Empty()
+        }
+    }
+}

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - BlueprintUI (0.27.0)
   - BlueprintUI/Tests (0.27.0)
   - BlueprintUICommonControls (0.27.0):
-    - BlueprintUI
+    - BlueprintUI (= 0.27.0)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   BlueprintUI: 0fe7dfb34d43c8ff1b6b69ca1bce853fa1eda084
-  BlueprintUICommonControls: e228bcd0a6918d52465d300a0dbce0bceaab4674
+  BlueprintUICommonControls: d852ecc315896740739f4e44a387321a66d2111c
 
 PODFILE CHECKSUM: a01a59366bcd21b6f7030cb454d88867c7b2cf25
 


### PR DESCRIPTION
Easy one – on init, check if our passed value is another `AdaptedEnvironment`, and if it is; append to its adaptors instead of wrapping it. For deeper nesting where you're doing:

```
element
.adaptedEnvironment(...)
.adaptedEnvironment(...)
.adaptedEnvironment(...)
.adaptedEnvironment(...)
```

Should remove the slight measurement / traversal penalty of deepening the hierarchy.