### PR TITLE
ElementContent & Layout API Updates

### DIFF
--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -67,7 +67,7 @@ public struct ElementContent {
         in size: CGSize,
         with context : LayoutContext,
         cache: CacheTree
-    ) -> [(identifier: ElementIdentifier, node: LayoutResultNode)] // TODO: Turn this into a reference type too
+    ) -> [(identifier: ElementIdentifier, node: LayoutResultNode)]
     {
         storage.performLayout(
             in: size,

--- a/BlueprintUI/Sources/Element/EnvironmentElement.swift
+++ b/BlueprintUI/Sources/Element/EnvironmentElement.swift
@@ -1,0 +1,30 @@
+//
+//  EnvironmentElement.swift
+//  BlueprintUI
+//
+//  Created by Kyle Van Essen on 7/2/21.
+//
+
+import Foundation
+
+
+/// Allows creating an `Element` with access to the current `Environment`.
+public protocol EnvironmentElement : Element {
+    
+    /// Return your `Element` body, reading from the constraint and environment as necessary.
+    func content(in size : SizeConstraint, with environment : Environment) -> Element
+}
+
+
+extension EnvironmentElement {
+    
+    public var content: ElementContent {
+        ElementContent { constraint, context in
+            self.content(in: constraint, with: context.environment)
+        }
+    }
+
+    public func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
+        nil
+    }
+}

--- a/BlueprintUI/Sources/Element/LayoutContext.swift
+++ b/BlueprintUI/Sources/Element/LayoutContext.swift
@@ -5,11 +5,24 @@
 //  Created by Kyle Van Essen on 7/2/21.
 //
 
-import Foundation
+import UIKit
 
 
 ///
+/// The ``LayoutContext`` is an object that is passed through the element hierarchy during
+/// layout and measurement passes, to give easy access to the ``Environment``, measurement
+/// views, etc.
 ///
+/// You usually do not create a ``LayoutContext`` yourself outside of testing contexts. Instead,
+/// utilize the ``LayoutContext`` passed to your ``ElementContent`` to correctly measure
+/// your content in the right environment and context:
+/// ```
+/// var content : ElementContent {
+///     ElementContent { size, context -> CGSize in
+///         self.wrapped.content.measure(in: size, with: context)
+///     }
+/// }
+/// ```
 public struct LayoutContext {
     
     // MARK: Environment
@@ -43,13 +56,13 @@ public struct LayoutContext {
     /// BlueprintView, or if measuring an element outside of a BlueprintView, for the length of the measurement cycle.
     ///
     /// The view passed to the method is wrapped in an `@autoclosure`; it will only be created once
-    /// per element for the lifetime of the containing Blueprint view / measurement cycle.
+    /// per element for the lifetime of the containing Blueprint view or measurement cycle.
     ///
     /// ```
     /// ElementContent { constraint, context -> CGSize in
     ///     context.measure(self, using: MyView()) { view in
     ///         view.configure(with: self)
-    ///         view.sizeThatFits(constraint.maximum)
+    ///         return view.sizeThatFits(constraint.maximum)
     ///     }
     /// }
     /// ```
@@ -73,7 +86,7 @@ public struct LayoutContext {
     // MARK: Mutating The Context
     
     /// Returns a new instance of the context by setting the provided key path to the provided value.
-    public func setting<Value>(
+    func setting<Value>(
         _ keyPath : WritableKeyPath<Self, Value>,
         to value : Value
     ) -> Self

--- a/BlueprintUI/Sources/Element/LayoutContext.swift
+++ b/BlueprintUI/Sources/Element/LayoutContext.swift
@@ -1,0 +1,125 @@
+//
+//  LayoutContext.swift
+//  BlueprintUI
+//
+//  Created by Kyle Van Essen on 7/2/21.
+//
+
+import Foundation
+
+
+///
+///
+public struct LayoutContext {
+    
+    // MARK: Environment
+
+    /// The current `Environment` for the `Element`.
+    public var environment : Environment
+    
+    // MARK: Making New Contexts
+        
+    /// Creates a new root context to pass to a root `Element` when you would like to measure
+    /// that element.
+    ///
+    /// You usually don't need to call this method yourself outside of tests. Instead,
+    /// pass through the `LayoutContext` that your `ElementContent` or `Layout` itself
+    /// was passed as part of the measurement and layout cycle.
+    public static func rootContext(with environment : Environment = .empty) -> Self {
+        Self(
+            environment: environment,
+            measurementCache: .init(),
+            measurementViews: .init()
+        )
+    }
+    
+    // MARK: Measuring Content
+    
+    /// Allows measuring of a prototype view in order to determine the size of an element during a
+    /// measurement and layout pass.
+    ///
+    /// Pass the method the containing element, as well as the view to use for measurement.
+    /// The method will pass back a cached prototype view that is retained for the length of the containing
+    /// BlueprintView, or if measuring an element outside of a BlueprintView, for the length of the measurement cycle.
+    ///
+    /// The view passed to the method is wrapped in an `@autoclosure`; it will only be created once
+    /// per element for the lifetime of the containing Blueprint view / measurement cycle.
+    ///
+    /// ```
+    /// ElementContent { constraint, context -> CGSize in
+    ///     context.measure(self, using: MyView()) { view in
+    ///         view.configure(with: self)
+    ///         view.sizeThatFits(constraint.maximum)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// #### Note
+    /// The view passed to this method will be reused for other elements of the same type
+    /// throughout the measurement cycle. Do **not** retain a reference to the view outside
+    /// of the `measure` closure.
+    ///
+    public func measure<ElementType:Element, ViewType:UIView>(
+        _ element : ElementType,
+        using view: @autoclosure () -> ViewType,
+        measure : (ViewType) -> CGSize
+    ) -> CGSize
+    {
+        let view = self.measurementViews.view(for: ElementType.self, make: view)
+        
+        return measure(view)
+    }
+    
+    // MARK: Mutating The Context
+    
+    /// Returns a new instance of the context by setting the provided key path to the provided value.
+    public func setting<Value>(
+        _ keyPath : WritableKeyPath<Self, Value>,
+        to value : Value
+    ) -> Self
+    {
+        var copy = self
+        copy[keyPath: keyPath] = value
+        return copy
+    }
+    
+    // MARK: Internal
+    
+    let measurementCache : MeasurementCache
+    let measurementViews : MeasurementViews
+}
+
+
+extension LayoutContext {
+    
+    /// Internal cache used to retain prototype views for measurement operations.
+    final class MeasurementViews {
+        
+        /// Returns a new to use for measurement.
+        fileprivate func view<ElementType:Element, ViewType:UIView>(
+            for element : ElementType.Type,
+            make : () -> ViewType
+        ) -> ViewType
+        {
+            let key = Key(
+                viewType: ObjectIdentifier(ViewType.self),
+                elementType: ObjectIdentifier(ElementType.self)
+            )
+            
+            if let existing = self.views[key] {
+                return existing as! ViewType
+            } else {
+                let new = make()
+                self.views[key] = new
+                return new
+            }
+        }
+        
+        private var views : [Key:UIView] = [:]
+        
+        private struct Key : Hashable {
+            let viewType : ObjectIdentifier
+            let elementType : ObjectIdentifier
+        }
+    }
+}

--- a/BlueprintUI/Sources/Element/MeasurementCache.swift
+++ b/BlueprintUI/Sources/Element/MeasurementCache.swift
@@ -18,7 +18,7 @@ final class MeasurementCache
     
     func measurement(
         with key : MeasurementCachingKey?,
-        in sizeConstraint : SizeConstraint,
+        in constraint : SizeConstraint,
         measure : () -> CGSize
     ) -> CGSize
     {
@@ -28,7 +28,7 @@ final class MeasurementCache
         
         let innerKey = Key(
             key: key,
-            sizeConstraint: sizeConstraint
+            sizeConstraint: constraint
         )
         
         if let existing = self.measurements[innerKey] {

--- a/BlueprintUI/Sources/Element/MeasurementCachingKey.swift
+++ b/BlueprintUI/Sources/Element/MeasurementCachingKey.swift
@@ -19,9 +19,8 @@ import Foundation
 ///
 /// Caching is only done on a per-layout pass. Caches are not reused between layout passes.
 ///
-/// Example
-/// -------
-/// Below is a simplified version of a `MeasurementCachingKey` in action, in this case for Blueprint's `Label` type.
+/// ### Example
+/// Below is a simplified version of a `MeasurementCachingKey` in action.
 /// ```
 /// struct Label : UIViewElement {
 ///
@@ -42,17 +41,14 @@ import Foundation
 ///     }
 ///
 ///     var measurementCacheKey : AnyHashable? {
-///         MeasurementCachingKey(
-///             type: Self.self,
-///             input: Key(
-///               text: self.text,
-///               font: self.font,
-///               numberOfLines: self.numberOfLines
-///             )
+///         MyKey(
+///             text: self.text,
+///             font: self.font,
+///             numberOfLines: self.numberOfLines
 ///         )
 ///     }
 ///
-///     struct Key : Hashable {
+///     struct MyKey : Hashable {
 ///         var text : String
 ///         var font : UIFont
 ///         var numberOfLines : Int
@@ -82,9 +78,7 @@ import Foundation
 ///     }
 ///
 ///     var measurementCacheKey : AnyHashable? {
-///         MeasurementCachingKey(
-///         type: Self.self,
-///         input: self
+///         self
 ///     }
 /// }
 /// ```

--- a/BlueprintUI/Sources/Environment/Environment.swift
+++ b/BlueprintUI/Sources/Environment/Environment.swift
@@ -39,17 +39,7 @@ public struct Environment {
     /// A default "empty" environment, with no values overridden.
     /// Each key will return its default value.
     public static var empty : Environment {
-        
-        /// Intentionally a derived value instead of a `static let empty = ...`. because `MeasurementCache`
-        /// is a `class` type (needed due to implementation constraints – the `MeasurementCache` is passed around during layout),
-        /// we want to ensure that each new environment that we ask for has a new `measurementCache` to avoid "leaking" / retaining
-        /// all the contained keys for the lifetime of the application, as a `static let` would cause.
-        
-        Environment(measurementCache: MeasurementCache())
-    }
-
-    private init(measurementCache : MeasurementCache) {
-        self.measurementCache = measurementCache
+        .init()
     }
 
     private var values: [ObjectIdentifier: Any] = [:]
@@ -78,11 +68,6 @@ public struct Environment {
         merged.values.merge(other.values) { $1 }
         return merged
     }
-        
-    /// Cache used to speed up measurements during a layout pass.
-    /// This is declared on the `Environment` directly, because access to the `measurementCache` is a hot path
-    /// which we can optimize by not needing the usual `env.values[...]` lookup.
-    var measurementCache : MeasurementCache
 }
 
 

--- a/BlueprintUI/Sources/Environment/EnvironmentReader.swift
+++ b/BlueprintUI/Sources/Environment/EnvironmentReader.swift
@@ -24,12 +24,12 @@ public struct EnvironmentReader: Element {
     }
 
     public var content: ElementContent {
-        return ElementContent { (_, environment) in
-            self.elementRepresentation(environment)
+        ElementContent { _, context in
+            self.elementRepresentation(context.environment)
         }
     }
 
     public func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
-        return nil
+        nil
     }
 }

--- a/BlueprintUI/Sources/Internal/Extensions/Array.swift
+++ b/BlueprintUI/Sources/Internal/Extensions/Array.swift
@@ -1,0 +1,43 @@
+//
+//  Array.swift
+//  BlueprintUI
+//
+//  Created by Kyle Van Essen on 7/2/21.
+//
+
+import Foundation
+
+
+extension Array {
+    
+    /// A `map` implementation that also passes the `index` of each element in the original array.
+    ///
+    /// This method is more performant than calling `array.enumerated().map(...)` by up
+    /// to 25% for large collections, so prefer it when needing an indexed `map` in areas where performance is critical.
+    @inlinable func indexedMap<Mapped>(_ map : (Int, Element) -> Mapped) -> [Mapped] {
+        
+        let count = self.count
+        
+        var mapped = [Mapped]()
+        mapped.reserveCapacity(count)
+        
+        for index in 0..<count {
+            mapped.append(map(index, self[index]))
+        }
+        
+        return mapped
+    }
+    
+    /// A `forEach` implementation that also passes the `index` of each element in the original array.
+    ///
+    /// This method is more performant than calling `array.enumerated().forEac(...)` by up
+    /// to 25% for large collections, so prefer it when needing an indexed `forEach` in areas where performance is critical.
+    @inlinable func indexedForEach(_ each : (Int, Element) -> Void) {
+        
+        let count = self.count
+
+        for index in 0..<count {
+            each(index, self[index])
+        }
+    }
+}

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -1,23 +1,5 @@
 import UIKit
 
-extension Element {
-
-    /// Build a fully laid out element tree with complete layout attributes
-    /// for each element.
-    ///
-    /// - Parameter layoutAttributes: The layout attributes to assign to the
-    ///   root element.
-    ///
-    /// - Returns: A layout result
-    func layout(layoutAttributes: LayoutAttributes, environment: Environment) -> LayoutResultNode {
-        return LayoutResultNode(
-            root: self,
-            layoutAttributes: layoutAttributes,
-            environment: environment
-        )
-    }
-
-}
 
 /// Represents a tree of elements with complete layout attributes
 struct LayoutResultNode {
@@ -45,20 +27,30 @@ struct LayoutResultNode {
         self.children = children
     }
 
-    init(root: Element, layoutAttributes: LayoutAttributes, environment: Environment) {
+    init(
+        root: Element,
+        layoutAttributes: LayoutAttributes,
+        environment: Environment,
+        measurementViews: LayoutContext.MeasurementViews
+    ) {
         let cache = CacheFactory.makeCache(name: "\(type(of: root))")
+        let measurementCache = MeasurementCache()
+        
         self.init(
             element: root,
             layoutAttributes: layoutAttributes,
             environment: environment,
             children: root.content.performLayout(
-                attributes: layoutAttributes,
-                environment: environment,
+                in: layoutAttributes.frame.size,
+                with: .init(
+                    environment: environment,
+                    measurementCache: measurementCache,
+                    measurementViews: measurementViews
+                ),
                 cache: cache
             )
         )
     }
-
 }
 
 

--- a/BlueprintUI/Sources/Internal/Logger.swift
+++ b/BlueprintUI/Sources/Internal/Logger.swift
@@ -7,6 +7,9 @@ enum Logger { }
 /// BlueprintView signposts
 extension Logger {
     static func logLayoutStart(view: BlueprintView) {
+        
+        guard BlueprintLogging.enabled else { return }
+        
         if #available(iOS 12.0, *) {
             os_signpost(
                 .begin,
@@ -20,6 +23,9 @@ extension Logger {
     }
 
     static func logLayoutEnd(view: BlueprintView) {
+        
+        guard BlueprintLogging.enabled else { return }
+        
         if #available(iOS 12.0, *) {
             os_signpost(
                 .end,
@@ -31,6 +37,9 @@ extension Logger {
     }
 
     static func logViewUpdateStart(view: BlueprintView) {
+        
+        guard BlueprintLogging.enabled else { return }
+        
         if #available(iOS 12.0, *) {
             os_signpost(
                 .begin,
@@ -44,6 +53,9 @@ extension Logger {
     }
 
     static func logViewUpdateEnd(view: BlueprintView) {
+        
+        guard BlueprintLogging.enabled else { return }
+        
         if #available(iOS 12.0, *) {
             os_signpost(
                 .end,
@@ -55,6 +67,9 @@ extension Logger {
     }
 
     static func logElementAssigned(view: BlueprintView) {
+        
+        guard BlueprintLogging.enabled else { return }
+        
         if #available(iOS 12.0, *) {
             os_signpost(
                 .event,
@@ -71,6 +86,9 @@ extension Logger {
 /// Measuring signposts
 extension Logger {
     static func logMeasureStart(object: AnyObject, description: String, constraint: SizeConstraint) {
+        
+        guard BlueprintLogging.enabled else { return }
+        
         if #available(iOS 12.0, *) {
             os_signpost(
                 .begin,
@@ -87,6 +105,9 @@ extension Logger {
     }
 
     static func logMeasureEnd(object: AnyObject) {
+        
+        guard BlueprintLogging.enabled else { return }
+        
         if #available(iOS 12.0, *) {
             os_signpost(
                 .end,

--- a/BlueprintUI/Sources/Layout/Aligned.swift
+++ b/BlueprintUI/Sources/Layout/Aligned.swift
@@ -70,13 +70,23 @@ public struct Aligned: Element {
         var verticalAlignment: VerticalAlignment
         var horizontalAlignment: HorizontalAlignment
 
-        func measure(in constraint: SizeConstraint, child: Measurable) -> CGSize {
-            return child.measure(in: constraint)
+        func measure(
+            child: Measurable,
+            in constraint : SizeConstraint,
+            with context: LayoutContext
+        ) -> CGSize
+        {
+            child.measure(in: constraint, with: context)
         }
 
-        func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
-            let contentSize = child.measure(in: SizeConstraint(size))
-
+        func layout(
+            child: Measurable,
+            in size : CGSize,
+            with context : LayoutContext
+        ) -> LayoutAttributes
+        {
+            let contentSize = child.measure(in: SizeConstraint(size), with: context)
+                        
             var attributes = LayoutAttributes(size: contentSize)
 
             switch verticalAlignment {

--- a/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
@@ -64,16 +64,27 @@ public struct ConstrainedAspectRatio: Element {
     }
 
     private struct Layout: SingleChildLayout {
+        
         var aspectRatio: AspectRatio
         var contentMode: ContentMode
 
-        func measure(in sizeConstraint: SizeConstraint, child: Measurable) -> CGSize {
-            let size = child.measure(in: sizeConstraint)
+        func measure(
+            child: Measurable,
+            in constraint : SizeConstraint,
+            with context: LayoutContext
+        ) -> CGSize
+        {
+            let size = child.measure(in: constraint, with: context)
             return contentMode.constrain(size: size, to: aspectRatio)
         }
 
-        func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
-            return LayoutAttributes(size: size)
+        func layout(
+            child: Measurable,
+            in size : CGSize,
+            with context : LayoutContext
+        ) -> LayoutAttributes
+        {
+            LayoutAttributes(size: size)
         }
     }
 }

--- a/BlueprintUI/Sources/Layout/ConstrainedSize.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedSize.swift
@@ -156,8 +156,12 @@ extension ConstrainedSize {
         var width: Constraint
         var height: Constraint
 
-        func measure(in constraint: SizeConstraint, child: Measurable) -> CGSize {
-
+        func measure(
+            child: Measurable,
+            in constraint : SizeConstraint,
+            with context: LayoutContext
+        ) -> CGSize
+        {
             // If both height & width are absolute, we can avoid measuring entirely.
             if case let .absolute(width) = width, case let .absolute(height) = height {
                 return CGSize(width: width, height: height)
@@ -175,7 +179,7 @@ extension ConstrainedSize {
                 height: .init(self.height.applied(to: constraint.height.maximum))
             )
             
-            let measurement = child.measure(in: maximumConstraint)
+            let measurement = child.measure(in: maximumConstraint, with: context)
             
             /// 2) If our returned size needs to be larger than the measured size,
             /// eg: the element did not take up all the space during measurement,
@@ -187,9 +191,14 @@ extension ConstrainedSize {
                 height: height.applied(to: measurement.height)
             )
         }
-
-        func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
-            return LayoutAttributes(size: size)
+        
+        func layout(
+            child: Measurable,
+            in size : CGSize,
+            with context : LayoutContext
+        ) -> LayoutAttributes
+        {
+            LayoutAttributes(size: size)
         }
     }
 

--- a/BlueprintUI/Sources/Layout/Decorate.swift
+++ b/BlueprintUI/Sources/Layout/Decorate.swift
@@ -65,19 +65,19 @@ public struct Decorate : ProxyElement {
     
     public var elementRepresentation: Element {
         EnvironmentReader { environment in
-            LayoutWriter { context, layout in
+            LayoutWriter { constraint, context, layout in
                 
                 let contentSize = self.wrapped.content.measure(
-                    in: context.size,
-                    environment: environment
-                )
+                    in: constraint,
+                    with: context
+                ) // TODO: This doesn't pass caching through...
                 
                 let contentFrame = CGRect(origin: .zero, size: contentSize)
                 
                 let decorationFrame = self.position.frame(
                     with: contentFrame,
                     decoration: self.decoration,
-                    environment: environment
+                    context: context
                 )
                 
                 layout.sizing = .fixed(contentSize)
@@ -152,14 +152,14 @@ extension Decorate {
             /// The frame of the content element within the `Decorate` element.
             public var contentFrame : CGRect
             
-            /// The environment the element is being rendered in.
-            public var environment : Environment
+            /// The context the element is being rendered in.
+            public var context : LayoutContext
         }
         
         func frame(
             with contentFrame : CGRect,
             decoration : Element,
-            environment : Environment
+            context : LayoutContext
         ) -> CGRect {
             
             switch self {
@@ -168,7 +168,7 @@ extension Decorate {
                 
             case .corner(let corner, let offset):
                 
-                let size = decoration.content.measure(in: .init(contentFrame.size), environment: environment)
+                let size = decoration.content.measure(in: .init(contentFrame.size), with: context)
                 
                 let center : CGPoint = {
                     switch corner {
@@ -194,7 +194,7 @@ extension Decorate {
                 )
                 
             case .custom(let provider):
-                return provider(.init(contentFrame: contentFrame, environment: environment))
+                return provider(.init(contentFrame: contentFrame, context: context))
             }
         }
     }

--- a/BlueprintUI/Sources/Layout/Decorate.swift
+++ b/BlueprintUI/Sources/Layout/Decorate.swift
@@ -70,7 +70,7 @@ public struct Decorate : ProxyElement {
                 let contentSize = self.wrapped.content.measure(
                     in: constraint,
                     with: context
-                ) // TODO: This doesn't pass caching through...
+                )
                 
                 let contentFrame = CGRect(origin: .zero, size: contentSize)
                 

--- a/BlueprintUI/Sources/Layout/EqualStack.swift
+++ b/BlueprintUI/Sources/Layout/EqualStack.swift
@@ -64,11 +64,17 @@ extension EqualStack {
         var direction: Direction
         var spacing: CGFloat
 
-        func measure(in constraint: SizeConstraint, items: [(traits: Void, content: Measurable)]) -> CGSize {
+        func measure(
+            items: LayoutItems<Void>,
+            in constraint : SizeConstraint,
+            with context: LayoutContext
+        ) -> CGSize
+        {
             guard items.count > 0 else { return .zero }
 
             let totalSpacing = (spacing * CGFloat(items.count - 1))
             let itemConstraint: SizeConstraint
+            
             switch direction {
             case .horizontal:
                 itemConstraint = SizeConstraint(
@@ -81,7 +87,8 @@ extension EqualStack {
                     height: (constraint.height - totalSpacing) / CGFloat(items.count)
                 )
             }
-            let itemSizes = items.map { $1.measure(in: itemConstraint) }
+            
+            let itemSizes = items.all.map { $0.content.measure(in: itemConstraint, with: context) }
 
             let maximumItemWidth = itemSizes.map { $0.width }.max() ?? 0
             let maximumItemHeight = itemSizes.map { $0.height }.max() ?? 0
@@ -101,11 +108,17 @@ extension EqualStack {
             return totalSize
         }
 
-        func layout(size: CGSize, items: [(traits: (), content: Measurable)]) -> [LayoutAttributes] {
+        func layout(
+            items: LayoutItems<Void>,
+            in size : CGSize,
+            with context : LayoutContext
+        ) -> [LayoutAttributes]
+        {
             guard items.count > 0 else { return [] }
 
             let totalSpacing = (spacing * CGFloat(items.count - 1))
             let itemSize: CGSize
+            
             switch direction {
             case .horizontal:
                 itemSize = CGSize(
@@ -134,7 +147,5 @@ extension EqualStack {
 
             return result
         }
-
     }
-
 }

--- a/BlueprintUI/Sources/Layout/GeometryReader.swift
+++ b/BlueprintUI/Sources/Layout/GeometryReader.swift
@@ -31,8 +31,8 @@ public struct GeometryReader: Element {
     }
 
     public var content: ElementContent {
-        ElementContent { (constraint, environment) -> Element in
-            self.elementRepresentation(GeometryProxy(environment: environment, constraint: constraint))
+        ElementContent { constraint, context in
+            self.elementRepresentation(GeometryProxy(constraint: constraint, context: context))
         }
     }
 
@@ -43,13 +43,19 @@ public struct GeometryReader: Element {
 
 /// Contains information about the current layout being measured by GeometryReader
 public struct GeometryProxy {
-    var environment: Environment
-
+    
     /// The size constraint of the element being laid out.
     public var constraint: SizeConstraint
+    
+    /// The environment the element is being laid out in.
+    public var environment: Environment {
+        context.environment
+    }
+    
+    var context : LayoutContext
 
     /// Measure the given element, using this proxy's constraint and the current environment.
-    public func measure(element: Element) -> CGSize {
-        element.content.measure(in: constraint, environment: environment)
+    public func size(for element: Element) -> CGSize {
+        element.content.measure(in: constraint, with: context)
     }
 }

--- a/BlueprintUI/Sources/Layout/Inset.swift
+++ b/BlueprintUI/Sources/Layout/Inset.swift
@@ -131,12 +131,18 @@ extension Inset {
         var left: CGFloat
         var right: CGFloat
 
-        func measure(in constraint: SizeConstraint, child: Measurable) -> CGSize {
+        func measure(
+            child: Measurable,
+            in constraint : SizeConstraint,
+            with context: LayoutContext
+        ) -> CGSize
+        {
             let insetConstraint = constraint.inset(
                 width: left + right,
-                height: top + bottom)
+                height: top + bottom
+            )
 
-            var size = child.measure(in: insetConstraint)
+            var size = child.measure(in: insetConstraint, with: context)
 
             size.width += left + right
             size.height += top + bottom
@@ -144,12 +150,18 @@ extension Inset {
             return size
         }
 
-        func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
+        func layout(
+            child: Measurable,
+            in size : CGSize,
+            with context : LayoutContext
+        ) -> LayoutAttributes
+        {
             var frame = CGRect(origin: .zero, size: size)
             frame.origin.x += left
             frame.origin.y += top
             frame.size.width -= left + right
             frame.size.height -= top + bottom
+            
             return LayoutAttributes(frame: frame)
         }
     }

--- a/BlueprintUI/Sources/Layout/Keyed.swift
+++ b/BlueprintUI/Sources/Layout/Keyed.swift
@@ -62,11 +62,22 @@ public struct Keyed: Element {
     }
     
     private struct KeyedLayout: SingleChildLayout {
-        func measure(in constraint: SizeConstraint, child: Measurable) -> CGSize {
-            child.measure(in: constraint)
+
+        func measure(
+            child: Measurable,
+            in constraint : SizeConstraint,
+            with context: LayoutContext
+        ) -> CGSize
+        {
+            child.measure(in: constraint, with: context)
         }
         
-        func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
+        func layout(
+            child: Measurable,
+            in size : CGSize,
+            with context : LayoutContext
+        ) -> LayoutAttributes
+        {
             LayoutAttributes(size: size)
         }
     }

--- a/BlueprintUI/Sources/Layout/Layout.swift
+++ b/BlueprintUI/Sources/Layout/Layout.swift
@@ -50,10 +50,15 @@ extension Layout where Traits == () {
 }
 
 
+/// Provides a list of items to measure or position during the element layout and measurement pass.
+/// You can measure each item by calling `content.measure(in:with:)`, passing the
+/// desired size and ``LayoutContent`` to propagate the ``Environment``, etc.
 public final class LayoutItems<Traits> {
     
+    /// The items to be measured or laid out.
     public let all : [Item]
     
+    /// The count of the items to be measured or laid out.
     public let count : Int
     
     init(with all : [Item]) {
@@ -61,9 +66,14 @@ public final class LayoutItems<Traits> {
         self.count = self.all.count
     }
     
+    /// An individual item to layout or measure.
     public struct Item {
         
+        /// The traits associated with the item, from its containing `Layout`. For most layouts, the `Traits`
+        /// are `()`, or `Void`.
         public let traits : Traits
+        
+        /// The content of the layout item to be measured.
         public let content : Measurable
         
         init(traits: Traits, content: Measurable) {

--- a/BlueprintUI/Sources/Layout/Layout.swift
+++ b/BlueprintUI/Sources/Layout/Layout.swift
@@ -15,7 +15,11 @@ public protocol Layout {
     ///   object and a `Measurable` value.
     ///
     /// - returns: The measured size for the given array of items.
-    func measure(in constraint: SizeConstraint, items: [(traits: Self.Traits, content: Measurable)]) -> CGSize
+    func measure(
+        items: LayoutItems<Self.Traits>,
+        in constraint : SizeConstraint,
+        with context: LayoutContext
+    ) -> CGSize
 
     /// Generates layout attributes for the given items.
     ///
@@ -26,17 +30,46 @@ public protocol Layout {
     ///   object and a `Measurable` value.
     ///
     /// - returns: Layout attributes for the given array of items.
-    func layout(size: CGSize, items: [(traits: Self.Traits, content: Measurable)]) -> [LayoutAttributes]
+    func layout(
+        items: LayoutItems<Self.Traits>,
+        in size : CGSize,
+        with context : LayoutContext
+    ) -> [LayoutAttributes]
     
     /// Returns a default traits object.
     static var defaultTraits: Self.Traits { get }
     
 }
 
+
 extension Layout where Traits == () {
     
     public static var defaultTraits: () {
         return ()
     }
-    
 }
+
+
+public final class LayoutItems<Traits> {
+    
+    public let all : [Item]
+    
+    public let count : Int
+    
+    init(with all : [Item]) {
+        self.all = all
+        self.count = self.all.count
+    }
+    
+    public struct Item {
+        
+        public let traits : Traits
+        public let content : Measurable
+        
+        init(traits: Traits, content: Measurable) {
+            self.traits = traits
+            self.content = content
+        }
+    }
+}
+

--- a/BlueprintUI/Sources/Layout/Opacity.swift
+++ b/BlueprintUI/Sources/Layout/Opacity.swift
@@ -31,15 +31,27 @@ public struct Opacity: Element {
     }
 
     private struct Layout: SingleChildLayout {
+        
         var opacity: CGFloat
 
-        func measure(in constraint: SizeConstraint, child: Measurable) -> CGSize {
-            return child.measure(in: constraint)
+        func measure(
+            child: Measurable,
+            in constraint : SizeConstraint,
+            with context: LayoutContext
+        ) -> CGSize
+        {
+            child.measure(in: constraint, with: context)
         }
 
-        func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
+        func layout(
+            child: Measurable,
+            in size : CGSize,
+            with context : LayoutContext
+        ) -> LayoutAttributes
+        {
             var attributes = LayoutAttributes(size: size)
             attributes.alpha = opacity
+            
             return attributes
         }
     }

--- a/BlueprintUI/Sources/Layout/Overlay.swift
+++ b/BlueprintUI/Sources/Layout/Overlay.swift
@@ -45,19 +45,29 @@ public struct Overlay: Element {
 /// the same frame (filling the container’s bounds).
 fileprivate struct OverlayLayout: Layout {
 
-    func measure(in constraint: SizeConstraint, items: [(traits: Void, content: Measurable)]) -> CGSize {
-        return items.reduce(into: CGSize.zero, { (result, item) in
-            let measuredSize = item.content.measure(in: constraint)
+    func measure(
+        items: LayoutItems<Void>,
+        in constraint : SizeConstraint,
+        with context: LayoutContext
+    ) -> CGSize
+    {
+        items.all.reduce(into: CGSize.zero) { result, item in
+            let measuredSize = item.content.measure(in: constraint, with: context)
+            
             result.width = max(result.width, measuredSize.width)
             result.height = max(result.height, measuredSize.height)
-        })
+        }
     }
 
-    func layout(size: CGSize, items: [(traits: Void, content: Measurable)]) -> [LayoutAttributes] {
-        return Array(
+    func layout(
+        items: LayoutItems<Void>,
+        in size : CGSize,
+        with context : LayoutContext
+    ) -> [LayoutAttributes]
+    {
+        Array(
             repeating: LayoutAttributes(size: size),
             count: items.count
         )
     }
-
 }

--- a/BlueprintUI/Sources/Layout/SingleChildLayout.swift
+++ b/BlueprintUI/Sources/Layout/SingleChildLayout.swift
@@ -9,7 +9,11 @@ public protocol SingleChildLayout {
     /// - parameter child: A `Measurable` representing the single child of this layout.
     ///
     /// - returns: The measured size.
-    func measure(in constraint: SizeConstraint, child: Measurable) -> CGSize
+    func measure(
+        child: Measurable,
+        in constraint : SizeConstraint,
+        with context: LayoutContext
+    ) -> CGSize
 
     /// Generates layout attributes for the child.
     ///
@@ -18,6 +22,9 @@ public protocol SingleChildLayout {
     /// - parameter child: A `Measurable` representing the single child of this layout.
     ///
     /// - returns: Layout attributes for the child of this layout.
-    func layout(size: CGSize, child: Measurable) -> LayoutAttributes
-
+    func layout(
+        child: Measurable,
+        in size : CGSize,
+        with context : LayoutContext
+    ) -> LayoutAttributes
 }

--- a/BlueprintUI/Sources/Layout/Transformed.swift
+++ b/BlueprintUI/Sources/Layout/Transformed.swift
@@ -45,15 +45,27 @@ public struct Transformed: Element {
     }
 
     private struct Layout: SingleChildLayout {
+        
         var transform: CATransform3D
 
-        func measure(in constraint: SizeConstraint, child: Measurable) -> CGSize {
-            return child.measure(in: constraint)
+        func measure(
+            child: Measurable,
+            in constraint : SizeConstraint,
+            with context: LayoutContext
+        ) -> CGSize
+        {
+            child.measure(in: constraint, with: context)
         }
 
-        func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
+        func layout(
+            child: Measurable,
+            in size : CGSize,
+            with context : LayoutContext
+        ) -> LayoutAttributes
+        {
             var attributes = LayoutAttributes(size: size)
             attributes.transform = transform
+            
             return attributes
         }
     }

--- a/BlueprintUI/Sources/Measuring/Measurable.swift
+++ b/BlueprintUI/Sources/Measuring/Measurable.swift
@@ -5,8 +5,12 @@ public protocol Measurable {
 
     /// Measures the required size of the receiver.
     ///
-    /// - parameter constraint: The size constraint.
+    /// - parameter context: The context describing the layout environment.
     ///
     /// - returns: The layout size needed by the receiver.
-    func measure(in constraint: SizeConstraint) -> CGSize
+    func measure(
+        in constraint : SizeConstraint,
+        with context: LayoutContext
+    ) -> CGSize
 }
+

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -446,7 +446,6 @@ private struct TestContainer: Element {
             items: LayoutItems<Void>,
             in constraint : SizeConstraint,
             with context: LayoutContext
-            
         ) -> CGSize
         {
             .zero

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -371,7 +371,7 @@ fileprivate struct MeasurableElement : Element {
     var validate : (SizeConstraint) -> CGSize
     
     var content: ElementContent {
-        ElementContent { constraint -> CGSize in
+        ElementContent { constraint, _ -> CGSize in
             self.validate(constraint)
         }
     }
@@ -440,13 +440,25 @@ private struct TestContainer: Element {
         return nil
     }
 
-    private class TestLayout: Layout {
-        func measure(in constraint: SizeConstraint, items: [(traits: (), content: Measurable)]) -> CGSize {
-            return .zero
+    private struct TestLayout: Layout {
+        
+        func measure(
+            items: LayoutItems<Void>,
+            in constraint : SizeConstraint,
+            with context: LayoutContext
+            
+        ) -> CGSize
+        {
+            .zero
         }
 
-        func layout(size: CGSize, items: [(traits: (), content: Measurable)]) -> [LayoutAttributes] {
-            return Array(repeating: LayoutAttributes(size: .zero), count: items.count)
+        func layout(
+            items: LayoutItems<Void>,
+            in size : CGSize,
+            with context : LayoutContext
+        ) -> [LayoutAttributes]
+        {
+            Array(repeating: LayoutAttributes(size: .zero), count: items.count)
         }
     }
 }

--- a/BlueprintUI/Tests/ConstrainedSizeTests.swift
+++ b/BlueprintUI/Tests/ConstrainedSizeTests.swift
@@ -323,7 +323,7 @@ class ConstrainedSizeTests: XCTestCase {
 fileprivate struct FixedElement: Element {
 
     var content: ElementContent {
-        ElementContent { constraint -> CGSize in
+        ElementContent { constraint, context -> CGSize in
             // Using different sizes for width and height in case
             // any internal calculations mix up x and y; we'll catch that.
             
@@ -340,7 +340,7 @@ fileprivate struct FixedElement: Element {
 fileprivate struct FlexibleElement: Element {
 
     var content: ElementContent {
-        ElementContent { constraint -> CGSize in
+        ElementContent { constraint, context -> CGSize in
             let totalArea : CGFloat = 100 * 110
             
             let width : CGFloat

--- a/BlueprintUI/Tests/DecorateTests.swift
+++ b/BlueprintUI/Tests/DecorateTests.swift
@@ -17,9 +17,11 @@ class Decorate_Position_Tests : XCTestCase {
         
         // .inset
         
+        let context = LayoutContext.rootContext()
+        
         let inset = Decorate.Position.inset(UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10))
         XCTAssertEqual(
-            inset.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
+            inset.frame(with: contentFrame, decoration: DecorationElement(), context: context),
             CGRect(x: 0, y: 0, width: 70, height: 50)
         )
         
@@ -27,25 +29,25 @@ class Decorate_Position_Tests : XCTestCase {
         
         let topLeft = Decorate.Position.corner(.topLeft, .init(horizontal: 1, vertical: 2))
         XCTAssertEqual(
-            topLeft.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
+            topLeft.frame(with: contentFrame, decoration: DecorationElement(), context: context),
             CGRect(x: -4, y: -5.5, width: 10, height: 15)
         )
         
         let topRight = Decorate.Position.corner(.topRight, .init(horizontal: 1, vertical: 2))
         XCTAssertEqual(
-            topRight.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
+            topRight.frame(with: contentFrame, decoration: DecorationElement(), context: context),
             CGRect(x: 56, y: -5.5, width: 10, height: 15)
         )
         
         let bottomRight = Decorate.Position.corner(.bottomRight, .init(horizontal: 1, vertical: 2))
         XCTAssertEqual(
-            bottomRight.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
+            bottomRight.frame(with: contentFrame, decoration: DecorationElement(), context: context),
             CGRect(x: 56, y: 34.5, width: 10, height: 15)
         )
         
         let bottomLeft = Decorate.Position.corner(.bottomLeft, .init(horizontal: 1, vertical: 2))
         XCTAssertEqual(
-            bottomLeft.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
+            bottomLeft.frame(with: contentFrame, decoration: DecorationElement(), context: context),
             CGRect(x: -4, y: 34.5, width: 10, height: 15)
         )
         
@@ -56,7 +58,7 @@ class Decorate_Position_Tests : XCTestCase {
         })
         
         XCTAssertEqual(
-            custom.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
+            custom.frame(with: contentFrame, decoration: DecorationElement(), context: context),
             CGRect(x: 10, y: 15, width: 20, height: 30)
         )
     }
@@ -66,7 +68,7 @@ class Decorate_Position_Tests : XCTestCase {
 fileprivate struct DecorationElement : Element {
     
     var content: ElementContent {
-        ElementContent { _ in CGSize(width: 10, height: 15) }
+        ElementContent { _, _ in CGSize(width: 10, height: 15) }
     }
     
     func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {

--- a/BlueprintUI/Tests/Element+Testing.swift
+++ b/BlueprintUI/Tests/Element+Testing.swift
@@ -9,26 +9,30 @@ extension Element {
     ///
     /// - Returns: A layout result
     func layout(frame: CGRect, environment: Environment = .empty) -> LayoutResultNode {
-        return layout(layoutAttributes: LayoutAttributes(frame: frame), environment: environment)
+        return LayoutResultNode(
+            root: self,
+            layoutAttributes: LayoutAttributes(frame: frame),
+            environment: environment,
+            measurementViews: .init()
+        )
     }
 }
 
 extension ElementContent {
-    /// A convenience method to measure the required size of this element's content,
-    /// using a default environment.
-    /// - Parameters:
-    ///   - constraint: The size constraint.
-    /// - returns: The layout size needed by this content.
-    func measure(in constraint: SizeConstraint) -> CGSize {
-        return measure(in: constraint, environment: .empty)
+
+    func measure(in constraint: SizeConstraint, environment: Environment = .empty) -> CGSize {
+        measure(
+            in: constraint,
+            with: .rootContext(with: environment)
+        )
     }
 
     /// A convenience wrapper to perform layout during testing, using a default `Environment` and
     /// a new cache.
-    func testLayout(attributes: LayoutAttributes) -> [(identifier: ElementIdentifier, node: LayoutResultNode)] {
+    func testLayout(in size : CGSize) -> [(identifier: ElementIdentifier, node: LayoutResultNode)] {
         self.performLayout(
-            attributes: attributes,
-            environment: .empty,
+            in: size,
+            with: .rootContext(),
             cache: CacheFactory.makeCache(name: "test")
         )
     }

--- a/BlueprintUI/Tests/EnvironmentTests.swift
+++ b/BlueprintUI/Tests/EnvironmentTests.swift
@@ -246,12 +246,22 @@ private struct TestElement: Element {
     struct TestLayout: Layout {
         var value: TestValue
 
-        func measure(in constraint: SizeConstraint, items: [(traits: (), content: Measurable)]) -> CGSize {
-            return value.size
+        func measure(
+            items: LayoutItems<Void>,
+            in constraint : SizeConstraint,
+            with context: LayoutContext
+        ) -> CGSize
+        {
+            value.size
         }
 
-        func layout(size: CGSize, items: [(traits: (), content: Measurable)]) -> [LayoutAttributes] {
-            return [value.layoutAttributes]
+        func layout(
+            items: LayoutItems<Void>,
+            in size : CGSize,
+            with context : LayoutContext
+        ) -> [LayoutAttributes]
+        {
+            [value.layoutAttributes]
         }
     }
 

--- a/BlueprintUI/Tests/EqualStackTests.swift
+++ b/BlueprintUI/Tests/EqualStackTests.swift
@@ -250,7 +250,7 @@ fileprivate struct AreaElement: Element {
     }
 
     var content: ElementContent {
-        return ElementContent { [area] constraint in
+        ElementContent { [area] constraint, context -> CGSize in
             if case .atMost(let maxWidth) = constraint.width {
                 return CGSize(
                     width: maxWidth,

--- a/BlueprintUI/Tests/GeometryReaderTests.swift
+++ b/BlueprintUI/Tests/GeometryReaderTests.swift
@@ -67,13 +67,13 @@ final class GeometryReaderTests: XCTestCase {
             }
 
             XCTAssertEqual(
-                geometry.measure(element: adaptiveElement),
+                geometry.size(for: adaptiveElement),
                 CGSize(width: 10, height: 10)
             )
 
             XCTAssertEqual(
-                geometry.measure(
-                    element: adaptiveElement.adaptedEnvironment(key: TestKey.self, value: 5)
+                geometry.size(
+                    for: adaptiveElement.adaptedEnvironment(key: TestKey.self, value: 5)
                 ),
                 CGSize(width: 5, height: 5)
             )

--- a/BlueprintUI/Tests/LayoutResultNodeTests.swift
+++ b/BlueprintUI/Tests/LayoutResultNodeTests.swift
@@ -46,11 +46,22 @@ fileprivate struct AbstractElement: Element {
     }
 
     private struct Layout: SingleChildLayout {
-        func measure(in constraint: SizeConstraint, child: Measurable) -> CGSize {
-            return .zero
+        func measure(
+            child: Measurable,
+            in constraint : SizeConstraint,
+            with context: LayoutContext
+        ) -> CGSize
+        {
+            .zero
         }
-        func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
-            return LayoutAttributes(frame: CGRect(origin: .zero, size: size).insetBy(dx: 10, dy: 10))
+        
+        func layout(
+            child: Measurable,
+            in size : CGSize,
+            with context : LayoutContext
+        ) -> LayoutAttributes
+        {
+            LayoutAttributes(frame: CGRect(origin: .zero, size: size).insetBy(dx: 10, dy: 10))
         }
     }
 

--- a/BlueprintUI/Tests/LayoutWriterTests.swift
+++ b/BlueprintUI/Tests/LayoutWriterTests.swift
@@ -18,7 +18,7 @@ class LayoutWriterTests : XCTestCase {
         
         var buildCount : Int = 0
         
-        let writer = LayoutWriter { _, layout in
+        let writer = LayoutWriter { _, _, layout in
             buildCount += 1
         }
         
@@ -39,7 +39,7 @@ class LayoutWriterTests : XCTestCase {
         /// `.unionOfChildren`, positive frames.
         
         do {
-            let writer = LayoutWriter { context, layout in
+            let writer = LayoutWriter { constraint, context, layout in
                 layout.add(with: CGRect(x: 10, y: 20, width: 50, height: 50), child: TestElement())
                 layout.add(with: CGRect(x: 20, y: 10, width: 20, height: 100), child: TestElement())
                 
@@ -52,7 +52,7 @@ class LayoutWriterTests : XCTestCase {
         /// `.unionOfChildren`, positive & negative frames.
         
         do {
-            let writer = LayoutWriter { context, layout in
+            let writer = LayoutWriter { constraint, context, layout in
                 layout.add(with: CGRect(x: -10, y: -10, width: 50, height: 50), child: TestElement())
                 layout.add(with: CGRect(x: -20, y: 50, width: 20, height: 60), child: TestElement())
                 layout.add(with: CGRect(x: 50, y: 25, width: 50, height: 60), child: TestElement())
@@ -67,7 +67,7 @@ class LayoutWriterTests : XCTestCase {
         /// `.fixed`
         
         do {
-            let writer = LayoutWriter { context, layout in
+            let writer = LayoutWriter { constraint, context, layout in
                 layout.add(with: CGRect(x: 10, y: 20, width: 50, height: 50), child: TestElement())
                 
                 layout.sizing = .fixed(CGSize(width: 100, height: 100))
@@ -79,12 +79,12 @@ class LayoutWriterTests : XCTestCase {
     }
     
     func test_layout() {
-        let writer = LayoutWriter { context, layout in
+        let writer = LayoutWriter { constraint, context, layout in
             layout.add(with: CGRect(x: 10, y: 20, width: 50, height: 50), child: TestElement())
             layout.add(with: CGRect(x: 20, y: 10, width: 20, height: 100), child: TestElement())
         }
     
-        let layoutResult = writer.content.testLayout(attributes: LayoutAttributes(size: CGSize(width: 100, height: 100)))
+        let layoutResult = writer.content.testLayout(in: CGSize(width: 100, height: 100))
         let innerElement = layoutResult[0]
         
         let nodes = innerElement.node.children.map(\.node)
@@ -103,11 +103,11 @@ class LayoutWriterTests : XCTestCase {
 fileprivate struct TestElement : Element {
     
     var content: ElementContent {
-        ElementContent { $0.maximum }
+        ElementContent { constraint, _ in constraint.maximum }
     }
     
     func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
         UIView.describe { _ in }
     }
-    
+
 }

--- a/BlueprintUI/Tests/PerformancePlayground.swift
+++ b/BlueprintUI/Tests/PerformancePlayground.swift
@@ -95,7 +95,8 @@ class PerformancePlayground : XCTestCase
                 return Column { column in
                     for string in lipsumStrings[0..<leafLabelCount] {
                         labelCount += 1
-                        column.add(child: NonCachingLabel(text: string))
+                        //column.add(child: NonCachingLabel(text: string))
+                        column.add(child: NoOpElement())
                     }
                 }
             }
@@ -107,8 +108,7 @@ class PerformancePlayground : XCTestCase
         let tree = element(depth: stackDepth)
         print("layout depth: \(stackDepth) contains \(labelCount) labels")
 
-        for i in 1...runCount {
-            print("run \(i) of \(runCount)")
+        self.determineAverage(for: 10.0) {
             view.element = tree
             view.layoutIfNeeded()
         }
@@ -116,27 +116,40 @@ class PerformancePlayground : XCTestCase
     
     func determineAverage(for seconds : TimeInterval, using block : () -> ()) {
         let start = Date()
-        
+
         var iterations : Int = 0
         
+        var lastUpdateDate = Date()
+
         repeat {
-            let iterationStart = Date()
             block()
-            let iterationEnd = Date()
-            let duration = iterationEnd.timeIntervalSince(iterationStart)
             
             iterations += 1
-
-            print("Iteration: \(iterations), Duration : \(duration)")
             
+            if Date().timeIntervalSince(lastUpdateDate) >= 1 {
+                lastUpdateDate = Date()
+                print("Continuing Test: \(iterations) Iterations...")
+            }
+
         } while Date() < start + seconds
-        
+
         let end = Date()
-        
+
         let duration = end.timeIntervalSince(start)
         let average = duration / TimeInterval(iterations)
-        
+
         print("Iterations: \(iterations), Average Time: \(average)")
+    }
+}
+
+
+private struct NoOpElement : Element {
+    var content: ElementContent {
+        ElementContent.init(intrinsicSize: CGSize(width: 100, height: 20))
+    }
+    
+    func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
+        nil
     }
 }
 

--- a/BlueprintUI/Tests/StackTests.swift
+++ b/BlueprintUI/Tests/StackTests.swift
@@ -1121,7 +1121,7 @@ class StackTests: XCTestCase {
         var axis: StackLayout.Axis
 
         var content: ElementContent {
-            ElementContent { constraint -> CGSize in
+            ElementContent { constraint, context -> CGSize in
                 switch self.axis {
                 case .horizontal:
                     let itemsPerLine = max(1, Int(constraint.width.maximum / self.itemSize.width))

--- a/BlueprintUI/Tests/UIViewElementTests.swift
+++ b/BlueprintUI/Tests/UIViewElementTests.swift
@@ -42,9 +42,11 @@ class UIViewElementTests : XCTestCase {
                 view.sizeThatFits = self.size
             }
         }
+        
+        let context = LayoutContext.rootContext()
 
         XCTAssertEqual(
-            TestElement(size: CGSize(width: 20.0, height: 30.0)).content.measure(in: .unconstrained),
+            TestElement(size: CGSize(width: 20.0, height: 30.0)).content.measure(in: .unconstrained, with: context),
             CGSize(width: 20.0, height: 30.0)
         )
 
@@ -54,7 +56,7 @@ class UIViewElementTests : XCTestCase {
         XCTAssertEqual(TestElement.updateUIView_count, 1)
 
         XCTAssertEqual(
-            TestElement(size: CGSize(width: 40.0, height: 60.0)).content.measure(in: .unconstrained),
+            TestElement(size: CGSize(width: 40.0, height: 60.0)).content.measure(in: .unconstrained, with: context),
             CGSize(width: 40.0, height: 60.0)
         )
 

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -19,23 +19,15 @@ public struct AttributedLabel: Element, Hashable {
         configure(&self)
     }
 
+    private static let measurementLabel = LabelView()
+    
     public var content: ElementContent {
-        struct Measurer: Measurable {
-            private static let prototypeLabel = LabelView()
-
-            var model: AttributedLabel
-
-            func measure(in constraint: SizeConstraint) -> CGSize {
-                let label = Self.prototypeLabel
-                model.update(label: label)
-                return label.sizeThatFits(constraint.maximum)
-            }
+        let key = MeasurementCachingKey(type: Self.self, input: self)
+        
+        return ElementContent(measurementCachingKey: key) { constraint, context -> CGSize in
+            self.update(label: Self.measurementLabel)
+            return Self.measurementLabel.sizeThatFits(constraint.maximum)
         }
-
-        return ElementContent(
-            measurable: Measurer(model: self),
-            measurementCachingKey: .init(type: Self.self, input: self)
-        )
     }
 
     private func update(label: LabelView) {

--- a/BlueprintUICommonControls/Sources/Image.swift
+++ b/BlueprintUICommonControls/Sources/Image.swift
@@ -101,7 +101,11 @@ extension Image {
         var contentMode: ContentMode
         var imageSize: CGSize?
 
-        func measure(in constraint: SizeConstraint) -> CGSize {
+        func measure(
+            in constraint : SizeConstraint,
+            with context: LayoutContext
+        ) -> CGSize
+        {
             guard let imageSize = imageSize else { return .zero }
 
             enum Mode {
@@ -111,12 +115,15 @@ extension Image {
             }
 
             let mode: Mode
-
+            
             switch contentMode {
             case .center, .stretch:
                 mode = .useImageSize
             case .aspectFit, .aspectFill:
-                if case .atMost(let width) = constraint.width, case .atMost(let height) = constraint.height {
+                if
+                    case .atMost(let width) = constraint.width,
+                    case .atMost(let height) = constraint.height
+                {
                     if CGSize(width: width, height: height).aspectRatio > imageSize.aspectRatio {
                         mode = .fitWidth(width)
                     } else {

--- a/BlueprintUICommonControls/Sources/ScrollView.swift
+++ b/BlueprintUICommonControls/Sources/ScrollView.swift
@@ -97,34 +97,50 @@ extension ScrollView {
         var contentSize: ContentSize
         var centersUnderflow: Bool
 
-        func fittedSize(in constraint: SizeConstraint, child: Measurable) -> CGSize {
+        func fittedSize(
+            for child: Measurable,
+            in constraint: SizeConstraint,
+            with context : LayoutContext
+        ) -> CGSize {
             switch contentSize {
             case .custom(let size):
                 return size
 
             case .fittingContent:
-                return child.measure(in: .unconstrained)
+                return child.measure(in: .unconstrained, with: context)
 
             case .fittingHeight:
                 return child.measure(
                     in: SizeConstraint(
                         width: constraint.width,
-                        height: .unconstrained))
+                        height: .unconstrained
+                    ),
+                    with: context
+                )
 
             case .fittingWidth:
                 return child.measure(
                     in: SizeConstraint(
                         width: .unconstrained,
-                        height: constraint.height))
+                        height: constraint.height
+                     ),
+                    with: context
+                )
             }
         }
 
-        func measure(in constraint: SizeConstraint, child: Measurable) -> CGSize {
+        func measure(
+            child: Measurable,
+            in constraint : SizeConstraint,
+            with context: LayoutContext
+        ) -> CGSize
+        {
             let adjustedConstraint = constraint.inset(
                 width: contentInset.left + contentInset.right,
-                height: contentInset.top + contentInset.bottom)
+                height: contentInset.top + contentInset.bottom
+            )
 
-            var result = fittedSize(in: adjustedConstraint, child: child)
+            var result = fittedSize(for: child, in: adjustedConstraint, with: context)
 
             result.width += contentInset.left + contentInset.right
             result.height += contentInset.top + contentInset.bottom
@@ -135,13 +151,22 @@ extension ScrollView {
             return result
         }
 
-        func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
-
+        func layout(
+            child: Measurable,
+            in size : CGSize,
+            with context : LayoutContext
+        ) -> LayoutAttributes
+        {
             var insetSize = size
             insetSize.width -= contentInset.left + contentInset.right
             insetSize.height -= contentInset.top + contentInset.bottom
 
-            var itemSize = fittedSize(in: SizeConstraint(insetSize), child: child)
+            var itemSize = fittedSize(
+                for: child,
+                in: .init(insetSize),
+                with: context
+            )
+            
             if self.contentSize == .fittingHeight {
                 itemSize.width = insetSize.width
             } else if self.contentSize == .fittingWidth {
@@ -159,11 +184,10 @@ extension ScrollView {
                     contentAttributes.center.y = size.height / 2.0
                 }
             }
+            
             return contentAttributes
         }
-
     }
-
 }
 
 extension ScrollView {

--- a/BlueprintUICommonControls/Sources/SegmentedControl.swift
+++ b/BlueprintUICommonControls/Sources/SegmentedControl.swift
@@ -3,7 +3,7 @@ import BlueprintUI
 
 
 /// Allows users to pick from an array of options.
-public struct SegmentedControl: Element, Measurable {
+public struct SegmentedControl: Element {
 
     public var items: [Item]
 
@@ -21,16 +21,16 @@ public struct SegmentedControl: Element, Measurable {
     }
 
     public var content: ElementContent {
-        return ElementContent(measurable: self)
-    }
-
-    public func measure(in constraint: SizeConstraint) -> CGSize {
-        return items.reduce(CGSize.zero, { (current, item) -> CGSize in
-            let itemSize = item.measure(font: font, in: constraint, roundingScale: roundingScale)
-            return CGSize(
-                width: itemSize.width + current.width,
-                height: max(itemSize.height, current.height))
-        })
+        ElementContent { constraint, context in
+            items.reduce(CGSize.zero) { (current, item) -> CGSize in
+                let itemSize = item.measure(font: font, in: constraint, roundingScale: roundingScale)
+                
+                return CGSize(
+                    width: itemSize.width + current.width,
+                    height: max(itemSize.height, current.height)
+                )
+            }
+        }
     }
 
     public func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
@@ -42,7 +42,6 @@ public struct SegmentedControl: Element, Measurable {
     fileprivate var titleTextAttributes: [NSAttributedString.Key:Any] {
         return [NSAttributedString.Key.font: font]
     }
-
 }
 
 extension SegmentedControl {

--- a/BlueprintUICommonControls/Sources/TextField.swift
+++ b/BlueprintUICommonControls/Sources/TextField.swift
@@ -69,10 +69,11 @@ public struct TextField: Element {
     }
 
     public var content: ElementContent {
-        ElementContent { constraint -> CGSize in
-            return CGSize(
+        ElementContent { constraint, context in
+            CGSize(
                 width: max(constraint.maximum.width, 44),
-                height: 44.0)
+                height: 44.0
+            )
         }
     }
     

--- a/BlueprintUICommonControls/Tests/Sources/BoxTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/BoxTests.swift
@@ -115,10 +115,11 @@ private struct InsettingElement: Element {
     }
 
     private struct Layout: SingleChildLayout {
-        func measure(in constraint: SizeConstraint, child: Measurable) -> CGSize {
+        func measure(child: Measurable, in constraint: SizeConstraint, with context: LayoutContext) -> CGSize {
             return .zero
         }
-        func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
+        
+        func layout(child: Measurable, in size: CGSize, with context: LayoutContext) -> LayoutAttributes {
             return LayoutAttributes(frame: CGRect(origin: .zero, size: size).insetBy(dx: 20, dy: 20))
         }
     }

--- a/BlueprintUICommonControls/Tests/Sources/ElementContent+Testing.swift
+++ b/BlueprintUICommonControls/Tests/Sources/ElementContent+Testing.swift
@@ -2,12 +2,13 @@ import CoreGraphics
 import BlueprintUI
 
 extension ElementContent {
+    
     /// A convenience method to measure the required size of this element's content,
     /// using a default environment.
     /// - Parameters:
     ///   - constraint: The size constraint.
     /// - returns: The layout size needed by this content.
     func measure(in constraint: SizeConstraint) -> CGSize {
-        return measure(in: constraint, environment: .empty)
+        return measure(in: constraint, with: .rootContext())
     }
 }

--- a/SampleApp/SampleApp.xcodeproj/xcshareddata/xcschemes/SampleApp.xcscheme
+++ b/SampleApp/SampleApp.xcodeproj/xcshareddata/xcschemes/SampleApp.xcscheme
@@ -79,7 +79,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/SampleApp/SampleApp.xcodeproj/xcshareddata/xcschemes/SampleApp.xcscheme
+++ b/SampleApp/SampleApp.xcodeproj/xcshareddata/xcschemes/SampleApp.xcscheme
@@ -79,7 +79,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/SampleApp/Sources/ResponsiveViewController.swift
+++ b/SampleApp/Sources/ResponsiveViewController.swift
@@ -43,7 +43,7 @@ struct ResponsiveLabel: ProxyElement {
                 label.numberOfLines = 1
             }
 
-            let labelWidth = geometry.measure(element: label).width
+            let labelWidth = geometry.size(for: label).width
 
             // If the label does not fit within this constraint, replace it with "..."
             if let maxWidth = geometry.constraint.width.constrainedValue, labelWidth > maxWidth {


### PR DESCRIPTION
This PR contains a few updates to the `ElementContent` and `Layout` APIs, in order to:

- Pass `Environment` (via `LayoutContext`) through to the various measurement and layout functions to ensure that you always have access to the current `Environment` as a consumer. In general I'd like us to move towards "Environment Everywhere"; this is to discourage people from passing `.empty` through to measurement methods, because, especially in Market, an `.empty` `Environment` is likely almost _always_ wrong in subtle ways (In a follow up, we may want to rename / remove `.empty` or change the `Environment` API to make getting an empty environment harder / more obvious that it's not what you want in most cases).
- Introduce the `LayoutContext` as a container for `Environment`, etc, as passed through to these methods, to reduce the need for future breaking changes when we want to add additional optional parameters to layout and measurement. This is similar to the `ViewDescriptionContext` introduced in https://github.com/square/Blueprint/pull/231.
- Take advantage of the newly introduced `LayoutContext` to fix the lifetime of static measurement / prototype views. These are now tied to the lifetime of their containing blueprint view / standalone measurement pass, via the `LayoutContext.measure(...)` methods. This fixes an issue that John D raised; where because the static shared view instances lived forever, they would outlive their context (eg being logged in), and appear as a memory leak / retain cycle.
- Update `Layout` and `SingleChildLayout` to take in  the`LayoutContext` and `LayoutItems`; `LayoutItems` is a class-based wrapper around the previous top-level array of layout items we'd pass around – turns out that this actually has a pretty significant performance benefit when looking at the bookkeeping vs passing around the array of tuples previously – something like a 20-30% perf benefit in testing a deep hierarchy where actual measurement and layout was a no-op – 0.12s before vs 0.07-0.08s afterwards.
- Add `EnvironmentElement` to allow easier creation of Environment-backed elements.

## Details

### `ElementContent`Updates
`ElementContent` and its associated initializers have been updated to take in a `LayoutContext` object.

### `Layout & SingleChildLayout`Updates

These two protocols have been updated to take in the new `LayoutContext`, as well as use the new `LayoutItems` type. I also re-ordered the parameters to make them read a little better and unify the ordering across layout and single child layout.

```
public protocol SingleChildLayout {

    func measure(
        child: Measurable,
        in constraint : SizeConstraint,
        with context: LayoutContext
    ) -> CGSize

    func layout(
        child: Measurable,
        in size : CGSize,
        with context : LayoutContext
    ) -> LayoutAttributes
}

public protocol Layout {

    func measure(
        items: LayoutItems<Self.Traits>,
        in constraint : SizeConstraint,
        with context: LayoutContext
    ) -> CGSize

    func layout(
        items: LayoutItems<Self.Traits>,
        in size : CGSize,
        with context : LayoutContext
    ) -> [LayoutAttributes]    
}
```

### Introduce `LayoutContext`, Fix Measurement View Lifetimes
Similar to `ViewDescriptionContext`, introduces a context object that is passed through the layout process; to give global access to the `Environment`, and allows us to add further optional parameters to layout and measurement methods without further breaking API changes.

LayoutContext also provides a way to perform easier measurement using prototype views that respects the containing Blueprint View's lifecycle. `UIViewElement` has been moved to use this caching method.

```
public struct LayoutContext {
    
    /// The current `Environment` for the `Element`.
    public var environment : Environment

    public func measure<ElementType:Element, ViewType:UIView>(
        _ element : ElementType,
        using view: @autoclosure () -> ViewType,
        measure : (ViewType) -> CGSize
    ) -> CGSize { ... }
}
```

### Introduce `LayoutItems<Traits>`
As mentioned above; wrapping up this previously array of tuples into a reference type provides pretty significant performance benefits when it comes to just running the mechanics of a layout cycle – I was seeing improvements of about 20-30%; or 0.12s to ~0.07s when running the measure + layout pass where measurement and layout were no-ops; allowing performance benchmarking of the mechanics of the cycle itself. Digging into this a bit; its because copying around the value type and tuples actually has a high enough cost in very hot codepaths to matter. I did this testing in release mode, and the same cost / benefit was still there.

### Introduce `EnvironmentElement`
Because we now have access to the `Environment` everywhere, we can introduce a shorthand API for elements which depend on the `Environment`, removing the need to wrap everything in a nested `EnvironmentReader` or `GeometryReader` (which IMO, hurts readability because of the extra 1-2 levels of nesting):

```
public protocol EnvironmentElement : Element {    
    func content(in size : SizeConstraint, with environment : Environment) -> Element
}
```