### PR TITLE
fixed an issue were labels weren't accessible by default

### DIFF
--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -5,7 +5,6 @@ public struct AttributedLabel: Element, Hashable {
 
     public var attributedText: NSAttributedString
     public var numberOfLines: Int = 0
-    public var isAccessibilityElement = false
 
     /// An offset that will be applied to the rect used by `drawText(in:)`.
     ///
@@ -41,7 +40,6 @@ public struct AttributedLabel: Element, Hashable {
     private func update(label: LabelView) {
         label.attributedText = attributedText
         label.numberOfLines = numberOfLines
-        label.isAccessibilityElement = isAccessibilityElement
         label.textRectOffset = textRectOffset
     }
 

--- a/BlueprintUICommonControls/Sources/Label.swift
+++ b/BlueprintUICommonControls/Sources/Label.swift
@@ -14,7 +14,6 @@ public struct Label: ProxyElement {
     public var numberOfLines: Int = 0
     public var lineBreakMode: NSLineBreakMode = .byWordWrapping
     public var lineHeight: LineHeight = .font
-    public var isAccessibilityElement = false
 
     public init(text: String, configure: (inout Label) -> Void = { _ in }) {
         self.text = text
@@ -57,7 +56,6 @@ public struct Label: ProxyElement {
     public var elementRepresentation: Element {
         AttributedLabel(attributedText: attributedText) { label in
             label.numberOfLines = numberOfLines
-            label.isAccessibilityElement = isAccessibilityElement
 
             switch lineHeight {
             case .custom(let lineHeight, .top):


### PR DESCRIPTION
Labels should almost always be accessibility elements. 
In a situation where one would want to explicitly set `isAccessabilityElement` to `false`  the `AccessibilityBlocker` would suffice. 