### PR TITLE
Lifecycle callbacks

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -141,13 +141,6 @@ public final class BlueprintView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        // ensure final unmount is called if there's still a mounted element tree
-        rootController.traverse { node in
-            node.onUnmount?()
-        }
-    }
-
     ///
     /// Measures the size needed to display the view within then given constraining size,
     /// by measuring the current `element` of the `BlueprintView`.
@@ -410,14 +403,6 @@ extension BlueprintView {
             viewDescription.onDisappear
         }
 
-        var onMount: LifecycleCallback? {
-            viewDescription.onMount
-        }
-
-        var onUnmount: LifecycleCallback? {
-            viewDescription.onUnmount
-        }
-
         let view: UIView
 
         init(node: NativeViewNode) {
@@ -525,7 +510,6 @@ extension BlueprintView {
 
                         contentView.insertSubview(controller.view, at: index)
 
-                        controller.onMount?()
                         if context.viewIsVisible {
                             controller.onAppear?()
                         }
@@ -549,11 +533,10 @@ extension BlueprintView {
 
             for controller in oldChildren.values {
                 func removeChild() {
-                    controller.traverse { node in
-                        if context.viewIsVisible {
+                    if context.viewIsVisible {
+                        controller.traverse { node in
                             node.onDisappear?()
                         }
-                        node.onUnmount?()
                     }
                     controller.view.removeFromSuperview()
                 }

--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -91,6 +91,18 @@ public final class BlueprintView: UIView {
     /// Provides performance metrics about the duration of layouts, updates, etc.
     public weak var metricsDelegate: BlueprintViewMetricsDelegate? = nil
 
+    private var isVisible: Bool = false {
+        didSet {
+            switch (oldValue, isVisible) {
+            case (false, true):
+                handleAppeared()
+            case (true, false):
+                handleDisappeared()
+            default: break
+            }
+        }
+    }
+
     /// Instantiates a view with the given element
     ///
     /// - parameter element: The root element that will be displayed in the view.
@@ -127,6 +139,13 @@ public final class BlueprintView: UIView {
     @available(*, unavailable)
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        // ensure final unmount is called if there's still a mounted element tree
+        rootController.traverse { node in
+            node.onUnmount?()
+        }
     }
 
     ///
@@ -220,6 +239,7 @@ public final class BlueprintView: UIView {
 
     public override func didMoveToWindow() {
         super.didMoveToWindow()
+        isVisible = (window != nil)
         setNeedsViewHierarchyUpdate()
     }
 
@@ -277,7 +297,8 @@ public final class BlueprintView: UIView {
         rootController.update(
             node: rootNode,
             context: .init(
-                appearanceTransitionsEnabled: hasUpdatedViewHierarchy
+                appearanceTransitionsEnabled: hasUpdatedViewHierarchy,
+                viewIsVisible: isVisible
             )
         )
 
@@ -338,6 +359,18 @@ public final class BlueprintView: UIView {
 
         return environment
     }
+
+    private func handleAppeared() {
+        rootController.traverse { node in
+            node.onAppear?()
+        }
+    }
+
+    private func handleDisappeared() {
+        rootController.traverse { node in
+            node.onDisappear?()
+        }
+    }
 }
 
 
@@ -368,6 +401,22 @@ extension BlueprintView {
         private var layoutAttributes: LayoutAttributes
 
         private(set) var children: [(ElementPath, NativeViewController)]
+
+        var onAppear: LifecycleCallback? {
+            viewDescription.onAppear
+        }
+
+        var onDisappear: LifecycleCallback? {
+            viewDescription.onDisappear
+        }
+
+        var onMount: LifecycleCallback? {
+            viewDescription.onMount
+        }
+
+        var onUnmount: LifecycleCallback? {
+            viewDescription.onUnmount
+        }
 
         let view: UIView
 
@@ -476,6 +525,11 @@ extension BlueprintView {
 
                         contentView.insertSubview(controller.view, at: index)
 
+                        controller.onMount?()
+                        if context.viewIsVisible {
+                            controller.onAppear?()
+                        }
+
                         controller.update(node: child, context: context.modified {
                             $0.appearanceTransitionsEnabled = false
                         })
@@ -494,16 +548,36 @@ extension BlueprintView {
             }
 
             for controller in oldChildren.values {
-                if let transition = controller.viewDescription.disappearingTransition {
-                    transition.performDisappearing(view: controller.view, layoutAttributes: controller.layoutAttributes, completion: {
-                        controller.view.removeFromSuperview()
-                    })
-                } else {
+                func removeChild() {
+                    controller.traverse { node in
+                        if context.viewIsVisible {
+                            node.onDisappear?()
+                        }
+                        node.onUnmount?()
+                    }
                     controller.view.removeFromSuperview()
+                }
+
+                if let transition = controller.viewDescription.disappearingTransition {
+                    transition.performDisappearing(
+                        view: controller.view,
+                        layoutAttributes: controller.layoutAttributes,
+                        completion: removeChild
+                    )
+                } else {
+                    removeChild()
                 }
             }
 
             children = newChildren
+        }
+
+        /// Perform a depth-first traversal of the view-backing tree from this node.
+        func traverse(visitor: (NativeViewController) -> Void) {
+            visitor(self)
+            for (_, child) in children {
+                child.traverse(visitor: visitor)
+            }
         }
     }
 }
@@ -516,6 +590,9 @@ extension BlueprintView.NativeViewController {
 
         /// If appearance transitions are enabled for insertions and removals.
         var appearanceTransitionsEnabled: Bool
+
+        /// True if the hosting view is in the view hierarchy
+        var viewIsVisible: Bool
 
         /// Returns a copy of the update context, modified by the changes provided.
         func modified(_ modify: (inout Self) -> Void) -> Self {

--- a/BlueprintUI/Sources/ViewDescription/LifecycleCallback.swift
+++ b/BlueprintUI/Sources/ViewDescription/LifecycleCallback.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// This is the type used by all lifecycle callback hooks.
+///
+/// - Tag: ElementLifecycle
+///
+/// # The Element Lifecycle
+///
+/// View-backed elements have a lifecycle with 3 states:
+///
+/// 1. **Unmounted**
+///
+///    This is the initial state of an element, before a render pass, as well as the final state,
+///    after an element is removed.
+///
+/// 2. **Mounted**
+///
+///    When an element is present during a render pass, it is "mounted". This means the element's
+///    backing view has been created and added to the hosting `BlueprintView`. However, the
+///    element's backing view may not yet be visible, if the hosting view is not part of the view
+///    hierarchy yet.
+///
+/// 3. **Visible**
+///
+///    Finally, when the hosting view is added to the view hierarchy, the element becomes visible.
+///    If the hosting view is already in a view hierarchy when the element is mounted, it will
+///    immediately transition to this state.
+///
+/// There are 4 lifecycle events that occur when an element transitions between these states. An
+/// element will always be mounted before it is visible, and will disappear before it is unmounted.
+///
+/// The following diagram shows how an element may transition between states:
+///
+/// ```
+///           ┌───onMount───┐   ┌──onAppear───┐
+///           │             │   │             │
+///   ┌───────┴───┐     ┌───▼───┴───┐     ┌───▼───────┐
+///   │ Unmounted │     │  Mounted  │     │  Visible  │
+///   └───────▲───┘     └───┬───▲───┘     └───┬───────┘
+///           │             │   │             │
+///           └──onUnmount──┘   └─onDisappear─┘
+/// ```
+///
+public typealias LifecycleCallback = () -> Void

--- a/BlueprintUI/Sources/ViewDescription/LifecycleCallback.swift
+++ b/BlueprintUI/Sources/ViewDescription/LifecycleCallback.swift
@@ -2,43 +2,4 @@ import Foundation
 
 /// This is the type used by all lifecycle callback hooks.
 ///
-/// - Tag: ElementLifecycle
-///
-/// # The Element Lifecycle
-///
-/// View-backed elements have a lifecycle with 3 states:
-///
-/// 1. **Unmounted**
-///
-///    This is the initial state of an element, before a render pass, as well as the final state,
-///    after an element is removed.
-///
-/// 2. **Mounted**
-///
-///    When an element is present during a render pass, it is "mounted". This means the element's
-///    backing view has been created and added to the hosting `BlueprintView`. However, the
-///    element's backing view may not yet be visible, if the hosting view is not part of the view
-///    hierarchy yet.
-///
-/// 3. **Visible**
-///
-///    Finally, when the hosting view is added to the view hierarchy, the element becomes visible.
-///    If the hosting view is already in a view hierarchy when the element is mounted, it will
-///    immediately transition to this state.
-///
-/// There are 4 lifecycle events that occur when an element transitions between these states. An
-/// element will always be mounted before it is visible, and will disappear before it is unmounted.
-///
-/// The following diagram shows how an element may transition between states:
-///
-/// ```
-///           ┌───onMount───┐   ┌──onAppear───┐
-///           │             │   │             │
-///   ┌───────┴───┐     ┌───▼───┴───┐     ┌───▼───────┐
-///   │ Unmounted │     │  Mounted  │     │  Visible  │
-///   └───────▲───┘     └───┬───▲───┘     └───┬───────┘
-///           │             │   │             │
-///           └──onUnmount──┘   └─onDisappear─┘
-/// ```
-///
 public typealias LifecycleCallback = () -> Void

--- a/BlueprintUI/Sources/ViewDescription/ViewDescription.swift
+++ b/BlueprintUI/Sources/ViewDescription/ViewDescription.swift
@@ -34,6 +34,7 @@ extension NativeView where Self: UIView {
 ///   additional subviews.
 /// - How to animate transitions for appearance, layout changes, and
 ///   disappearance.
+/// - Hooks to be called during lifecycle events.
 ///
 /// A view description does **not** contain a concrete view instance. It simply
 /// contains functionality for creating, updating, and animating view instances.
@@ -47,6 +48,11 @@ public struct ViewDescription {
     private let _layoutTransition: LayoutTransition
     private let _appearingTransition: VisibilityTransition?
     private let _disappearingTransition: VisibilityTransition?
+
+    let onAppear: LifecycleCallback?
+    let onDisappear: LifecycleCallback?
+    let onMount: LifecycleCallback?
+    let onUnmount: LifecycleCallback?
 
     /// Generates a view description for the given view class.
     /// - parameter viewType: The class of the described view.
@@ -88,6 +94,11 @@ public struct ViewDescription {
         _layoutTransition = configuration.layoutTransition
         _appearingTransition = configuration.appearingTransition
         _disappearingTransition = configuration.disappearingTransition
+
+        onAppear = configuration.onAppear
+        onDisappear = configuration.onDisappear
+        onMount = configuration.onMount
+        onUnmount = configuration.onUnmount
     }
 
     public var viewType: UIView.Type {
@@ -151,6 +162,18 @@ extension ViewDescription {
 
         /// The transition to use when this view disappears.
         public var disappearingTransition: VisibilityTransition? = nil
+
+        /// A hook to call when the element appears.
+        public var onAppear: LifecycleCallback?
+
+        /// A hook to call when the element disappears.
+        public var onDisappear: LifecycleCallback?
+
+        /// A hook to call when the element is mounted.
+        public var onMount: LifecycleCallback?
+
+        /// A hook to call when the element is unmounted.
+        public var onUnmount: LifecycleCallback?
 
         /// Initializes a default configuration object.
         public init() {

--- a/BlueprintUI/Sources/ViewDescription/ViewDescription.swift
+++ b/BlueprintUI/Sources/ViewDescription/ViewDescription.swift
@@ -51,8 +51,6 @@ public struct ViewDescription {
 
     let onAppear: LifecycleCallback?
     let onDisappear: LifecycleCallback?
-    let onMount: LifecycleCallback?
-    let onUnmount: LifecycleCallback?
 
     /// Generates a view description for the given view class.
     /// - parameter viewType: The class of the described view.
@@ -97,8 +95,6 @@ public struct ViewDescription {
 
         onAppear = configuration.onAppear
         onDisappear = configuration.onDisappear
-        onMount = configuration.onMount
-        onUnmount = configuration.onUnmount
     }
 
     public var viewType: UIView.Type {
@@ -168,12 +164,6 @@ extension ViewDescription {
 
         /// A hook to call when the element disappears.
         public var onDisappear: LifecycleCallback?
-
-        /// A hook to call when the element is mounted.
-        public var onMount: LifecycleCallback?
-
-        /// A hook to call when the element is unmounted.
-        public var onUnmount: LifecycleCallback?
 
         /// Initializes a default configuration object.
         public init() {

--- a/BlueprintUI/Tests/BlueprintViewAdditions.swift
+++ b/BlueprintUI/Tests/BlueprintViewAdditions.swift
@@ -32,4 +32,8 @@ extension BlueprintView {
 
         subviews.first?.subviews ?? []
     }
+
+    func ensureLayoutPass() {
+        _ = currentNativeViewControllers
+    }
 }

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -394,6 +394,136 @@ class BlueprintViewTests: XCTestCase {
             }
         }
     }
+
+    func test_lifecycleEvents() {
+        var events: [LifecycleTestEvent] = []
+        var expectedEvents: [LifecycleTestEvent] = []
+
+        let element = LifecycleTestElement(
+            onMount: {
+                events.append(.mount(1))
+            },
+            onUnmount: {
+                events.append(.unmount(1))
+            },
+            onAppear: {
+                events.append(.appear(1))
+            },
+            onDisappear: {
+                events.append(.disappear(1))
+            },
+            wrapped: LifecycleTestElement(
+                onMount: {
+                    events.append(.mount(2))
+                },
+                onUnmount: {
+                    events.append(.unmount(2))
+                },
+                onAppear: {
+                    events.append(.appear(2))
+                },
+                onDisappear: {
+                    events.append(.disappear(2))
+                },
+                wrapped: nil
+            )
+        )
+
+        let view = BlueprintView()
+
+        XCTAssertEqual(events, expectedEvents)
+
+        // Add element before visible
+
+        view.element = element
+        view.ensureLayoutPass()
+
+        expectedEvents.append(.mount(1))
+        expectedEvents.append(.mount(2))
+        XCTAssertEqual(events, expectedEvents)
+
+        // Become visible
+
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.addSubview(view)
+
+        expectedEvents.append(.appear(1))
+        expectedEvents.append(.appear(2))
+        XCTAssertEqual(events, expectedEvents)
+
+        // Remove element while visible
+
+        view.element = nil
+        view.ensureLayoutPass()
+
+        expectedEvents.append(.disappear(1))
+        expectedEvents.append(.unmount(1))
+        expectedEvents.append(.disappear(2))
+        expectedEvents.append(.unmount(2))
+        XCTAssertEqual(events, expectedEvents)
+
+        // Add element while visible
+
+        view.element = element
+        view.ensureLayoutPass()
+
+        expectedEvents.append(.mount(1))
+        expectedEvents.append(.appear(1))
+        expectedEvents.append(.mount(2))
+        expectedEvents.append(.appear(2))
+        XCTAssertEqual(events, expectedEvents)
+
+        // Become not visible while element is set
+
+        view.removeFromSuperview()
+
+        expectedEvents.append(.disappear(1))
+        expectedEvents.append(.disappear(2))
+        XCTAssertEqual(events, expectedEvents)
+
+        // Remove element while not visible
+
+        view.element = nil
+        view.ensureLayoutPass()
+
+        expectedEvents.append(.unmount(1))
+        expectedEvents.append(.unmount(2))
+        XCTAssertEqual(events, expectedEvents)
+    }
+
+    func test_unmountOnDeinit() {
+        var view: BlueprintView? = BlueprintView()
+
+        var events: [LifecycleTestEvent] = []
+        var expectedEvents: [LifecycleTestEvent] = []
+
+        let element = LifecycleTestElement(
+            onMount: {
+                events.append(.mount(1))
+            },
+            onUnmount: {
+                events.append(.unmount(1))
+            },
+            onAppear: {
+                events.append(.appear(1))
+            },
+            onDisappear: {
+                events.append(.disappear(1))
+            },
+            wrapped: nil
+        )
+
+        view?.element = element
+        view?.ensureLayoutPass()
+
+        expectedEvents.append(.mount(1))
+        XCTAssertEqual(events, expectedEvents)
+
+        view = nil
+
+        expectedEvents.append(.unmount(1))
+        XCTAssertEqual(events, expectedEvents)
+    }
 }
 
 fileprivate struct MeasurableElement: Element {
@@ -480,3 +610,51 @@ private struct TestContainer: Element {
         }
     }
 }
+
+private struct LifecycleTestElement: Element {
+    var onMount: LifecycleCallback
+    var onUnmount: LifecycleCallback
+
+    var onAppear: LifecycleCallback
+    var onDisappear: LifecycleCallback
+
+    var wrapped: Element?
+
+    var content: ElementContent {
+        if let wrapped = wrapped {
+            return ElementContent(child: wrapped)
+        } else {
+            return ElementContent(intrinsicSize: .zero)
+        }
+    }
+
+    func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
+        UIView.describe { config in
+            config.onMount = onMount
+            config.onUnmount = onUnmount
+            config.onAppear = onAppear
+            config.onDisappear = onDisappear
+        }
+    }
+}
+
+private enum LifecycleTestEvent: Equatable, CustomStringConvertible {
+    case appear(Int)
+    case disappear(Int)
+    case mount(Int)
+    case unmount(Int)
+
+    var description: String {
+        switch self {
+        case .appear(let i):
+            return "appear(\(i))"
+        case .disappear(let i):
+            return "disappear(\(i))"
+        case .mount(let i):
+            return "mount(\(i))"
+        case .unmount(let i):
+            return "unmount(\(i))"
+        }
+    }
+}
+

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -400,12 +400,6 @@ class BlueprintViewTests: XCTestCase {
         var expectedEvents: [LifecycleTestEvent] = []
 
         let element = LifecycleTestElement(
-            onMount: {
-                events.append(.mount(1))
-            },
-            onUnmount: {
-                events.append(.unmount(1))
-            },
             onAppear: {
                 events.append(.appear(1))
             },
@@ -413,12 +407,6 @@ class BlueprintViewTests: XCTestCase {
                 events.append(.disappear(1))
             },
             wrapped: LifecycleTestElement(
-                onMount: {
-                    events.append(.mount(2))
-                },
-                onUnmount: {
-                    events.append(.unmount(2))
-                },
                 onAppear: {
                     events.append(.appear(2))
                 },
@@ -438,8 +426,6 @@ class BlueprintViewTests: XCTestCase {
         view.element = element
         view.ensureLayoutPass()
 
-        expectedEvents.append(.mount(1))
-        expectedEvents.append(.mount(2))
         XCTAssertEqual(events, expectedEvents)
 
         // Become visible
@@ -457,9 +443,7 @@ class BlueprintViewTests: XCTestCase {
         view.ensureLayoutPass()
 
         expectedEvents.append(.disappear(1))
-        expectedEvents.append(.unmount(1))
         expectedEvents.append(.disappear(2))
-        expectedEvents.append(.unmount(2))
         XCTAssertEqual(events, expectedEvents)
 
         // Add element while visible
@@ -467,9 +451,7 @@ class BlueprintViewTests: XCTestCase {
         view.element = element
         view.ensureLayoutPass()
 
-        expectedEvents.append(.mount(1))
         expectedEvents.append(.appear(1))
-        expectedEvents.append(.mount(2))
         expectedEvents.append(.appear(2))
         XCTAssertEqual(events, expectedEvents)
 
@@ -486,42 +468,6 @@ class BlueprintViewTests: XCTestCase {
         view.element = nil
         view.ensureLayoutPass()
 
-        expectedEvents.append(.unmount(1))
-        expectedEvents.append(.unmount(2))
-        XCTAssertEqual(events, expectedEvents)
-    }
-
-    func test_unmountOnDeinit() {
-        var view: BlueprintView? = BlueprintView()
-
-        var events: [LifecycleTestEvent] = []
-        var expectedEvents: [LifecycleTestEvent] = []
-
-        let element = LifecycleTestElement(
-            onMount: {
-                events.append(.mount(1))
-            },
-            onUnmount: {
-                events.append(.unmount(1))
-            },
-            onAppear: {
-                events.append(.appear(1))
-            },
-            onDisappear: {
-                events.append(.disappear(1))
-            },
-            wrapped: nil
-        )
-
-        view?.element = element
-        view?.ensureLayoutPass()
-
-        expectedEvents.append(.mount(1))
-        XCTAssertEqual(events, expectedEvents)
-
-        view = nil
-
-        expectedEvents.append(.unmount(1))
         XCTAssertEqual(events, expectedEvents)
     }
 }
@@ -612,9 +558,6 @@ private struct TestContainer: Element {
 }
 
 private struct LifecycleTestElement: Element {
-    var onMount: LifecycleCallback
-    var onUnmount: LifecycleCallback
-
     var onAppear: LifecycleCallback
     var onDisappear: LifecycleCallback
 
@@ -630,8 +573,6 @@ private struct LifecycleTestElement: Element {
 
     func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
         UIView.describe { config in
-            config.onMount = onMount
-            config.onUnmount = onUnmount
             config.onAppear = onAppear
             config.onDisappear = onDisappear
         }
@@ -641,8 +582,6 @@ private struct LifecycleTestElement: Element {
 private enum LifecycleTestEvent: Equatable, CustomStringConvertible {
     case appear(Int)
     case disappear(Int)
-    case mount(Int)
-    case unmount(Int)
 
     var description: String {
         switch self {
@@ -650,10 +589,6 @@ private enum LifecycleTestEvent: Equatable, CustomStringConvertible {
             return "appear(\(i))"
         case .disappear(let i):
             return "disappear(\(i))"
-        case .mount(let i):
-            return "mount(\(i))"
-        case .unmount(let i):
-            return "unmount(\(i))"
         }
     }
 }

--- a/BlueprintUICommonControls/Sources/LifecycleObserver.swift
+++ b/BlueprintUICommonControls/Sources/LifecycleObserver.swift
@@ -2,31 +2,19 @@ import BlueprintUI
 
 /// Allows element lifecycle callbacks to be inserted anywhere into the element tree.
 ///
-/// For more details about lifecycle hooks, see `LifecycleCallback`.
-///
-/// ## In Xcode
-/// [The Element Lifecycle](x-source-tag://ElementLifecycle)
-///
 public struct LifecycleObserver: Element {
     public var wrapped: Element
 
     public var onAppear: LifecycleCallback?
     public var onDisappear: LifecycleCallback?
 
-    public var onMount: LifecycleCallback?
-    public var onUnmount: LifecycleCallback?
-
     public init(
         onAppear: LifecycleCallback? = nil,
         onDisappear: LifecycleCallback? = nil,
-        onMount: LifecycleCallback? = nil,
-        onUnmount: LifecycleCallback? = nil,
         wrapping: Element
     ) {
         self.onAppear = onAppear
         self.onDisappear = onDisappear
-        self.onMount = onMount
-        self.onUnmount = onUnmount
         wrapped = wrapping
     }
 
@@ -38,8 +26,6 @@ public struct LifecycleObserver: Element {
         PassthroughView.describe { config in
             config.onAppear = onAppear
             config.onDisappear = onDisappear
-            config.onMount = onMount
-            config.onUnmount = onUnmount
         }
     }
 }
@@ -48,68 +34,20 @@ public struct LifecycleObserver: Element {
 extension LifecycleObserver {
     /// Adds a hook that will be called when this element appears.
     ///
-    /// For more details about lifecycle hooks, see `LifecycleCallback`.
-    ///
-    /// ## In Xcode
-    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
-    ///
     public func onAppear(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
         LifecycleObserver(
             onAppear: onAppear + callback,
             onDisappear: onDisappear,
-            onMount: onMount,
-            onUnmount: onUnmount,
             wrapping: wrapped
         )
     }
 
     /// Adds a hook that will be called when this element disappears.
     ///
-    /// For more details about lifecycle hooks, see `LifecycleCallback`.
-    ///
-    /// ## In Xcode
-    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
-    ///
     public func onDisappear(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
         LifecycleObserver(
             onAppear: onAppear,
             onDisappear: onDisappear + callback,
-            onMount: onMount,
-            onUnmount: onUnmount,
-            wrapping: wrapped
-        )
-    }
-
-    /// Adds a hook that will be called when this element is mounted.
-    ///
-    /// For more details about lifecycle hooks, see `LifecycleCallback`.
-    ///
-    /// ## In Xcode
-    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
-    ///
-    public func onMount(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
-        LifecycleObserver(
-            onAppear: onAppear,
-            onDisappear: onDisappear,
-            onMount: onMount + callback,
-            onUnmount: onUnmount,
-            wrapping: wrapped
-        )
-    }
-
-    /// Adds a hook that will be called when this element is unmounted.
-    ///
-    /// For more details about lifecycle hooks, see `LifecycleCallback`.
-    ///
-    /// ## In Xcode
-    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
-    ///
-    public func onUnmount(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
-        LifecycleObserver(
-            onAppear: onAppear,
-            onDisappear: onDisappear,
-            onMount: onMount,
-            onUnmount: onUnmount + callback,
             wrapping: wrapped
         )
     }
@@ -118,46 +56,14 @@ extension LifecycleObserver {
 extension Element {
     /// Adds a hook that will be called when this element appears.
     ///
-    /// For more details about lifecycle hooks, see `LifecycleCallback`.
-    ///
-    /// ## In Xcode
-    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
-    ///
     public func onAppear(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
         LifecycleObserver(onAppear: callback, wrapping: self)
     }
 
     /// Adds a hook that will be called when this element disappears.
     ///
-    /// For more details about lifecycle hooks, see `LifecycleCallback`.
-    ///
-    /// ## In Xcode
-    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
-    ///
     public func onDisappear(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
         LifecycleObserver(onDisappear: callback, wrapping: self)
-    }
-
-    /// Adds a hook that will be called when this element is mounted.
-    ///
-    /// For more details about lifecycle hooks, see `LifecycleCallback`.
-    ///
-    /// ## In Xcode
-    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
-    ///
-    public func onMount(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
-        LifecycleObserver(onMount: callback, wrapping: self)
-    }
-
-    /// Adds a hook that will be called when this element is unmounted.
-    ///
-    /// For more details about lifecycle hooks, see `LifecycleCallback`.
-    ///
-    /// ## In Xcode
-    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
-    ///
-    public func onUnmount(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
-        LifecycleObserver(onUnmount: callback, wrapping: self)
     }
 }
 

--- a/BlueprintUICommonControls/Sources/LifecycleObserver.swift
+++ b/BlueprintUICommonControls/Sources/LifecycleObserver.swift
@@ -1,0 +1,173 @@
+import BlueprintUI
+
+/// Allows element lifecycle callbacks to be inserted anywhere into the element tree.
+///
+/// For more details about lifecycle hooks, see `LifecycleCallback`.
+///
+/// ## In Xcode
+/// [The Element Lifecycle](x-source-tag://ElementLifecycle)
+///
+public struct LifecycleObserver: Element {
+    public var wrapped: Element
+
+    public var onAppear: LifecycleCallback?
+    public var onDisappear: LifecycleCallback?
+
+    public var onMount: LifecycleCallback?
+    public var onUnmount: LifecycleCallback?
+
+    public init(
+        onAppear: LifecycleCallback? = nil,
+        onDisappear: LifecycleCallback? = nil,
+        onMount: LifecycleCallback? = nil,
+        onUnmount: LifecycleCallback? = nil,
+        wrapping: Element
+    ) {
+        self.onAppear = onAppear
+        self.onDisappear = onDisappear
+        self.onMount = onMount
+        self.onUnmount = onUnmount
+        wrapped = wrapping
+    }
+
+    public var content: ElementContent {
+        ElementContent(child: wrapped)
+    }
+
+    public func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
+        PassthroughView.describe { config in
+            config.onAppear = onAppear
+            config.onDisappear = onDisappear
+            config.onMount = onMount
+            config.onUnmount = onUnmount
+        }
+    }
+}
+
+// These extensions collapse chained callbacks into a single element
+extension LifecycleObserver {
+    /// Adds a hook that will be called when this element appears.
+    ///
+    /// For more details about lifecycle hooks, see `LifecycleCallback`.
+    ///
+    /// ## In Xcode
+    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
+    ///
+    public func onAppear(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
+        LifecycleObserver(
+            onAppear: onAppear + callback,
+            onDisappear: onDisappear,
+            onMount: onMount,
+            onUnmount: onUnmount,
+            wrapping: wrapped
+        )
+    }
+
+    /// Adds a hook that will be called when this element disappears.
+    ///
+    /// For more details about lifecycle hooks, see `LifecycleCallback`.
+    ///
+    /// ## In Xcode
+    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
+    ///
+    public func onDisappear(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
+        LifecycleObserver(
+            onAppear: onAppear,
+            onDisappear: onDisappear + callback,
+            onMount: onMount,
+            onUnmount: onUnmount,
+            wrapping: wrapped
+        )
+    }
+
+    /// Adds a hook that will be called when this element is mounted.
+    ///
+    /// For more details about lifecycle hooks, see `LifecycleCallback`.
+    ///
+    /// ## In Xcode
+    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
+    ///
+    public func onMount(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
+        LifecycleObserver(
+            onAppear: onAppear,
+            onDisappear: onDisappear,
+            onMount: onMount + callback,
+            onUnmount: onUnmount,
+            wrapping: wrapped
+        )
+    }
+
+    /// Adds a hook that will be called when this element is unmounted.
+    ///
+    /// For more details about lifecycle hooks, see `LifecycleCallback`.
+    ///
+    /// ## In Xcode
+    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
+    ///
+    public func onUnmount(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
+        LifecycleObserver(
+            onAppear: onAppear,
+            onDisappear: onDisappear,
+            onMount: onMount,
+            onUnmount: onUnmount + callback,
+            wrapping: wrapped
+        )
+    }
+}
+
+extension Element {
+    /// Adds a hook that will be called when this element appears.
+    ///
+    /// For more details about lifecycle hooks, see `LifecycleCallback`.
+    ///
+    /// ## In Xcode
+    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
+    ///
+    public func onAppear(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
+        LifecycleObserver(onAppear: callback, wrapping: self)
+    }
+
+    /// Adds a hook that will be called when this element disappears.
+    ///
+    /// For more details about lifecycle hooks, see `LifecycleCallback`.
+    ///
+    /// ## In Xcode
+    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
+    ///
+    public func onDisappear(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
+        LifecycleObserver(onDisappear: callback, wrapping: self)
+    }
+
+    /// Adds a hook that will be called when this element is mounted.
+    ///
+    /// For more details about lifecycle hooks, see `LifecycleCallback`.
+    ///
+    /// ## In Xcode
+    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
+    ///
+    public func onMount(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
+        LifecycleObserver(onMount: callback, wrapping: self)
+    }
+
+    /// Adds a hook that will be called when this element is unmounted.
+    ///
+    /// For more details about lifecycle hooks, see `LifecycleCallback`.
+    ///
+    /// ## In Xcode
+    /// [The Element Lifecycle](x-source-tag://ElementLifecycle)
+    ///
+    public func onUnmount(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
+        LifecycleObserver(onUnmount: callback, wrapping: self)
+    }
+}
+
+/// Concatenate callbacks.
+private func + (lhs: LifecycleCallback?, rhs: @escaping LifecycleCallback) -> LifecycleCallback {
+    if let lhs = lhs {
+        return {
+            lhs()
+            rhs()
+        }
+    }
+    return rhs
+}

--- a/BlueprintUICommonControls/Tests/Sources/LifecycleObserverTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/LifecycleObserverTests.swift
@@ -6,8 +6,6 @@ final class LifecycleObserverTests: XCTestCase {
     enum Event: Equatable {
         case appear(Int)
         case disappear(Int)
-        case mount(Int)
-        case unmount(Int)
     }
 
     func test_coalescingCallbacks() {
@@ -16,8 +14,6 @@ final class LifecycleObserverTests: XCTestCase {
         let element = LifecycleObserver(
             onAppear: { events.append(.appear(1)) },
             onDisappear: { events.append(.disappear(1)) },
-            onMount: { events.append(.mount(1)) },
-            onUnmount: { events.append(.unmount(1)) },
             wrapping: Empty()
         )
         .onAppear {
@@ -26,12 +22,6 @@ final class LifecycleObserverTests: XCTestCase {
         .onDisappear {
             events.append(.disappear(2))
         }
-        .onMount {
-            events.append(.mount(2))
-        }
-        .onUnmount {
-            events.append(.unmount(2))
-        }
 
         element.onAppear?()
         XCTAssertEqual(events, [.appear(1), .appear(2)])
@@ -39,14 +29,6 @@ final class LifecycleObserverTests: XCTestCase {
         events.removeAll()
         element.onDisappear?()
         XCTAssertEqual(events, [.disappear(1), .disappear(2)])
-
-        events.removeAll()
-        element.onMount?()
-        XCTAssertEqual(events, [.mount(1), .mount(2)])
-
-        events.removeAll()
-        element.onUnmount?()
-        XCTAssertEqual(events, [.unmount(1), .unmount(2)])
     }
 
     func test_viewDescription() {
@@ -55,8 +37,6 @@ final class LifecycleObserverTests: XCTestCase {
         let element = LifecycleObserver(
             onAppear: { events.append(.appear(1)) },
             onDisappear: { events.append(.disappear(1)) },
-            onMount: { events.append(.mount(1)) },
-            onUnmount: { events.append(.unmount(1)) },
             wrapping: Empty()
         )
 
@@ -74,13 +54,5 @@ final class LifecycleObserverTests: XCTestCase {
         events.removeAll()
         viewDescription?.onDisappear?()
         XCTAssertEqual(events, [.disappear(1)])
-
-        events.removeAll()
-        viewDescription?.onMount?()
-        XCTAssertEqual(events, [.mount(1)])
-
-        events.removeAll()
-        viewDescription?.onUnmount?()
-        XCTAssertEqual(events, [.unmount(1)])
     }
 }

--- a/BlueprintUICommonControls/Tests/Sources/LifecycleObserverTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/LifecycleObserverTests.swift
@@ -1,0 +1,86 @@
+import BlueprintUICommonControls
+import XCTest
+@testable import BlueprintUI
+
+final class LifecycleObserverTests: XCTestCase {
+    enum Event: Equatable {
+        case appear(Int)
+        case disappear(Int)
+        case mount(Int)
+        case unmount(Int)
+    }
+
+    func test_coalescingCallbacks() {
+        var events: [Event] = []
+
+        let element = LifecycleObserver(
+            onAppear: { events.append(.appear(1)) },
+            onDisappear: { events.append(.disappear(1)) },
+            onMount: { events.append(.mount(1)) },
+            onUnmount: { events.append(.unmount(1)) },
+            wrapping: Empty()
+        )
+        .onAppear {
+            events.append(.appear(2))
+        }
+        .onDisappear {
+            events.append(.disappear(2))
+        }
+        .onMount {
+            events.append(.mount(2))
+        }
+        .onUnmount {
+            events.append(.unmount(2))
+        }
+
+        element.onAppear?()
+        XCTAssertEqual(events, [.appear(1), .appear(2)])
+
+        events.removeAll()
+        element.onDisappear?()
+        XCTAssertEqual(events, [.disappear(1), .disappear(2)])
+
+        events.removeAll()
+        element.onMount?()
+        XCTAssertEqual(events, [.mount(1), .mount(2)])
+
+        events.removeAll()
+        element.onUnmount?()
+        XCTAssertEqual(events, [.unmount(1), .unmount(2)])
+    }
+
+    func test_viewDescription() {
+        var events: [Event] = []
+
+        let element = LifecycleObserver(
+            onAppear: { events.append(.appear(1)) },
+            onDisappear: { events.append(.disappear(1)) },
+            onMount: { events.append(.mount(1)) },
+            onUnmount: { events.append(.unmount(1)) },
+            wrapping: Empty()
+        )
+
+        let viewDescription = element.backingViewDescription(
+            with: ViewDescriptionContext(
+                bounds: .zero,
+                subtreeExtent: nil,
+                environment: .empty
+            )
+        )
+
+        viewDescription?.onAppear?()
+        XCTAssertEqual(events, [.appear(1)])
+
+        events.removeAll()
+        viewDescription?.onDisappear?()
+        XCTAssertEqual(events, [.disappear(1)])
+
+        events.removeAll()
+        viewDescription?.onMount?()
+        XCTAssertEqual(events, [.mount(1)])
+
+        events.removeAll()
+        viewDescription?.onUnmount?()
+        XCTAssertEqual(events, [.unmount(1)])
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [The `Environment` is now automatically propagated through to nested `BlueprintViews` within a displayed `Element` hierarchy](https://github.com/square/Blueprint/pull/234). This means that if your view-backed `Elements` themselves contain a `BlueprintView` (eg to manage their own state), that nested view will now automatically receive the correct `Environment` across `BlueprintView` boundaries. If you were previously manually propagating `Environment` values you may remove this code. If you would like to opt-out of this behavior; you can set `view.automaticallyInheritsEnvironmentFromContainingBlueprintViews = false` on your `BlueprintView`.
 
+- [Lifecycle hooks][#244]. You can hook into 4 lifecycle events:
+  - `onMount` occurs when a backing view has been created and attached to its hosting view's view hierarchy
+  - `onAppear` occurs when a mounted element becomes visible
+  - `onDisappear` occurs when a visible element is no longer visible
+  - `onUnmount` occurs when a mounted element is removed from the hosting view's view hierarchy
+
+  Each hook is can be added with a modifier of the same name:
+
+  ```swift
+  element.onAppear { ... }
+  ```
+
 ### Removed
 
 - [Removed support for / deprecated iOS 11](https://github.com/square/Blueprint/pull/250).
@@ -617,6 +629,7 @@ searchField
 [0.3.1]: https://github.com/square/Blueprint/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/square/Blueprint/compare/0.2.2...0.3.0
 [0.2.2]: https://github.com/square/Blueprint/releases/tag/0.2.2
+[#244]: https://github.com/square/Blueprint/pull/244
 [#209]: https://github.com/square/Blueprint/pull/209
 [#176]: https://github.com/square/Blueprint/pull/176
 [#175]: https://github.com/square/Blueprint/pull/175

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [The `Environment` is now automatically propagated through to nested `BlueprintViews` within a displayed `Element` hierarchy](https://github.com/square/Blueprint/pull/234). This means that if your view-backed `Elements` themselves contain a `BlueprintView` (eg to manage their own state), that nested view will now automatically receive the correct `Environment` across `BlueprintView` boundaries. If you were previously manually propagating `Environment` values you may remove this code. If you would like to opt-out of this behavior; you can set `view.automaticallyInheritsEnvironmentFromContainingBlueprintViews = false` on your `BlueprintView`.
 
-- [Lifecycle hooks][#244]. You can hook into 4 lifecycle events:
-  - `onMount` occurs when a backing view has been created and attached to its hosting view's view hierarchy
-  - `onAppear` occurs when a mounted element becomes visible
-  - `onDisappear` occurs when a visible element is no longer visible
-  - `onUnmount` occurs when a mounted element is removed from the hosting view's view hierarchy
-
-  Each hook is can be added with a modifier of the same name:
-
+- [Lifecycle hooks][#244]. You can hook into lifecycle events when an element's visibility changes.
   ```swift
-  element.onAppear { ... }
+  element
+    .onAppear {
+      // runs when `element` appears
+    }
+    .onDisappear {
+      // runs when `element` disappears
+    }
   ```
 
 ### Removed


### PR DESCRIPTION
This PR introduces 4 lifecycle callbacks. Here's a state diagram:

```
          ┌───onMount───┐   ┌──onAppear───┐
          │             │   │             │
  ┌───────┴───┐     ┌───▼───┴───┐     ┌───▼───────┐
  │ Unmounted │     │  Mounted  │     │  Visible  │
  └───────▲───┘     └───┬───▲───┘     └───┬───────┘
          │             │   │             │
          └──onUnmount──┘   └─onDisappear─┘
```

"Mounting" refers to creating a backing view and adding it as a subview to the hosting `BlueprintView` as part of a render pass. This is distinct from appearing: an element may or may not become visible immediately after mounting, and it may disappear & reappear without unmounting.

These are also distinct from the appearing/disappearing _transitions_, which currently run during mounting & unmounting regardless of whether the hosting view is visible (and in the case of appearance, are suppressed when nested in another appearance transition). We could probably update transitions to match this lifecycle, but I didn't attempt it in this PR.

There's more documentation on the `LifecycleCallback` type.

Fixes #48 