### PR TITLE
Introduce onDidLayoutContents on BlueprintView

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -90,7 +90,10 @@ public final class BlueprintView: UIView {
     
     /// Provides performance metrics about the duration of layouts, updates, etc.
     public weak var metricsDelegate : BlueprintViewMetricsDelegate? = nil
-
+    
+    /// Called after the view lays out its content, as a result of a new element, a bounds change, etc.
+    public var onDidLayoutContents : (() -> ())? = nil
+    
     /// Instantiates a view with the given element
     ///
     /// - parameter element: The root element that will be displayed in the view.
@@ -277,6 +280,8 @@ public final class BlueprintView: UIView {
                 appearanceTransitionsEnabled: hasUpdatedViewHierarchy
             )
         )
+        
+        self.onDidLayoutContents?()
 
         Logger.logViewUpdateEnd(view: self)
         let viewUpdateEndDate = Date()

--- a/BlueprintUI/Tests/AdaptedEnvironmentTests.swift
+++ b/BlueprintUI/Tests/AdaptedEnvironmentTests.swift
@@ -21,7 +21,7 @@ class AdaptedEnvironmentTests : XCTestCase {
         
         view.layoutIfNeeded()
         
-        XCTAssertEqual(environment?[TestingKey1], "adapted1")
+        XCTAssertEqual(environment?[TestingKey1.self], "adapted1")
     }
     
     func test_wrapping_multiple() {
@@ -41,8 +41,8 @@ class AdaptedEnvironmentTests : XCTestCase {
         view.layoutIfNeeded()
         
         // The inner-most change; the one closest to the element; should be the value we get.
-        XCTAssertEqual(environment?[TestingKey1], "adapted1.1")
-        XCTAssertEqual(environment?[TestingKey2], "adapted2.1")
+        XCTAssertEqual(environment?[TestingKey1.self], "adapted1.1")
+        XCTAssertEqual(environment?[TestingKey2.self], "adapted2.1")
         
         // Ensure we collapsed the AdaptedEnvironments down to one level of wrapping.
         XCTAssertTrue((element as? AdaptedEnvironment)?.wrapped is TestElement)

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -82,6 +82,32 @@ class BlueprintViewTests: XCTestCase {
             }
         }
     }
+    
+    func test_onDidLayoutContents() {
+        let view = BlueprintView()
+        
+        var callCount : Int = 0
+        
+        view.onDidLayoutContents = {
+            callCount += 1
+        }
+        
+        XCTAssertEqual(callCount, 0)
+        
+        view.element = SimpleViewElement(color: .red)
+        XCTAssertEqual(callCount, 0)
+        
+        // Should not get called until an explicit layout event.
+        view.layoutIfNeeded()
+        XCTAssertEqual(callCount, 1)
+        
+        view.element = SimpleViewElement(color: .red)
+        XCTAssertEqual(callCount, 1)
+        
+        // Ensure setting a new element still calls the callback.
+        view.layoutIfNeeded()
+        XCTAssertEqual(callCount, 2)
+    }
 
     func test_displaysSimpleView() {
 

--- a/BlueprintUI/Tests/EnvironmentTests.swift
+++ b/BlueprintUI/Tests/EnvironmentTests.swift
@@ -148,19 +148,19 @@ class EnvironmentTests: XCTestCase {
     
     func test_merged() {
         var lhs = Environment.empty
-        lhs[TestKey] = .wrong
-        lhs[LHSTestKey] = 2
+        lhs[TestKey.self] = .wrong
+        lhs[LHSTestKey.self] = 2
         
         
         var rhs = Environment.empty
-        rhs[TestKey] = .right
-        rhs[RHSTestKey] = 3
+        rhs[TestKey.self] = .right
+        rhs[RHSTestKey.self] = 3
         
         let output = lhs.merged(prioritizing: rhs)
         
-        XCTAssertEqual(output[TestKey], .right)
-        XCTAssertEqual(output[LHSTestKey], 2)
-        XCTAssertEqual(output[RHSTestKey], 3)
+        XCTAssertEqual(output[TestKey.self], .right)
+        XCTAssertEqual(output[LHSTestKey.self], 2)
+        XCTAssertEqual(output[RHSTestKey.self], 3)
         
         enum LHSTestKey : EnvironmentKey { static let defaultValue: Int? = nil }
         enum RHSTestKey : EnvironmentKey { static let defaultValue: Int? = nil }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [The `Environment` is now automatically propagated through to nested `BlueprintViews` within a displayed `Element` hierarchy](https://github.com/square/Blueprint/pull/234). This means that if your view-backed `Elements` themselves contain a `BlueprintView` (eg to manage their own state), that nested view will now automatically receive the correct `Environment` across `BlueprintView` boundaries. If you were previously manually propagating `Environment` values you may remove this code. If you would like to opt-out of this behavior; you can set `view.automaticallyInheritsEnvironmentFromContainingBlueprintViews = false` on your `BlueprintView`.
 
+- [Introduced `BlueprintView.onDidLayoutContents`](https://github.com/square/Blueprint/pull/248), to allow monitoring and performing additional work when a `BlueprintView`'s contents are laid out.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
Add an `onDidLayoutContents` callback on `BlueprintView` which is invoked when a layout occurs. We'll use this in `MarketViewController/MarketScreen/etc` to update the `preferredContentSize` to avoid repeated redundant calculations from workflow-based updates, or other updates which are sent more than once per layout pass.