### PR TITLE
Adding accessibilityTraits properties to text elements / restoring isAccessibilityElement property

### DIFF
--- a/BlueprintUICommonControls/Sources/AccessibilityElement.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityElement.swift
@@ -50,7 +50,7 @@ public struct AccessibilityElement: Element {
     }
 
     private var accessibilityTraits: UIAccessibilityTraits {
-        return UIAccessibilityTraits(withSet: self.traits)
+        return UIAccessibilityTraits(withSet: traits)
     }
 
     public var content: ElementContent {
@@ -119,47 +119,47 @@ extension Element {
 }
 
 
-public extension UIAccessibilityTraits {
-    
-    init(withSet set:Set<AccessibilityElement.Trait>) {
-         self.init(rawValue: UIAccessibilityTraits.none.rawValue)
-             for trait in set {
-                 switch trait {
-                 case .button:
-                     self.formUnion(.button)
-                 case .link:
-                     self.formUnion(.link)
-                 case .header:
-                     self.formUnion(.header)
-                 case .searchField:
-                     self.formUnion(.searchField)
-                 case .image:
-                     self.formUnion(.image)
-                 case .selected:
-                     self.formUnion(.selected)
-                 case .playsSound:
-                     self.formUnion(.playsSound)
-                 case .keyboardKey:
-                     self.formUnion(.keyboardKey)
-                 case .staticText:
-                     self.formUnion(.staticText)
-                 case .summaryElement:
-                     self.formUnion(.summaryElement)
-                 case .notEnabled:
-                     self.formUnion(.notEnabled)
-                 case .updatesFrequently:
-                     self.formUnion(.updatesFrequently)
-                 case .startsMediaSession:
-                     self.formUnion(.startsMediaSession)
-                 case .adjustable:
-                     self.formUnion(.adjustable)
-                 case .allowsDirectInteraction:
-                     self.formUnion(.allowsDirectInteraction)
-                 case .causesPageTurn:
-                     self.formUnion(.causesPageTurn)
-                 case .tabBar:
-                     self.formUnion(.tabBar)
-                 }
-             }
-         }
+extension UIAccessibilityTraits {
+
+    public init(withSet set: Set<AccessibilityElement.Trait>) {
+        self.init(rawValue: UIAccessibilityTraits.none.rawValue)
+        for trait in set {
+            switch trait {
+            case .button:
+                formUnion(.button)
+            case .link:
+                formUnion(.link)
+            case .header:
+                formUnion(.header)
+            case .searchField:
+                formUnion(.searchField)
+            case .image:
+                formUnion(.image)
+            case .selected:
+                formUnion(.selected)
+            case .playsSound:
+                formUnion(.playsSound)
+            case .keyboardKey:
+                formUnion(.keyboardKey)
+            case .staticText:
+                formUnion(.staticText)
+            case .summaryElement:
+                formUnion(.summaryElement)
+            case .notEnabled:
+                formUnion(.notEnabled)
+            case .updatesFrequently:
+                formUnion(.updatesFrequently)
+            case .startsMediaSession:
+                formUnion(.startsMediaSession)
+            case .adjustable:
+                formUnion(.adjustable)
+            case .allowsDirectInteraction:
+                formUnion(.allowsDirectInteraction)
+            case .causesPageTurn:
+                formUnion(.causesPageTurn)
+            case .tabBar:
+                formUnion(.tabBar)
+            }
+        }
+    }
 }

--- a/BlueprintUICommonControls/Sources/AccessibilityElement.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityElement.swift
@@ -50,48 +50,7 @@ public struct AccessibilityElement: Element {
     }
 
     private var accessibilityTraits: UIAccessibilityTraits {
-        var traits: UIAccessibilityTraits = .none
-
-        for trait in self.traits {
-            switch trait {
-            case .button:
-                traits.formUnion(.button)
-            case .link:
-                traits.formUnion(.link)
-            case .header:
-                traits.formUnion(.header)
-            case .searchField:
-                traits.formUnion(.searchField)
-            case .image:
-                traits.formUnion(.image)
-            case .selected:
-                traits.formUnion(.selected)
-            case .playsSound:
-                traits.formUnion(.playsSound)
-            case .keyboardKey:
-                traits.formUnion(.keyboardKey)
-            case .staticText:
-                traits.formUnion(.staticText)
-            case .summaryElement:
-                traits.formUnion(.summaryElement)
-            case .notEnabled:
-                traits.formUnion(.notEnabled)
-            case .updatesFrequently:
-                traits.formUnion(.updatesFrequently)
-            case .startsMediaSession:
-                traits.formUnion(.startsMediaSession)
-            case .adjustable:
-                traits.formUnion(.adjustable)
-            case .allowsDirectInteraction:
-                traits.formUnion(.allowsDirectInteraction)
-            case .causesPageTurn:
-                traits.formUnion(.causesPageTurn)
-            case .tabBar:
-                traits.formUnion(.tabBar)
-            }
-        }
-
-        return traits
+        return UIAccessibilityTraits(withSet: self.traits)
     }
 
     public var content: ElementContent {
@@ -157,4 +116,50 @@ extension Element {
             wrapping: self
         )
     }
+}
+
+
+public extension UIAccessibilityTraits {
+    
+    init(withSet set:Set<AccessibilityElement.Trait>) {
+         self.init(rawValue: UIAccessibilityTraits.none.rawValue)
+             for trait in set {
+                 switch trait {
+                 case .button:
+                     self.formUnion(.button)
+                 case .link:
+                     self.formUnion(.link)
+                 case .header:
+                     self.formUnion(.header)
+                 case .searchField:
+                     self.formUnion(.searchField)
+                 case .image:
+                     self.formUnion(.image)
+                 case .selected:
+                     self.formUnion(.selected)
+                 case .playsSound:
+                     self.formUnion(.playsSound)
+                 case .keyboardKey:
+                     self.formUnion(.keyboardKey)
+                 case .staticText:
+                     self.formUnion(.staticText)
+                 case .summaryElement:
+                     self.formUnion(.summaryElement)
+                 case .notEnabled:
+                     self.formUnion(.notEnabled)
+                 case .updatesFrequently:
+                     self.formUnion(.updatesFrequently)
+                 case .startsMediaSession:
+                     self.formUnion(.startsMediaSession)
+                 case .adjustable:
+                     self.formUnion(.adjustable)
+                 case .allowsDirectInteraction:
+                     self.formUnion(.allowsDirectInteraction)
+                 case .causesPageTurn:
+                     self.formUnion(.causesPageTurn)
+                 case .tabBar:
+                     self.formUnion(.tabBar)
+                 }
+             }
+         }
 }

--- a/BlueprintUICommonControls/Sources/AccessibilityElement.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityElement.swift
@@ -50,7 +50,7 @@ public struct AccessibilityElement: Element {
     }
 
     private var accessibilityTraits: UIAccessibilityTraits {
-        return UIAccessibilityTraits(withSet: traits)
+        return UIAccessibilityTraits(with: traits)
     }
 
     public var content: ElementContent {
@@ -121,7 +121,7 @@ extension Element {
 
 extension UIAccessibilityTraits {
 
-    public init(withSet set: Set<AccessibilityElement.Trait>) {
+    public init(with set: Set<AccessibilityElement.Trait>) {
         self.init(rawValue: UIAccessibilityTraits.none.rawValue)
         for trait in set {
             switch trait {

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -43,9 +43,7 @@ public struct AttributedLabel: Element, Hashable {
         label.attributedText = attributedText
         label.numberOfLines = numberOfLines
         label.textRectOffset = textRectOffset
-        if let traits = accessibilityTraits {
-            label.accessibilityTraits.formUnion(UIAccessibilityTraits(withSet: traits))
-        }
+        updateAccessibilityTraits(label)
     }
 
     public func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
@@ -53,9 +51,21 @@ public struct AttributedLabel: Element, Hashable {
             config.apply(update)
         }
     }
+    
+    private func updateAccessibilityTraits(_ label: UILabel) {
+        if let traits = accessibilityTraits {
+            var union = label.accessibilityTraits.union(UIAccessibilityTraits(withSet: traits))
+            // UILabel has the `.staticText` trait by default. If we explicitly set `.updatesFrequently` this should be removed.
+            if traits.contains(.updatesFrequently) && label.accessibilityTraits.contains(.staticText) {
+                union.subtract(.staticText)
+            }
+            label.accessibilityTraits = union
+        }
+    }
 }
 
 extension AttributedLabel {
+    
     private final class LabelView: UILabel {
         var textRectOffset: UIOffset = .zero {
             didSet {

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -11,6 +11,8 @@ public struct AttributedLabel: Element, Hashable {
     /// This can be used to adjust the positioning of text within each line's frame, such as adjusting
     /// the way text is distributed within the line height.
     public var textRectOffset: UIOffset = .zero
+    
+    public var accessibilityTraits: Set<AccessibilityElement.Trait>?
 
     public init(attributedText: NSAttributedString, configure: (inout Self) -> Void = { _ in }) {
         self.attributedText = attributedText
@@ -41,6 +43,9 @@ public struct AttributedLabel: Element, Hashable {
         label.attributedText = attributedText
         label.numberOfLines = numberOfLines
         label.textRectOffset = textRectOffset
+        if let traits = accessibilityTraits {
+            label.accessibilityTraits.formUnion(UIAccessibilityTraits(withSet: traits))
+        }
     }
 
     public func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -11,7 +11,8 @@ public struct AttributedLabel: Element, Hashable {
     /// This can be used to adjust the positioning of text within each line's frame, such as adjusting
     /// the way text is distributed within the line height.
     public var textRectOffset: UIOffset = .zero
-    
+
+    public var isAccessibilityElement = true
     public var accessibilityTraits: Set<AccessibilityElement.Trait>?
 
     public init(attributedText: NSAttributedString, configure: (inout Self) -> Void = { _ in }) {
@@ -43,6 +44,7 @@ public struct AttributedLabel: Element, Hashable {
         label.attributedText = attributedText
         label.numberOfLines = numberOfLines
         label.textRectOffset = textRectOffset
+        label.isAccessibilityElement = isAccessibilityElement
         updateAccessibilityTraits(label)
     }
 
@@ -51,7 +53,7 @@ public struct AttributedLabel: Element, Hashable {
             config.apply(update)
         }
     }
-    
+
     private func updateAccessibilityTraits(_ label: UILabel) {
         if let traits = accessibilityTraits {
             var union = label.accessibilityTraits.union(UIAccessibilityTraits(withSet: traits))
@@ -65,7 +67,7 @@ public struct AttributedLabel: Element, Hashable {
 }
 
 extension AttributedLabel {
-    
+
     private final class LabelView: UILabel {
         var textRectOffset: UIOffset = .zero {
             didSet {

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -12,7 +12,10 @@ public struct AttributedLabel: Element, Hashable {
     /// the way text is distributed within the line height.
     public var textRectOffset: UIOffset = .zero
 
+    /// Determines if the label should be included when navigating the UI via accessibility.
     public var isAccessibilityElement = true
+
+    /// A set of accessibility traits that should be applied to the label, these will be merged with any existing traits.
     public var accessibilityTraits: Set<AccessibilityElement.Trait>?
 
     public init(attributedText: NSAttributedString, configure: (inout Self) -> Void = { _ in }) {
@@ -56,7 +59,7 @@ public struct AttributedLabel: Element, Hashable {
 
     private func updateAccessibilityTraits(_ label: UILabel) {
         if let traits = accessibilityTraits {
-            var union = label.accessibilityTraits.union(UIAccessibilityTraits(withSet: traits))
+            var union = label.accessibilityTraits.union(UIAccessibilityTraits(with: traits))
             // UILabel has the `.staticText` trait by default. If we explicitly set `.updatesFrequently` this should be removed.
             if traits.contains(.updatesFrequently) && label.accessibilityTraits.contains(.staticText) {
                 union.subtract(.staticText)

--- a/BlueprintUICommonControls/Sources/Label.swift
+++ b/BlueprintUICommonControls/Sources/Label.swift
@@ -14,6 +14,7 @@ public struct Label: ProxyElement {
     public var numberOfLines: Int = 0
     public var lineBreakMode: NSLineBreakMode = .byWordWrapping
     public var lineHeight: LineHeight = .font
+    public var isAccessibilityElement = true
     public var accessibilityTraits: Set<AccessibilityElement.Trait>?
 
     public init(text: String, configure: (inout Label) -> Void = { _ in }) {
@@ -58,6 +59,7 @@ public struct Label: ProxyElement {
     public var elementRepresentation: Element {
         AttributedLabel(attributedText: attributedText) { label in
             label.numberOfLines = numberOfLines
+            label.isAccessibilityElement = isAccessibilityElement
             label.accessibilityTraits = accessibilityTraits
 
             switch lineHeight {

--- a/BlueprintUICommonControls/Sources/Label.swift
+++ b/BlueprintUICommonControls/Sources/Label.swift
@@ -14,6 +14,7 @@ public struct Label: ProxyElement {
     public var numberOfLines: Int = 0
     public var lineBreakMode: NSLineBreakMode = .byWordWrapping
     public var lineHeight: LineHeight = .font
+    public var accessibilityTraits: Set<AccessibilityElement.Trait>?
 
     public init(text: String, configure: (inout Label) -> Void = { _ in }) {
         self.text = text
@@ -57,6 +58,7 @@ public struct Label: ProxyElement {
     public var elementRepresentation: Element {
         AttributedLabel(attributedText: attributedText) { label in
             label.numberOfLines = numberOfLines
+            label.accessibilityTraits = accessibilityTraits
 
             switch lineHeight {
             case .custom(let lineHeight, .top):

--- a/BlueprintUICommonControls/Sources/Label.swift
+++ b/BlueprintUICommonControls/Sources/Label.swift
@@ -14,7 +14,11 @@ public struct Label: ProxyElement {
     public var numberOfLines: Int = 0
     public var lineBreakMode: NSLineBreakMode = .byWordWrapping
     public var lineHeight: LineHeight = .font
+
+    /// Determines if the label should be included when navigating the UI via accessibility.
     public var isAccessibilityElement = true
+
+    /// A set of accessibility traits that should be applied to the label, these will be merged with any existing traits.
     public var accessibilityTraits: Set<AccessibilityElement.Trait>?
 
     public init(text: String, configure: (inout Label) -> Void = { _ in }) {

--- a/BlueprintUICommonControls/Sources/TextField.swift
+++ b/BlueprintUICommonControls/Sources/TextField.swift
@@ -30,6 +30,7 @@ public struct TextField: Element {
 
     public var becomeActiveTrigger: Trigger?
     public var resignActiveTrigger: Trigger?
+    public var accessibilityTraits: Set<AccessibilityElement.Trait>?
 
     public init(text: String, configure: (inout TextField) -> Void = { _ in }) {
         self.text = text
@@ -65,6 +66,14 @@ public struct TextField: Element {
 
             configuration[\.becomeActiveTrigger] = becomeActiveTrigger
             configuration[\.resignActiveTrigger] = resignActiveTrigger
+            if let traits = accessibilityTraits {
+                if let existing = configuration[\.accessibilityTraits] {
+                    configuration[\.accessibilityTraits] = existing.union(UIAccessibilityTraits(withSet: traits))
+                }
+                else{
+                    configuration[\.accessibilityTraits] = UIAccessibilityTraits(withSet: traits)
+                }
+            }
         }
     }
 

--- a/BlueprintUICommonControls/Sources/TextField.swift
+++ b/BlueprintUICommonControls/Sources/TextField.swift
@@ -69,8 +69,7 @@ public struct TextField: Element {
             if let traits = accessibilityTraits {
                 if let existing = configuration[\.accessibilityTraits] {
                     configuration[\.accessibilityTraits] = existing.union(UIAccessibilityTraits(withSet: traits))
-                }
-                else{
+                } else {
                     configuration[\.accessibilityTraits] = UIAccessibilityTraits(withSet: traits)
                 }
             }

--- a/BlueprintUICommonControls/Sources/TextField.swift
+++ b/BlueprintUICommonControls/Sources/TextField.swift
@@ -30,6 +30,9 @@ public struct TextField: Element {
 
     public var becomeActiveTrigger: Trigger?
     public var resignActiveTrigger: Trigger?
+
+    /// A set of accessibility traits that should be applied to the field, these will be merged with any existing traits.
+    /// These traits should relate to the content of the text, for example `.header`, `.link`, or `.updatesFrequently`.
     public var accessibilityTraits: Set<AccessibilityElement.Trait>?
 
     public init(text: String, configure: (inout TextField) -> Void = { _ in }) {
@@ -68,9 +71,9 @@ public struct TextField: Element {
             configuration[\.resignActiveTrigger] = resignActiveTrigger
             if let traits = accessibilityTraits {
                 if let existing = configuration[\.accessibilityTraits] {
-                    configuration[\.accessibilityTraits] = existing.union(UIAccessibilityTraits(withSet: traits))
+                    configuration[\.accessibilityTraits] = existing.union(UIAccessibilityTraits(with: traits))
                 } else {
-                    configuration[\.accessibilityTraits] = UIAccessibilityTraits(withSet: traits)
+                    configuration[\.accessibilityTraits] = UIAccessibilityTraits(with: traits)
                 }
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Label` `AttributedLabel` and `TextField` elements now support configuration of accessibility traits.
+
 - [The `Environment` is now automatically propagated through to nested `BlueprintViews` within a displayed `Element` hierarchy](https://github.com/square/Blueprint/pull/234). This means that if your view-backed `Elements` themselves contain a `BlueprintView` (eg to manage their own state), that nested view will now automatically receive the correct `Environment` across `BlueprintView` boundaries. If you were previously manually propagating `Environment` values you may remove this code. If you would like to opt-out of this behavior; you can set `view.automaticallyInheritsEnvironmentFromContainingBlueprintViews = false` on your `BlueprintView`.
 
 - [Lifecycle hooks][#244]. You can hook into lifecycle events when an element's visibility changes.


### PR DESCRIPTION
Some accessibility traits such as `.header`, `.link`,  `staticText`, or `.updatesFrequently` refer specifically to attributes of text content drawn on the screen. This change allows those traits to be added to the backing UIKit implementation of a Blueprint  `Label` `AttributedLabel` or `TextField` without wrapping the entire element in a `AccessibilityElement`

This is part of a larger effort to add accessibility traits to `MarketTextStyle`

This PR also restores the `isAccessibilityElement` property removed in my previous PR, however the default remains `true`