### PR TITLE
Release 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Added
+
+### Removed
+
+### Changed
+
+### Deprecated
+
+### Security
+
+### Documentation
+
+### Misc
+
+# Past Releases
+
+## [0.28.0] - 2021-09-01
+
+### Fixed
+
 - Fixed an [issue](https://github.com/square/Blueprint/pull/241) where `Label` and `AttributedLabel` were not accessibility elements.
 
 ### Added
@@ -35,16 +55,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [`makeUIView()` on `UIViewElement` is no longer a static function](https://github.com/square/Blueprint/pull/246), to allow access to properties during view creation. 
-
-### Deprecated
-
-### Security
-
-### Documentation
-
-### Misc
-
-# Past Releases
 
 ## [0.27.0] - 2021-06-22
 
@@ -596,7 +606,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/0.27.0...HEAD
+[main]: https://github.com/square/Blueprint/compare/0.28.0...HEAD
+[0.28.0]: https://github.com/square/Blueprint/compare/0.27.0...0.28.0
 [0.27.0]: https://github.com/square/Blueprint/compare/0.26.0...0.27.0
 [0.26.0]: https://github.com/square/Blueprint/compare/0.25.0...0.26.0
 [0.25.0]: https://github.com/square/Blueprint/compare/0.24.0...0.25.0

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (0.27.0)
-  - BlueprintUI/Tests (0.27.0)
-  - BlueprintUICommonControls (0.27.0):
-    - BlueprintUI (= 0.27.0)
+  - BlueprintUI (0.28.0)
+  - BlueprintUI/Tests (0.28.0)
+  - BlueprintUICommonControls (0.28.0):
+    - BlueprintUI (= 0.28.0)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: e7b5f4d1ac32c1158c4fceee565c57d0d18239ea
-  BlueprintUICommonControls: 7ad2bc4fc3416d699b2c1aad8b32e2ab6f7ad235
+  BlueprintUI: ec3f244e07671267cf1b2d404ef295f9cb244e31
+  BlueprintUICommonControls: 9a9eaf35e5ad46f03dda36f577e81cfd0f214a98
 
 PODFILE CHECKSUM: 63720a1a50b146640cc4fcc4f36d3770895c7e0d
 

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '0.27.0'
+BLUEPRINT_VERSION ||= '0.28.0'


### PR DESCRIPTION
### Fixed

- Fixed an [issue](https://github.com/square/Blueprint/pull/241) where `Label` and `AttributedLabel` were not accessibility elements.

### Added

- `Label` `AttributedLabel` and `TextField` elements now support configuration of accessibility traits.

- [The `Environment` is now automatically propagated through to nested `BlueprintViews` within a displayed `Element` hierarchy](https://github.com/square/Blueprint/pull/234). This means that if your view-backed `Elements` themselves contain a `BlueprintView` (eg to manage their own state), that nested view will now automatically receive the correct `Environment` across `BlueprintView` boundaries. If you were previously manually propagating `Environment` values you may remove this code. If you would like to opt-out of this behavior; you can set `view.automaticallyInheritsEnvironmentFromContainingBlueprintViews = false` on your `BlueprintView`.

- [Lifecycle hooks][#244]. You can hook into lifecycle events when an element's visibility changes.
  ```swift
  element
    .onAppear {
      // runs when `element` appears
    }
    .onDisappear {
      // runs when `element` disappears
    }
  ```

### Removed

- [Removed support for / deprecated iOS 11](https://github.com/square/Blueprint/pull/250).

### Changed

- [`makeUIView()` on `UIViewElement` is no longer a static function](https://github.com/square/Blueprint/pull/246), to allow access to properties during view creation. 

[#244]: https://github.com/square/Blueprint/pull/244
