### PR TITLE
FocusState

### DIFF
--- a/BlueprintUI/Sources/Focus/FocusBinding.swift
+++ b/BlueprintUI/Sources/Focus/FocusBinding.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// A two-way binding between a focusable element's backing view and a `FocusState`-wrapped
+/// property.
+///
+/// Generally you should not need to interact with this type directly. However, you can use focus
+/// bindings to add focus support to custom elements.
+///
+/// ## Adding Focus Bindings
+///
+/// On a `FocusState`, call the `binding(for:)` method to get a binding bound to an optional value,
+/// or `binding()` to get a binding bound to a boolean.
+///
+/// To set up the 2-way binding, there are 2 steps:
+///
+/// 1. Assign actions to the nested `FocusTrigger`, so that your backing view is updated when the
+///    `FocusState`'s value changes.
+///
+/// 2. Call the `onFocus` and `onBlur` callbacks when your backing view gains or loses focus, so
+///    that the value of the bound `FocusState` is updated.
+///
+/// ## Example
+///
+///     final class FocusableView: UIView {
+///         var focusBinding: FocusBinding? {
+///             didSet {
+///                 oldValue?.trigger.focusAction = nil
+///                 oldValue?.trigger.blurAction = nil
+///
+///                 guard let focusBinding = focusBinding else { return }
+///
+///                 focusBinding.trigger.focusAction = { [weak self] in
+///                     self?.becomeFirstResponder()
+///                 }
+///                 focusBinding.trigger.blurAction = { [weak self] in
+///                     self?.resignFirstResponder()
+///                 }
+///
+///                 if isFirstResponder {
+///                     focusBinding.onFocus()
+///                 } else {
+///                     focusBinding.onBlur()
+///                 }
+///             }
+///         }
+///
+///         @discardableResult
+///         override func becomeFirstResponder() -> Bool {
+///             let focused = super.becomeFirstResponder()
+///             if focused {
+///                 focusBinding?.onFocus()
+///             }
+///             return focused
+///         }
+///
+///         @discardableResult
+///         override func resignFirstResponder() -> Bool {
+///             let blurred = super.resignFirstResponder()
+///             if blurred {
+///                 focusBinding?.onBlur()
+///             }
+///             return blurred
+///         }
+///     }
+///
+/// - Tag: FocusBinding
+///
+public struct FocusBinding {
+    /// A trigger, which is responsible for piping focus changes from a `FocusState` into a backing
+    /// view.
+    public let trigger = FocusTrigger()
+    /// A callback to be called by a backing view when it is focused, to pipe changes from a backing
+    /// view to a bound `FocusState`.
+    public var onFocus: () -> Void
+    /// A callback to be called by a backing view when it loses focus, to pipe changes from a
+    /// backing view to a bound `FocusState`.
+    public var onBlur: () -> Void
+
+    /// Creates a new binding
+    public init(onFocus: @escaping () -> Void, onBlur: @escaping () -> Void) {
+        self.onFocus = onFocus
+        self.onBlur = onBlur
+    }
+}

--- a/BlueprintUI/Sources/Focus/FocusState.swift
+++ b/BlueprintUI/Sources/Focus/FocusState.swift
@@ -1,0 +1,249 @@
+import Foundation
+
+/// A property wrapper type that can read and write a value that represents the placement of focus.
+///
+/// Use this property wrapper in conjunction with modifiers on elements that support focus, such as
+/// `TextField.focused(when:equals)` and `TextField.focused(when:)`, to describe when those elements
+/// should have focus. When focus enters the modified element, the wrapped value of this property
+/// updates to match a given value. Similarly, when focus leaves, the wrapped value of this property
+/// resets to `nil` or `false`. Setting this property's value programmatically has the reverse
+/// effect, causing focus to move to the element associated with the updated value.
+///
+/// In the following example of a simple login screen, when the user presses the Sign In button and
+/// one of the fields is still empty, focus moves to that field. Otherwise, the sign-in process
+/// proceeds.
+///
+///     struct LoginForm: ProxyElement {
+///         enum Field: Hashable {
+///             case username
+///             case password
+///         }
+///
+///         var username: String
+///         var password: String
+///         var handleLogin: () -> Void
+///
+///         @FocusState private var focusedField: Field?
+///
+///         var elementRepresentation: Element {
+///             Column { column in
+///                 column.add(
+///                     child: TextField(text: "")
+///                         .focused(when: $focusedField, equals: .username)
+///                 )
+///
+///                 column.add(
+///                     child: TextField(text: "")
+///                         .focused(when: $focusedField, equals: .password)
+///                 )
+///
+///                 column.add(
+///                     child: Button(
+///                         onTap: {
+///                             if username.isEmpty {
+///                                 focusedField = .username
+///                             } else if password.isEmpty {
+///                                 focusedField = .password
+///                             } else {
+///                                 handleLogin()
+///                             }
+///                         },
+///                         wrapping: Label(text: "Sign In")
+///                     )
+///                 )
+///             }
+///         }
+///     }
+///
+/// To allow for cases where focus is completely absent from a view tree, the wrapped value must be
+/// either an optional or a Boolean. Set the focus binding to `false` or `nil` as appropriate to
+/// remove focus from all bound fields. You can also use this to remove focus from a ``TextField``
+/// and thereby dismiss the keyboard.
+///
+/// ### Auto-Focus
+///
+/// To auto-focus a field when it appears, set the value in an `onAppear` hook.
+///
+///     struct Example: ProxyElement {
+///         @FocusState var isFocused: Bool
+///
+///         var elementRepresentation: Element {
+///             TextField(text: "")
+///                 .focused(when: $isFocused)
+///                 .onAppear {
+///                     isFocused = true
+///                 }
+///         }
+///     }
+///
+/// ### Avoid Ambiguous Focus Bindings
+///
+/// A `TextField` can have only one focus binding, stored in its `focusBinding` property. If you apply
+/// the `focused` modifier multiple times, the last one will overwrite the previous value.
+///
+/// On the other hand, binding the same value to two views is ambiguous. In the following example,
+/// two separate fields bind focus to the `name` value:
+///
+///     struct Content: ProxyElement {
+///         enum Field: Hashable {
+///             case name
+///             case fullName
+///         }
+///
+///         @FocusState private var focusedField: Field?
+///
+///         var elementRepresentation: Element {
+///             Column { column in
+///                 column.add(
+///                     child: TextField(text: "")
+///                         .focused(when: $focusedField, equals: .name)
+///                 )
+///
+///                 column.add(
+///                     child: TextField(text: "")
+///                         .focused(when: $focusedField, equals: .name) // incorrect re-use of .name
+///                 )
+///             }
+///         }
+///     }
+///
+/// If the user moves focus to either field, the `focusedField` binding updates to `name`. However,
+/// if the app programmatically sets the value to `name`, the last field bound will be chosen.
+///
+@propertyWrapper
+public struct FocusState<Value> where Value: Hashable {
+
+    @Storage private var value: Value
+
+    /// Creates a focus state that binds to a Boolean.
+    public init() where Value == Bool {
+        _value = Storage(wrappedValue: false)
+        // In Xcode 12.5 use this instead:
+        // value = false
+    }
+
+    /// Creates a focus state that binds to an optional type.
+    public init<T>() where Value == T?, T: Hashable {
+        _value = Storage(wrappedValue: nil)
+        // In Xcode 12.5 use this instead
+        // value = nil
+    }
+
+    /// The current state value, taking into account whatever bindings might be
+    /// in effect due to the current location of focus.
+    ///
+    /// When focus is not in any view that is bound to this state, the wrapped
+    /// value will be `nil` (for optional-typed state) or `false` (for `Bool`-
+    /// typed state).
+    public var wrappedValue: Value {
+        get { value }
+        nonmutating set { value = newValue }
+    }
+
+    /// A projection of the focus state that can be bound to focusable elements.
+    ///
+    /// Use this property wrapper in conjunction with modifiers on elements that support focus, such
+    /// as `TextField.focused(when:equals)` and `TextField.focused(when:)`, to describe when those
+    /// elements should have focus.
+    ///
+    /// To add focus support to a custom element, use one of the methods on this projection to
+    /// retrieve a `FocusBinding`: `binding()` for `Bool` values and `binding(for:)` for optional
+    /// values.
+    ///
+    public var projectedValue: Self {
+        self
+    }
+
+    private var storage: Storage { $value }
+
+    private subscript(value: Value) -> FocusBinding {
+        if let binding = storage.bindings[value] {
+            return binding
+        }
+
+        let binding = FocusBinding(
+            onFocus: {
+                self.value = value
+            },
+            onBlur: {
+                if self.value == value {
+                    self.value = storage.defaultValue
+                }
+            }
+        )
+
+        storage.bindings[value] = binding
+
+        return binding
+    }
+
+    /// Gets a focus binding associated with the `FocusState` being a specific value.
+    ///
+    /// You can use this binding to add focus support to a custom element.
+    ///
+    /// When the `FocusState` property is set to this value, the binding's `focus` trigger will
+    /// fire, and when the property is set to another value, the binding's `blur` trigger will fire.
+    /// Similarly, calling the `onFocus` callback will set the `FocusState` to this value, and the
+    /// `onBlur` callback will set it to `nil`.
+    ///
+    /// ## See Also
+    /// [FocusBinding](x-source-tag://FocusBinding)
+    ///
+    public func binding<T>(for value: T) -> FocusBinding where Value == T?, T: Hashable {
+        self[value]
+    }
+
+    /// Gets a focus binding associated with the `FocusState` value being `true`.
+    ///
+    /// You can use this binding to add focus support to a custom element.
+    ///
+    /// When the `FocusState` property is set to true, the binding's `focus` trigger will fire, and
+    /// when the property is set to false, the binding's `blur` trigger will fire. Similarly,
+    /// calling the `onFocus` callback will set the `FocusState` to true, and the `onBlur` callback
+    /// will set it to false.
+    ///
+    /// ## See Also
+    /// [FocusBinding](x-source-tag://FocusBinding)
+    ///
+    public func binding() -> FocusBinding where Value == Bool {
+        self[true]
+    }
+}
+
+extension FocusState {
+    @propertyWrapper
+    private final class Storage {
+        let defaultValue: Value
+        var bindings: [Value: FocusBinding] = [:]
+
+        init(wrappedValue initialValue: Value) {
+            defaultValue = initialValue
+            value = initialValue
+        }
+
+        var projectedValue: Storage {
+            self
+        }
+
+        var wrappedValue: Value {
+            get { value }
+            set { value = newValue }
+        }
+
+        private var value: Value {
+            didSet {
+                guard oldValue != value else {
+                    return
+                }
+
+                if oldValue != defaultValue, let binding = bindings[oldValue] {
+                    binding.trigger.blur()
+                }
+
+                if value != defaultValue, let binding = bindings[value] {
+                    binding.trigger.focus()
+                }
+            }
+        }
+    }
+}

--- a/BlueprintUI/Sources/Focus/FocusState.swift
+++ b/BlueprintUI/Sources/Focus/FocusState.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A property wrapper type that can read and write a value that represents the placement of focus.
 ///
 /// Use this property wrapper in conjunction with modifiers on elements that support focus, such as
-/// `TextField.focused(when:equals)` and `TextField.focused(when:)`, to describe when those elements
+/// `TextField.focused(when:equals:)` and `TextField.focused(when:)`, to describe when those elements
 /// should have focus. When focus enters the modified element, the wrapped value of this property
 /// updates to match a given value. Similarly, when focus leaves, the wrapped value of this property
 /// resets to `nil` or `false`. Setting this property's value programmatically has the reverse

--- a/BlueprintUI/Sources/Focus/FocusTrigger.swift
+++ b/BlueprintUI/Sources/Focus/FocusTrigger.swift
@@ -14,6 +14,9 @@ import Foundation
 /// [FocusBinding](x-source-tag://FocusBinding)
 ///
 public final class FocusTrigger {
+    /// Create a new trigger, not yet bound to any view.
+    public init() {}
+
     /// The action to be invoked on focus, which will be set by a backing view.
     public var focusAction: (() -> Void)?
     /// The action to be invoked on blur, which will be set by a backing view.

--- a/BlueprintUI/Sources/Focus/FocusTrigger.swift
+++ b/BlueprintUI/Sources/Focus/FocusTrigger.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// A trigger for focus and blur actions.
+///
+/// This type is meant to be used in conjunction with `FocusState`; you will usually not create
+/// it directly. For information about adding focus support to a custom element, see `FocusBinding`.
+///
+/// Triggers allow imperative actions to be invoked on backing views, by creating a trigger in a
+/// declarative model before the view is realized, late-binding the actions to a backing view after
+/// that view has been realized, and then invoking the action on the trigger later in response to
+/// some other event.
+///
+/// ## See Also
+/// [FocusBinding](x-source-tag://FocusBinding)
+///
+public final class FocusTrigger {
+    /// The action to be invoked on focus, which will be set by a backing view.
+    public var focusAction: (() -> Void)?
+    /// The action to be invoked on blur, which will be set by a backing view.
+    public var blurAction: (() -> Void)?
+
+    /// Focuses the backing view bound to this trigger.
+    public func focus() {
+        focusAction?()
+    }
+
+    /// Blurs (removes focus from) the backing view bound to this trigger.
+    public func blur() {
+        blurAction?()
+    }
+}

--- a/BlueprintUI/Sources/Internal/Extensions/AnyObject+Debugging.swift
+++ b/BlueprintUI/Sources/Internal/Extensions/AnyObject+Debugging.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Gets the address of a reference type as a string, for debugging purposes.
+func address(of object: AnyObject) -> String {
+    "\(Unmanaged.passUnretained(object).toOpaque())"
+}

--- a/BlueprintUI/Tests/FocusStateTests.swift
+++ b/BlueprintUI/Tests/FocusStateTests.swift
@@ -1,0 +1,75 @@
+import BlueprintUI
+import XCTest
+
+final class FocusStateTests: XCTestCase {
+    func test_enum() {
+        enum Field {
+            case a, b
+        }
+
+        struct StateHolder {
+            @FocusState var focusedField: Field?
+        }
+        let state = StateHolder()
+
+        var isFocusedA: Bool = false
+        var isFocusedB: Bool = false
+
+        let bindingA = state.$focusedField.binding(for: .a)
+        bindingA.trigger.focusAction = { isFocusedA = true }
+        bindingA.trigger.blurAction = { isFocusedA = false }
+
+        let bindingB = state.$focusedField.binding(for: .b)
+        bindingB.trigger.focusAction = { isFocusedB = true }
+        bindingB.trigger.blurAction = { isFocusedB = false }
+
+        state.focusedField = .a
+        XCTAssertEqual(isFocusedA, true)
+        XCTAssertEqual(isFocusedB, false)
+
+        state.focusedField = .b
+        XCTAssertEqual(isFocusedA, false)
+        XCTAssertEqual(isFocusedB, true)
+
+        state.focusedField = nil
+        XCTAssertEqual(isFocusedA, false)
+        XCTAssertEqual(isFocusedB, false)
+
+        bindingA.onFocus()
+        XCTAssertEqual(state.focusedField, .a)
+
+        bindingA.onBlur()
+        XCTAssertEqual(state.focusedField, nil)
+
+        bindingB.onFocus()
+        XCTAssertEqual(state.focusedField, .b)
+
+        bindingB.onBlur()
+        XCTAssertEqual(state.focusedField, nil)
+    }
+
+    func test_bool() {
+        struct StateHolder {
+            @FocusState var isFocused: Bool
+        }
+        let state = StateHolder()
+
+        var isFocused: Bool = false
+
+        let binding = state.$isFocused.binding()
+        binding.trigger.focusAction = { isFocused = true }
+        binding.trigger.blurAction = { isFocused = false }
+
+        state.isFocused = true
+        XCTAssertEqual(isFocused, true)
+
+        state.isFocused = false
+        XCTAssertEqual(isFocused, false)
+
+        binding.onFocus()
+        XCTAssertEqual(state.isFocused, true)
+
+        binding.onBlur()
+        XCTAssertEqual(state.isFocused, false)
+    }
+}

--- a/BlueprintUICommonControls/Sources/TextField.swift
+++ b/BlueprintUICommonControls/Sources/TextField.swift
@@ -160,7 +160,7 @@ fileprivate final class CallbackTextField: UITextField, UITextFieldDelegate {
 extension TextField {
     /// Modifies this text field by binding its focus state to the given state value.
     ///
-    /// Use this modifier to cause the text field to receive focus whenever the the `state` equals
+    /// Use this modifier to cause the text field to receive focus whenever the `state` equals
     /// the `value`. Typically, you create an enumeration of fields that may receive focus, bind an
     /// instance of this enumeration, and assign its cases to focusable views.
     ///

--- a/BlueprintUICommonControls/Tests/Sources/TextFieldTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/TextFieldTests.swift
@@ -68,5 +68,34 @@ class TextFieldTests: XCTestCase {
 
     }
 
-}
+    func test_focus() {
+        // make a fake window so that focus works
+        withWindow { window in
+            let view = BlueprintView()
+            window.addSubview(view)
 
+            var isFocused = true
+            let binding = FocusBinding(
+                onFocus: { isFocused = true },
+                onBlur: { isFocused = false }
+            )
+            view.element = TextField(text: "") { textField in
+                textField.focusBinding = binding
+            }
+
+            view.layoutIfNeeded()
+            let testView = view.subviews[0].subviews[0]
+
+            XCTAssertFalse(testView.isFirstResponder)
+            XCTAssertFalse(isFocused)
+
+            binding.trigger.focus()
+            XCTAssertTrue(testView.isFirstResponder)
+            XCTAssertTrue(isFocused)
+
+            binding.trigger.blur()
+            XCTAssertFalse(testView.isFirstResponder)
+            XCTAssertFalse(isFocused)
+        }
+    }
+}

--- a/BlueprintUICommonControls/Tests/Sources/XCTestCaseExtensions.swift
+++ b/BlueprintUICommonControls/Tests/Sources/XCTestCaseExtensions.swift
@@ -146,3 +146,18 @@ extension UIImage {
         return pixelData
     }
 }
+
+extension XCTestCase {
+    /// Run the given block with a window that is key and visible, then releases it.
+    func withWindow(block: (UIWindow) -> Void) {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.makeKeyAndVisible()
+
+        block(window)
+
+        window.isHidden = true
+        if #available(iOS 13, *) {
+            window.windowScene = nil
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The `@FocusState` property wrapper can be used to manage focus of text fields. ([#259])
+
+  After binding a text field to a state, you can programmatically focus the field by setting the state value.
+  
+  ```swift
+  struct LoginForm: ProxyElement {
+      enum Field: Hashable {
+          case username, password
+      }
+
+      @FocusState private var focusedField: Field?
+
+      var elementRepresentation: Element {
+          // This text field will be focused when `self.focusedField = .username`
+          TextField(text: "")
+              .focused(when: $focusedField, equals: .username)
+      }
+  }
+  ```
+
 ### Removed
 
 ### Changed
+
+- `TextField`'s `becomeActiveTrigger` and `resignActiveTrigger` properties have been replaced with a `focusBinding` for use with the new `@FocusState` property wrapper.
 
 ### Deprecated
 
@@ -655,6 +677,7 @@ searchField
 [0.3.0]: https://github.com/square/Blueprint/compare/0.2.2...0.3.0
 [0.2.2]: https://github.com/square/Blueprint/releases/tag/0.2.2
 [#260]: https://github.com/square/Blueprint/pull/260
+[#259]: https://github.com/square/Blueprint/pull/259
 [#257]: https://github.com/square/Blueprint/pull/257
 [#244]: https://github.com/square/Blueprint/pull/244
 [#209]: https://github.com/square/Blueprint/pull/209


### PR DESCRIPTION
This PR introduces some abstractions for managing focus.

The `Trigger` type from `TextField` is generalized into a top-level type, and wrapped in a `FocusBinding` that includes `onFocus` and `onBlur` callbacks.

You can use this the same way you'd use a trigger today, but it also facilitates a new `@FocusState` property wrapper type that is intended to be the new recommended way to manage focus. `@FocusState` has an API based on [the new `@FocusState` in SwiftUI](https://developer.apple.com/documentation/swiftui/focusstate).

## Example usage

```swift
struct LoginForm: ProxyElement {
    enum Field: Hashable {
        case username
        case password
    }

    var username: String
    var password: String
    var handleLogin: () -> Void

    @FocusState private var focusedField: Field?

    var elementRepresentation: Element {
        Column { column in
            column.add(
                child: TextField(text: username)
                    .focused(when: $focusedField, equals: .username)
            )
            column.add(
                child: TextField(text: password)
                    .focused(when: $focusedField, equals: .password)
            )
            column.add(
                child: Button(
                    onTap: {
                        if username.isEmpty {
                            focusedField = .username
                        } else if password.isEmpty {
                            focusedField = .password
                        } else {
                            handleLogin()
                        }
                    },
                    wrapping: Label(text: "Sign In")
                )
            )
        }
    }
}
```

This is in draft status while I add docs and clean up, but the general shape is ready for review.