### PR TITLE
Defer lifecycle callbacks until view updates complete

### DIFF
--- a/BlueprintUICommonControls/Sources/LifecycleObserver.swift
+++ b/BlueprintUICommonControls/Sources/LifecycleObserver.swift
@@ -34,6 +34,7 @@ public struct LifecycleObserver: Element {
 extension LifecycleObserver {
     /// Adds a hook that will be called when this element appears.
     ///
+    /// Callbacks run in depth-first traversal order, with parents before children.
     public func onAppear(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
         LifecycleObserver(
             onAppear: onAppear + callback,
@@ -44,6 +45,9 @@ extension LifecycleObserver {
 
     /// Adds a hook that will be called when this element disappears.
     ///
+    /// Callbacks run in depth-first traversal order, with parents before children. There is no
+    /// guaranteed order between disappearance callbacks and backing views being removed from their
+    /// superviews.
     public func onDisappear(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
         LifecycleObserver(
             onAppear: onAppear,
@@ -56,12 +60,16 @@ extension LifecycleObserver {
 extension Element {
     /// Adds a hook that will be called when this element appears.
     ///
+    /// Callbacks run in depth-first traversal order, with parents before children.
     public func onAppear(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
         LifecycleObserver(onAppear: callback, wrapping: self)
     }
 
     /// Adds a hook that will be called when this element disappears.
     ///
+    /// Callbacks run in depth-first traversal order, with parents before children. There is no
+    /// guaranteed order between disappearance callbacks and backing views being removed from their
+    /// superviews.
     public func onDisappear(_ callback: @escaping LifecycleCallback) -> LifecycleObserver {
         LifecycleObserver(onDisappear: callback, wrapping: self)
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Lifecycle hooks are guaranteed to run after all views are updated. ([#260])
+
 ### Deprecated
 
 ### Security
@@ -643,6 +645,7 @@ searchField
 [0.3.1]: https://github.com/square/Blueprint/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/square/Blueprint/compare/0.2.2...0.3.0
 [0.2.2]: https://github.com/square/Blueprint/releases/tag/0.2.2
+[#260]: https://github.com/square/Blueprint/pull/260
 [#244]: https://github.com/square/Blueprint/pull/244
 [#209]: https://github.com/square/Blueprint/pull/209
 [#176]: https://github.com/square/Blueprint/pull/176


### PR DESCRIPTION
This changes the time when lifecycle callbacks encountered during a view update are run: instead of running them in-line with the view update traversal, they are aggregated and run after the view update completes. It does not change the relative order of the callbacks themselves.

This ensures that all view descriptions are applied before running `onAppear` callbacks. Notably, this means that any focus triggers on children will be set up, so callbacks set on parents can use them.

Some additional docs on the appearance modifiers explain what is guaranteed (relative callback order) and what is not (superview removal).