### PR TITLE
Release 0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- View-backed elements may opt-in to a frame rounding behavior that prioritizes preserving the frame size rather than the frame edges. This is primarily meant for text labels, to fix an issue where labels gain or lose a pixel in rounding and become wrapped or truncated incorrectly. ([#257])
-
 ### Removed
 
 ### Changed
-
-- Lifecycle hooks are guaranteed to run after all views are updated. ([#260])
 
 ### Deprecated
 
@@ -28,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Misc
 
 # Past Releases
+
+## [0.28.1] - 2021-09-10
+
+### Added
+
+- View-backed elements may opt-in to a frame rounding behavior that prioritizes preserving the frame size rather than the frame edges. This is primarily meant for text labels, to fix an issue where labels gain or lose a pixel in rounding and become wrapped or truncated incorrectly. ([#257])
+
+### Changed
+
+- Lifecycle hooks are guaranteed to run after all views are updated. ([#260])
 
 ## [0.28.0] - 2021-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -616,7 +616,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/0.28.0...HEAD
+[main]: https://github.com/square/Blueprint/compare/0.28.1...HEAD
+[0.28.1]: https://github.com/square/Blueprint/compare/0.28.0...0.28.1
 [0.28.0]: https://github.com/square/Blueprint/compare/0.27.0...0.28.0
 [0.27.0]: https://github.com/square/Blueprint/compare/0.26.0...0.27.0
 [0.26.0]: https://github.com/square/Blueprint/compare/0.25.0...0.26.0

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (0.28.0)
-  - BlueprintUI/Tests (0.28.0)
-  - BlueprintUICommonControls (0.28.0):
-    - BlueprintUI (= 0.28.0)
+  - BlueprintUI (0.28.1)
+  - BlueprintUI/Tests (0.28.1)
+  - BlueprintUICommonControls (0.28.1):
+    - BlueprintUI (= 0.28.1)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: ec3f244e07671267cf1b2d404ef295f9cb244e31
-  BlueprintUICommonControls: 9a9eaf35e5ad46f03dda36f577e81cfd0f214a98
+  BlueprintUI: 7ece61925ae83cc322372a2f82cba5b2d3200ae9
+  BlueprintUICommonControls: 89f405eb0515edcc42a47f176a61eb6d7c74b603
 
 PODFILE CHECKSUM: 63720a1a50b146640cc4fcc4f36d3770895c7e0d
 

--- a/version.rb
+++ b/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '0.28.0'
+BLUEPRINT_VERSION ||= '0.28.1'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))


### PR DESCRIPTION
# PR Changes

- Bump version to 0.28.1
- `bepi` SampleApp
- Update changelog

# Version Changelog

### Added

- View-backed elements may opt-in to a frame rounding behavior that prioritizes preserving the frame size rather than the frame edges. This is primarily meant for text labels, to fix an issue where labels gain or lose a pixel in rounding and become wrapped or truncated incorrectly. ([#257])

### Changed

- Lifecycle hooks are guaranteed to run after all views are updated. ([#260])
