### PR TITLE
Ensure infinite constraints are `.unconstrained`

### DIFF
--- a/BlueprintUI/Sources/Measuring/SizeConstraint.swift
+++ b/BlueprintUI/Sources/Measuring/SizeConstraint.swift
@@ -7,10 +7,10 @@ import UIKit
 public struct SizeConstraint: Hashable {
 
     /// The width constraint.
-    public var width: Axis
+    @UnconstrainedInfiteAxis public var width: Axis
 
     /// The height constraint.
-    public var height: Axis
+    @UnconstrainedInfiteAxis public var height: Axis
 
     public init(width: Axis, height: Axis) {
         self.width = width
@@ -174,5 +174,35 @@ extension SizeConstraint {
             lhs = lhs * rhs
         }
 
+    }
+}
+
+extension SizeConstraint {
+    /// This property wrapper checks the value of `atMost` cases, and turns it into an
+    /// `unconstrained` axis if the value equals `greatestFiniteMagnitude` or `isInfinite`.
+    @propertyWrapper public struct UnconstrainedInfiteAxis: Equatable, Hashable {
+        private var correctedAxis: Axis
+
+        public var wrappedValue: Axis {
+            get { correctedAxis }
+            set { correctedAxis = Self.correctedAxis(for: newValue) }
+        }
+
+        public init(wrappedValue value: Axis) {
+            correctedAxis = Self.correctedAxis(for: value)
+        }
+
+        private static func correctedAxis(for axis: Axis) -> Axis {
+            switch axis {
+            case .atMost(let maxAxis):
+                if maxAxis.isInfinite || maxAxis == .greatestFiniteMagnitude {
+                    return .unconstrained
+                } else {
+                    return axis
+                }
+            case .unconstrained:
+                return axis
+            }
+        }
     }
 }

--- a/BlueprintUI/Sources/Measuring/SizeConstraint.swift
+++ b/BlueprintUI/Sources/Measuring/SizeConstraint.swift
@@ -7,10 +7,10 @@ import UIKit
 public struct SizeConstraint: Hashable {
 
     /// The width constraint.
-    @UnconstrainedInfiteAxis public var width: Axis
+    @UnconstrainedInfiniteAxis public var width: Axis
 
     /// The height constraint.
-    @UnconstrainedInfiteAxis public var height: Axis
+    @UnconstrainedInfiniteAxis public var height: Axis
 
     public init(width: Axis, height: Axis) {
         self.width = width
@@ -180,7 +180,7 @@ extension SizeConstraint {
 extension SizeConstraint {
     /// This property wrapper checks the value of `atMost` cases, and turns it into an
     /// `unconstrained` axis if the value equals `greatestFiniteMagnitude` or `isInfinite`.
-    @propertyWrapper public struct UnconstrainedInfiteAxis: Equatable, Hashable {
+    @propertyWrapper public struct UnconstrainedInfiniteAxis: Equatable, Hashable {
         private var correctedAxis: Axis
 
         public var wrappedValue: Axis {

--- a/BlueprintUI/Tests/UnconstrainedInfiniteAxisTests.swift
+++ b/BlueprintUI/Tests/UnconstrainedInfiniteAxisTests.swift
@@ -1,0 +1,56 @@
+import BlueprintUI
+import XCTest
+
+class UnconstrainedInfiniteAxisTests: XCTestCase {
+    struct ConstrainedAxis {
+        @SizeConstraint.UnconstrainedInfiniteAxis var axis: SizeConstraint.Axis
+    }
+
+    func test_initialValue() {
+        do {
+            let axis = ConstrainedAxis(axis: .atMost(.infinity))
+            XCTAssertEqual(axis.axis, .unconstrained)
+        }
+
+        do {
+            let axis = ConstrainedAxis(axis: .atMost(.greatestFiniteMagnitude))
+            XCTAssertEqual(axis.axis, .unconstrained)
+        }
+
+        do {
+            let axis = ConstrainedAxis(axis: .atMost(100))
+            XCTAssertEqual(axis.axis, .atMost(100))
+        }
+
+        do {
+            let axis = ConstrainedAxis(axis: .unconstrained)
+            XCTAssertEqual(axis.axis, .unconstrained)
+        }
+    }
+
+    func test_settingValue() {
+        do {
+            var axis = ConstrainedAxis(axis: .atMost(100))
+            axis.axis = .atMost(.infinity)
+            XCTAssertEqual(axis.axis, .unconstrained)
+        }
+
+        do {
+            var axis = ConstrainedAxis(axis: .atMost(100))
+            axis.axis = .atMost(.greatestFiniteMagnitude)
+            XCTAssertEqual(axis.axis, .unconstrained)
+        }
+
+        do {
+            var axis = ConstrainedAxis(axis: .atMost(100))
+            axis.axis = .atMost(200)
+            XCTAssertEqual(axis.axis, .atMost(200))
+        }
+
+        do {
+            var axis = ConstrainedAxis(axis: .atMost(100))
+            axis.axis = .unconstrained
+            XCTAssertEqual(axis.axis, .unconstrained)
+        }
+    }
+}


### PR DESCRIPTION
This init for `Axis` attempts to handle this, but there are many ways to create a constraint axis with a value of `.atMost([.greatestFiniteMagnitude|.infinity])` - e.g., using the enum case directly rather than the initializer. This PR ensures any constraint axes set on a `SizeConstraint` get set to unconstrained if it's one of those values.