### PR TITLE
Return UIView.noIntrinsicMetric for intrinsicContentSize when there is no element

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -188,7 +188,12 @@ public final class BlueprintView: UIView {
     /// UILabel’s `intrinsicContentSize` behavior)
     public override var intrinsicContentSize: CGSize {
 
-        guard let element = element else { return .zero }
+        guard let element = element else {
+            return CGSize(
+                width: UIView.noIntrinsicMetric,
+                height: UIView.noIntrinsicMetric
+            )
+        }
 
         let constraint: SizeConstraint
 

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -496,6 +496,30 @@ class BlueprintViewTests: XCTestCase {
         // of their children, so things like focus triggers can be set up.
         wait(for: [childViewDescriptionApplied, parentAppeared], timeout: 1, enforceOrder: true)
     }
+
+    func test_intrinsicContentSize_noElement() {
+        let view = BlueprintView()
+
+        let noIntrinsicMetricSize = CGSize(
+            width: UIView.noIntrinsicMetric,
+            height: UIView.noIntrinsicMetric
+        )
+
+        XCTAssertEqual(view.intrinsicContentSize, noIntrinsicMetricSize)
+    }
+
+    func test_intrinsicContentSize_constrained() {
+        let view = BlueprintView()
+
+        let size = CGSize(
+            width: 42,
+            height: 7
+        )
+
+        view.element = Empty().constrainedTo(size: size)
+
+        XCTAssertEqual(view.intrinsicContentSize, size)
+    }
 }
 
 fileprivate struct MeasurableElement: Element {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `BlueprintView`'s `intrinsicContentSize` will now return `UIView.noIntrinsicMetric` if there is no `element` associated with it.
+
 ### Deprecated
 
 ### Security


### PR DESCRIPTION
When building out support for custom input views I noticed a log message when UIKit attempted to interact with a `BlueprintView` that didn't have an element set yet:

> 2021-09-14 15:01:12.232905-0700 Demo[23792:556733] API error: <MarketUI.MarketInputViewElementContainer: 0x7ff394d34460; baseClass = UIInputView; frame = (0 0; 390 71); layer = <CALayer: 0x600003d390a0>> returned 0 width, assuming UIViewNoIntrinsicMetric

According to [the docs for `UIView.intrinsicContentSize`](https://developer.apple.com/documentation/uikit/uiview/1622600-intrinsiccontentsize):

> If a custom view has no intrinsic size for a given dimension, it can use noIntrinsicMetric for that dimension.
