### PR TITLE
Make merge public, so we don't stomp environments in Listable env bridging

### DIFF
--- a/BlueprintUI/Sources/Environment/Environment.swift
+++ b/BlueprintUI/Sources/Environment/Environment.swift
@@ -73,7 +73,7 @@ public struct Environment {
     /// Returns a new `Environment` by merging the values from `self` and the
     /// provided environment; keeping values from the provided environment when there
     /// are key overlaps between the two environments.
-    func merged(prioritizing other: Environment) -> Environment {
+    public func merged(prioritizing other: Environment) -> Environment {
         var merged = self
         merged.values.merge(other.values) { $1 }
         return merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `merged(prioritizing:)` on `Environment` is now public, to allow for use cases where environments need to be manually bridged between views.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
- Listable has to manually bridge environments from the outer list view, to the inner blueprint views within the cells of the list. The current method we use stomps the environment whole, which can sometimes means we drop environment properties. Safer to merge them instead, but to do that, I need this method!