### PR TITLE
Read Xcode version from common env file

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,11 +7,18 @@ on:
 jobs:
   build:
     name: Generate docs with jazzy and publish to Github pages
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Read env
+        run: cat .github/workflows/env.properties >> $GITHUB_ENV
+
+      - name: Switch to Xcode ${{ env.xcode_version }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app
+
       - name: Generate Docs
         run: |
           bundle

--- a/.github/workflows/env.properties
+++ b/.github/workflows/env.properties
@@ -1,0 +1,1 @@
+xcode_version=12.5.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,11 +9,17 @@ on:
 jobs:
   lint:
     name: Lint Swift code with SwiftFormat
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Read env
+        run: cat .github/workflows/env.properties >> $GITHUB_ENV
+
+      - name: Switch to Xcode ${{ env.xcode_version }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app
 
       - name: Cache SPM build
         uses: actions/cache@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,8 +30,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Switch to Xcode 12.5.1
-      run: sudo xcode-select -s /Applications/Xcode_12.5.1.app
+    - name: Read env
+      run: cat .github/workflows/env.properties >> $GITHUB_ENV
+
+    - name: Switch to Xcode ${{ env.xcode_version }}
+      run: sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app
 
     - name: Install iOS ${{ matrix.sdk }}
       run: xcversion simulators --install="iOS ${{ matrix.sdk }}"
@@ -54,18 +57,24 @@ jobs:
 
 
   cocoapods:
-    name: "Cocoapods"
+    name: "CocoaPods"
 
     runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v1
 
-    - name: Cache gems
-      uses: actions/cache@v1
+    - name: Read env
+      run: cat .github/workflows/env.properties >> $GITHUB_ENV
+
+    - name: Switch to Xcode ${{ env.xcode_version }}
+      run: sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
       with:
-          path: .bundle
-          key: gems-${{ hashFiles('Gemfile.lock') }}
+        ruby-version: 2.6
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
     - name: Bundle Install
       run: |
@@ -74,9 +83,6 @@ jobs:
     - name: Pod Install
       run: |
         bundle exec pod install --project-directory=SampleApp/
-
-    - name: Switch to Xcode 12.5.1
-      run: sudo xcode-select -s /Applications/Xcode_12.5.1.app
 
     - name: Build & Test
       run: |


### PR DESCRIPTION
The doc generation job has been failing since we updated to Xcode 12.5.1. This updates all the workflows to read the Xcode version from a file. There doesn't seem to be an easier to way to share environment variables across workflows, from what I could find.