### PR TITLE
Change how we cache sizing across sizeThatFits and autolayout

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -148,7 +148,7 @@ public final class BlueprintView: UIView {
     }
 
     ///
-    /// Measures the size needed to display the view within then given constraining size,
+    /// Measures the size needed to display the view within the given constraining size,
     /// by measuring the current `element` of the `BlueprintView`.
     ///
     /// If you would like to not constrain the measurement in a given axis,
@@ -166,9 +166,6 @@ public final class BlueprintView: UIView {
     /// ```
     ///
     public override func sizeThatFits(_ fittingSize: CGSize) -> CGSize {
-        guard let element = element else {
-            return .zero
-        }
 
         func measurementConstraint(with size: CGSize) -> SizeConstraint {
 
@@ -183,7 +180,15 @@ public final class BlueprintView: UIView {
             )
         }
 
-        let constraint = measurementConstraint(with: fittingSize)
+        return sizeThatFits(measurementConstraint(with: fittingSize))
+    }
+
+    /// Measures the size needed to display the view within the given `SizeConstraint`.
+    /// by measuring the current `element` of the `BlueprintView`.
+    public func sizeThatFits(_ constraint: SizeConstraint) -> CGSize {
+        guard let element = element else {
+            return .zero
+        }
 
         if let cachedSize = sizesThatFit[constraint] {
             return cachedSize
@@ -240,15 +245,15 @@ public final class BlueprintView: UIView {
             )
         }
 
-        let constraint = { () -> SizeConstraint in
+        func constraint() -> SizeConstraint {
             if bounds.width == 0 {
                 return .unconstrained
             } else {
                 return .init(width: bounds.width)
             }
-        }()
+        }
 
-        return sizeThatFits(constraint.maximum)
+        return sizeThatFits(constraint())
     }
 
     public override var semanticContentAttribute: UISemanticContentAttribute {
@@ -276,6 +281,8 @@ public final class BlueprintView: UIView {
         setNeedsViewHierarchyUpdate()
     }
 
+    /// Clears any sizing caches, invalidates the `intrinsicContentSize` of the
+    /// view, and marks the view as needing a layout.
     private func setNeedsViewHierarchyUpdate() {
 
         invalidateIntrinsicContentSize()

--- a/BlueprintUI/Sources/Environment/Environment.swift
+++ b/BlueprintUI/Sources/Environment/Environment.swift
@@ -71,7 +71,7 @@ public struct Environment {
     }
 
     /// If the `Environment` contains any values.
-    public var isEmpty: Bool {
+    var isEmpty: Bool {
         values.isEmpty
     }
 

--- a/BlueprintUI/Sources/Environment/Environment.swift
+++ b/BlueprintUI/Sources/Environment/Environment.swift
@@ -70,6 +70,10 @@ public struct Environment {
         }
     }
 
+    public var isEmpty: Bool {
+        values.isEmpty
+    }
+
     /// Returns a new `Environment` by merging the values from `self` and the
     /// provided environment; keeping values from the provided environment when there
     /// are key overlaps between the two environments.

--- a/BlueprintUI/Sources/Environment/Environment.swift
+++ b/BlueprintUI/Sources/Environment/Environment.swift
@@ -70,6 +70,7 @@ public struct Environment {
         }
     }
 
+    /// If the `Environment` contains any values.
     public var isEmpty: Bool {
         values.isEmpty
     }

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -610,10 +610,22 @@ class BlueprintViewTests: XCTestCase {
         XCTAssertEqual(view.sizeThatFits(.init(width: 100, height: 200)), size2)
         XCTAssertEqual(measureCount, 5)
 
+        // If the environment goes from empty to empty, no measurement should occur.
+
+        view.environment = .empty
+
+        XCTAssertEqual(view.intrinsicContentSize, size2)
+        XCTAssertEqual(measureCount, 5)
+
+        XCTAssertEqual(view.sizeThatFits(.init(width: 100, height: 200)), size2)
+        XCTAssertEqual(measureCount, 5)
+
         // Changing the environment should re-measure (any change should do,
         // the environment has no concept of equality presently).
 
-        view.environment = .empty
+        var newEnv = Environment.empty
+        newEnv.safeAreaInsets = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
+        view.environment = newEnv
 
         XCTAssertEqual(view.intrinsicContentSize, size2)
         XCTAssertEqual(measureCount, 6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Environment` now has an `isEmpty`, to check to see if the environment contains any values.
+
 ### Removed
 
 ### Changed
+
+- Values returned from `sizeThatFits` and `systemLayoutSizeFitting` are now cached.
 
 ### Deprecated
 


### PR DESCRIPTION
@n8chur recently added support for caching intrinsic content size, which made me wonder: Why don't we do this everywhere? This will provide benefits for any existing impl which calls `sizeThatFits` or relies on the other autolayout methods, since we now only do an expensive re-measure when content has actually changed.

### Changes
- `sizeThatFits` now also caches results.
- `intrinsicContentSize` is now backed by `sizeThatFits`.
- Added `systemLayoutSizeFitting...` overrides to call through to `sizeThatFits`.
- We invalidate sizing when environment, safe area, etc, change.

### One more thing!
The old impl of `intrinsicContentSize` would use an unconstrained width if we had a new element, but had not yet laid out. This seems really wrong to me, since it was very inconsistent and hard to predict, to the point of non-determinism: Had you laid out yet? Great! Your constraint is the view width! Had you not? Uhh, you have no width constraint. This is a behaviour change, and there was value to the old behaviour, so it might make sense to add an optional/mode for this. Thoughts?