### PR TITLE
Improve result builder error messages

### DIFF
--- a/BlueprintUI/Sources/Layout/Builder.swift
+++ b/BlueprintUI/Sources/Layout/Builder.swift
@@ -23,6 +23,15 @@ public struct Builder<Child> {
         [child]
     }
 
+    @available(
+        *,
+        unavailable,
+        message: "Optionals must be unwrapped with `if let value = ...` to be returned from a result builder."
+    )
+    public static func buildExpression(_ child: Child?) -> Children {
+        fatalError()
+    }
+
     /// Allow for an array of `Child` to be flattened into the overall result.
     public static func buildExpression(_ children: [Child]) -> Children {
         children

--- a/BlueprintUI/Sources/Layout/Builder.swift
+++ b/BlueprintUI/Sources/Layout/Builder.swift
@@ -29,6 +29,16 @@ public struct Builder<Child> {
         message: "Optionals must be unwrapped with `if let value = ...` to be returned from a result builder."
     )
     public static func buildExpression(_ child: Child?) -> Children {
+
+        /// This method ensures better compile-time error messages are shown when
+        /// returning an `Optional` from a result builder. Without this method,
+        /// when an `Optional` is returned from a result builder, the compiler
+        /// will instead resolve the `configure`-based version of our component
+        /// initializers, resulting in a confusing error message.
+        ///
+        /// Adding this explicit override ensures that the compiler continues to attempt to resolve
+        /// the trailing closure as a result builder-based closure, and returns the above error message.
+
         fatalError()
     }
 

--- a/BlueprintUI/Sources/Layout/ElementBuilder.swift
+++ b/BlueprintUI/Sources/Layout/ElementBuilder.swift
@@ -7,6 +7,15 @@ extension ElementBuilder {
         [Child(element)]
     }
 
+    @available(
+        *,
+        unavailable,
+        message: "Optionals must be unwrapped with `if let value = ...` to be returned from a result builder."
+    )
+    public static func buildExpression(_ child: Element?) -> Children {
+        fatalError()
+    }
+
     /// Allow Elements to be implicitly converted into `Child`.
     public static func buildExpression(_ elements: [Element]) -> Children {
         elements.map(Child.init)

--- a/BlueprintUI/Sources/Layout/ElementBuilder.swift
+++ b/BlueprintUI/Sources/Layout/ElementBuilder.swift
@@ -13,6 +13,16 @@ extension ElementBuilder {
         message: "Optionals must be unwrapped with `if let value = ...` to be returned from a result builder."
     )
     public static func buildExpression(_ child: Element?) -> Children {
+
+        /// This method ensures better compile-time error messages are shown when
+        /// returning an `Optional` from a result builder. Without this method,
+        /// when an `Optional` is returned from a result builder, the compiler
+        /// will instead resolve the `configure`-based version of our component
+        /// initializers, resulting in a confusing error message.
+        ///
+        /// Adding this explicit override ensures that the compiler continues to attempt to resolve
+        /// the trailing closure as a result builder-based closure, and returns the above error message.
+
         fatalError()
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Improved error messages when using result builders with optional values.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
Because we have `configure` and result builder variants; the compiler gets confused if you try to return an optional value from a result builder with trailing closure syntax, and gives a non-obvious error. Adding these overloads provides a clearer error.

Before:
![image](https://user-images.githubusercontent.com/327847/140952662-01871cca-6c38-4742-9760-4e7723524d25.png)

After:
![image](https://user-images.githubusercontent.com/327847/140952556-237863be-f227-4466-97a8-a22bc7366e44.png)
