### PR TITLE
Improve assertion messages for unconstrained values

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -241,10 +241,11 @@ public final class BlueprintView: UIView {
     private func updateViewHierarchyIfNeeded() {
         guard needsViewHierarchyUpdate || bounds != lastViewHierarchyUpdateBounds else { return }
 
-        assert(
+        precondition(
             !isInsideUpdate,
             "Reentrant updates are not supported in BlueprintView. Ensure that view events from within the hierarchy are not synchronously triggering additional updates."
         )
+
         isInsideUpdate = true
 
         needsViewHierarchyUpdate = false

--- a/BlueprintUI/Sources/Layout/LayoutAttributes.swift
+++ b/BlueprintUI/Sources/Layout/LayoutAttributes.swift
@@ -152,19 +152,54 @@ public struct LayoutAttributes {
     }
 
     private func validateBounds() {
-        assert(bounds.isFinite, "LayoutAttributes.bounds must only contain finite values.")
+        assert(
+            bounds.width.isFinite,
+            """
+            The `width` of this `LayoutAttributes` is infinite, which is meaningless. \
+            This usually means that you are attempting to use the `constraint.width.maximum`
+            of a `SizeConstraint` for measurement or sizing, but \
+            that `SizeConstraint` has no actual maximum value for its `width`.
+
+            You should likely use `constraint.width.constrainedValue`, which is an
+            optional value, and provide a default width for unconstrained measurements. Or, \
+            you should ensure that you are not measuring against unconstrained sizes.
+            """
+        )
+
+        assert(
+            bounds.height.isFinite,
+            """
+            The `height` of this `LayoutAttributes` is infinite, which is meaningless. \
+            This usually means that you are attempting to use the `constraint.height.maximum`
+            of a `SizeConstraint` for measurement or sizing, but \
+            that `SizeConstraint` has no actual maximum value for its `height`.
+
+            You should likely use `constraint.height.constrainedValue`, which is an
+            optional value, and provide a default height for unconstrained measurements. Or, \
+            you should ensure that you are not measuring against unconstrained sizes.
+            """
+        )
     }
 
     private func validateCenter() {
-        assert(center.isFinite, "LayoutAttributes.center must only contain finite values.")
+        assert(
+            center.isFinite,
+            "LayoutAttributes.center must only contain finite values."
+        )
     }
 
     private func validateTransform() {
-        assert(transform.isFinite, "LayoutAttributes.transform only not contain finite values.")
+        assert(
+            transform.isFinite,
+            "LayoutAttributes.transform only not contain finite values."
+        )
     }
 
     private func validateAlpha() {
-        assert(alpha.isFinite, "LayoutAttributes.alpha must only contain finite values.")
+        assert(
+            alpha.isFinite,
+            "LayoutAttributes.alpha must only contain finite values."
+        )
     }
 
     /// Performs rounding on the frame to snap to pixel boundaries.


### PR DESCRIPTION
Improve the unconstrained assertion messages – these seem to always confuse people.