### PR TITLE
Adjust keyboard inset correctly

### DIFF
--- a/BlueprintUICommonControls/Sources/ScrollView.swift
+++ b/BlueprintUICommonControls/Sources/ScrollView.swift
@@ -357,7 +357,7 @@ fileprivate final class ScrollerWrapperView: UIView {
     private func applyContentInset(with scrollView: ScrollView) {
         let contentInset = ScrollView.calculateContentInset(
             scrollViewInsets: scrollView.contentInset,
-            safeAreaInsets: safeAreaInsets,
+            adjustedContentInsets: self.scrollView.adjustedContentInset,
             keyboardBottomInset: bottomContentInsetAdjustmentForKeyboard,
             refreshControlState: scrollView.pullToRefreshBehavior,
             refreshControlBounds: refreshControl?.bounds
@@ -407,7 +407,7 @@ extension ScrollView {
 
     static func calculateContentInset(
         scrollViewInsets: UIEdgeInsets,
-        safeAreaInsets: UIEdgeInsets,
+        adjustedContentInsets: UIEdgeInsets,
         keyboardBottomInset: CGFloat,
         refreshControlState: PullToRefreshBehavior,
         refreshControlBounds: CGRect?
@@ -421,7 +421,7 @@ extension ScrollView {
 
             // Exclude the safe area insets, so the content hugs the top of the keyboard.
 
-            finalContentInset.bottom -= safeAreaInsets.bottom
+            finalContentInset.bottom -= adjustedContentInsets.bottom
         }
 
         if #available(iOS 13, *) {
@@ -452,7 +452,7 @@ extension ScrollerWrapperView: KeyboardObserverDelegate {
 
         let contentInset = ScrollView.calculateContentInset(
             scrollViewInsets: representedElement.contentInset,
-            safeAreaInsets: safeAreaInsets,
+            adjustedContentInsets: scrollView.adjustedContentInset,
             keyboardBottomInset: bottomContentInsetAdjustmentForKeyboard,
             refreshControlState: representedElement.pullToRefreshBehavior,
             refreshControlBounds: refreshControl?.bounds

--- a/BlueprintUICommonControls/Tests/Sources/ScrollViewTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/ScrollViewTests.swift
@@ -23,7 +23,7 @@ class ScrollViewTests: XCTestCase {
 
             ScrollView.calculateContentInset(
                 scrollViewInsets: .zero,
-                safeAreaInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),
+                adjustedContentInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),
                 keyboardBottomInset: .zero,
                 refreshControlState: .disabled,
                 refreshControlBounds: CGRect(origin: .zero, size: CGSize(width: 25.0, height: 25.0))
@@ -37,7 +37,7 @@ class ScrollViewTests: XCTestCase {
 
             ScrollView.calculateContentInset(
                 scrollViewInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),
-                safeAreaInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),
+                adjustedContentInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),
                 keyboardBottomInset: 50.0,
                 refreshControlState: .disabled,
                 refreshControlBounds: CGRect(origin: .zero, size: CGSize(width: 25.0, height: 25.0))
@@ -59,7 +59,7 @@ class ScrollViewTests: XCTestCase {
 
             ScrollView.calculateContentInset(
                 scrollViewInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),
-                safeAreaInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),
+                adjustedContentInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),
                 keyboardBottomInset: 50.0,
                 refreshControlState: .refreshing,
                 refreshControlBounds: CGRect(origin: .zero, size: CGSize(width: 25.0, height: 25.0))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue where the keyboard inset adjustment was incorrect in some cases.
+
 ### Added
 
 ### Removed


### PR DESCRIPTION
This was using safeAreaInsets, however if the scroll view wasn't adjusting the content inset for the safe area (because the content wasn't tall enough) then the inset for the keyboard wasn't large enough (meaning you couldn't scroll to the bottom of the content; it would underlap the keyboard). Instead, we should use the actual adjusted safe area insets to adjust the keyboard inset.