### PR TITLE
Add support for for loop and available checks in result builders

### DIFF
--- a/BlueprintUI/Sources/Layout/Builder.swift
+++ b/BlueprintUI/Sources/Layout/Builder.swift
@@ -43,7 +43,7 @@ public struct Builder<Child> {
     }
 
     public static func buildArray(_ components: [Children]) -> Children {
-        components.reduce(into: []) { $0 += $1 }
+        components.flatMap { $0 }
     }
 
     public static func buildArray(_ components: Children) -> Children {

--- a/BlueprintUI/Sources/Layout/Builder.swift
+++ b/BlueprintUI/Sources/Layout/Builder.swift
@@ -42,6 +42,18 @@ public struct Builder<Child> {
         fatalError()
     }
 
+    public static func buildArray(_ components: [Children]) -> Children {
+        components.reduce(into: []) { $0 += $1 }
+    }
+
+    public static func buildArray(_ components: Children) -> Children {
+        components
+    }
+
+    public static func buildLimitedAvailability(_ component: Children) -> Children {
+        component
+    }
+
     /// Allow for an array of `Child` to be flattened into the overall result.
     public static func buildExpression(_ children: [Child]) -> Children {
         children

--- a/BlueprintUI/Tests/BuilderTests.swift
+++ b/BlueprintUI/Tests/BuilderTests.swift
@@ -1,0 +1,168 @@
+//
+//  BuilderTests.swift
+//  BlueprintUI-Unit-Tests
+//
+//  Created by Kyle Van Essen on 11/10/21.
+//
+
+import BlueprintUI
+import XCTest
+
+
+
+/// Note: The tests in this type should be kept in sync with `ElementBuilderTests`.
+class BuilderTests: XCTestCase {
+
+    func test_empty() {
+        let content: [String] = build {}
+
+        XCTAssertEqual(content, [])
+    }
+
+    func test_single() {
+        let content: [String] = build {
+            "1"
+        }
+
+        XCTAssertEqual(
+            content, ["1"]
+        )
+    }
+
+    func test_multiple() {
+        let content: [String] = build {
+            "1"
+            "2"
+        }
+
+        XCTAssertEqual(
+            content, ["1", "2"]
+        )
+    }
+
+    func test_array() {
+
+        let content: [String] = build {
+            ["1", "2"]
+        }
+
+        XCTAssertEqual(
+            content, ["1", "2"]
+        )
+    }
+
+    func test_if_else() {
+
+        /// If we use just `true` or `false`, the compiler (rightly) complains about unreachable code.
+        let trueValue = "true" == "true"
+        let falseValue = "true" == "false"
+
+        let content: [String] = build {
+            "1"
+
+            if trueValue {
+                "2"
+            } else {
+                "3"
+            }
+
+            if falseValue {
+                "4"
+            } else {
+                "5"
+            }
+
+            if falseValue {
+                "6"
+            } else if falseValue {
+                "7"
+            }
+        }
+
+        XCTAssertEqual(
+            content, ["1", "2", "5"]
+        )
+    }
+
+    func test_for_in() {
+
+        let content: [String] = build {
+            for item in 1...6 {
+                if item % 2 == 0 {
+                    "\(item)"
+                }
+            }
+        }
+
+        XCTAssertEqual(
+            content, ["2", "4", "6"]
+        )
+    }
+
+    func test_map() {
+
+        let numbers: [Int] = [1, 2, 3]
+
+        let content: [String] = build {
+            numbers.map(String.init)
+        }
+
+        XCTAssertEqual(
+            content, ["1", "2", "3"]
+        )
+    }
+
+    func test_switch() {
+
+        enum TestEnum: CaseIterable {
+            case first
+            case second
+            case third
+        }
+
+        let content: [String] = build {
+            for item in TestEnum.allCases {
+                switch item {
+                case .first:
+                    "1"
+                case .second:
+                    "2"
+                case .third:
+                    "3"
+                }
+            }
+        }
+
+        XCTAssertEqual(
+            content, ["1", "2", "3"]
+        )
+    }
+
+    func test_available() {
+
+        let content: [String] = build {
+
+            if #available(iOS 20, *) {
+                "1"
+            } else {
+                "2"
+            }
+
+            if #available(iOS 11, *) {
+                "3"
+            } else {
+                "4"
+            }
+        }
+
+        XCTAssertEqual(
+            content, ["2", "3"]
+        )
+    }
+
+    fileprivate func build<Content>(
+        @Builder<Content> using builder: () -> [Content]
+    ) -> [Content] {
+        builder()
+    }
+}

--- a/BlueprintUI/Tests/ElementBuilderTests.swift
+++ b/BlueprintUI/Tests/ElementBuilderTests.swift
@@ -132,6 +132,37 @@ class ElementBuilderTests: XCTestCase {
             XCTAssert(type(of: gridRow.children[0].element) == TestElement3.self)
         }
     }
+
+    func test_resultBuilder_for_loop() {
+
+        let gridRow = GridRow {
+            for _ in 1...3 {
+                TestElement()
+            }
+        }
+
+        XCTAssertEqual(gridRow.children.count, 3)
+    }
+
+    func test_resultBuilder_available() {
+
+        let gridRow = GridRow {
+            if #available(iOS 30.0, *) {
+                TestElement()
+            } else {
+                TestElement2()
+            }
+
+            if #available(iOS 11.0, *) {
+                TestElement3()
+            }
+        }
+
+        XCTAssertEqual(gridRow.children.count, 2)
+
+        XCTAssert(type(of: gridRow.children[0].element) == TestElement2.self)
+        XCTAssert(type(of: gridRow.children[1].element) == TestElement3.self)
+    }
 }
 
 private struct TestElement: Element {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for `for...in` loops and `available` checks to result builder APIs.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
- This fixes some build errors when you try to use `for...in` loops or `available` checks in result builders. I copied the tests over from Listable to ensure everything works on the base type.