### PR TITLE
Allow specifying an explicit constraint when measuring in a GeometryProxy

### DIFF
--- a/BlueprintUI/Sources/Layout/GeometryReader.swift
+++ b/BlueprintUI/Sources/Layout/GeometryReader.swift
@@ -48,8 +48,8 @@ public struct GeometryProxy {
     /// The size constraint of the element being laid out.
     public var constraint: SizeConstraint
 
-    /// Measure the given element, using this proxy's constraint and the current environment.
-    public func measure(element: Element) -> CGSize {
-        element.content.measure(in: constraint, environment: environment)
+    /// Measure the given element, using the provided constraint (or the proxy's constraint if not provided), and the current environment.
+    public func measure(in explicit: SizeConstraint? = nil, element: Element) -> CGSize {
+        element.content.measure(in: explicit ?? constraint, environment: environment)
     }
 }

--- a/BlueprintUI/Sources/Layout/GeometryReader.swift
+++ b/BlueprintUI/Sources/Layout/GeometryReader.swift
@@ -49,7 +49,7 @@ public struct GeometryProxy {
     public var constraint: SizeConstraint
 
     /// Measure the given element, using the provided constraint (or the proxy's constraint if not provided), and the current environment.
-    public func measure(in explicit: SizeConstraint? = nil, element: Element) -> CGSize {
+    public func measure(element: Element, in explicit: SizeConstraint? = nil) -> CGSize {
         element.content.measure(in: explicit ?? constraint, environment: environment)
     }
 }

--- a/BlueprintUI/Sources/Layout/GeometryReader.swift
+++ b/BlueprintUI/Sources/Layout/GeometryReader.swift
@@ -48,7 +48,7 @@ public struct GeometryProxy {
     /// The size constraint of the element being laid out.
     public var constraint: SizeConstraint
 
-    /// Measure the given element, using the provided constraint (or the proxy's constraint if not provided), and the current environment.
+    /// Measure the given element, constrained to the same size as the `GeometryProxy` itself (unless a constraint is explicitly provided).
     public func measure(element: Element, in explicit: SizeConstraint? = nil) -> CGSize {
         element.content.measure(in: explicit ?? constraint, environment: environment)
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Allow measuring within an explicit `SizeConstraint` in `GeometryProxy`.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
In Market, we have this method:

```
extension GeometryProxy {
    func element(
        ifFitsWidth: @autoclosure () -> Element,
        else fallback: @autoclosure () -> Element
    ) -> Element {
        let ifFitsWidthElement = ifFitsWidth()
        
        if measure(element: ifFitsWidthElement).width <= constraint.maximum.width {
            return ifFitsWidthElement
        } else {
            return fallback()
        }
    }
}
```

Which utilizes `measure(element:)` on `GeometryProxy`. However, this is not actually a correct implementation of `ifFitsWidth`. The problem is we're not actually passing an `.unconstrained` width to the element during this measurement, we're passing the constraint of the `GeometryProxy`:

```
public struct GeometryProxy {
    var environment: Environment

    /// The size constraint of the element being laid out.
    public var constraint: SizeConstraint

    /// Measure the given element, using this proxy's constraint and the current environment.
    public func measure(element: Element) -> CGSize {
        element.content.measure(in: constraint, environment: environment)
    }
}
```

So thus, if the `ifFitsWidth` contains any sort of element (eg, a text label) which will "re-flow" when it hits a width constraint, the measurement will result in a width `<= constraint.maximum.width`, and we will return "yes, I do fit the width!", when in reality, it does not. 

Thus, introduce a way to specify an explicit constraint when calling `measure`; while still measuring within the `GeometryProxy`'s `Environment`.