### PR TITLE
Add an ElementContent.init(measureFunction:) variant which takes in an environment

### DIFF
--- a/BlueprintUI/Sources/Layout/LayoutWriter.swift
+++ b/BlueprintUI/Sources/Layout/LayoutWriter.swift
@@ -47,7 +47,7 @@ public struct LayoutWriter: Element {
     //
 
     public var content: ElementContent {
-        ElementContent { size, env in
+        ElementContent { size, env -> Element in
             var builder = Builder()
             self.build(Context(size: size), &builder)
 

--- a/BlueprintUI/Tests/ElementContentTests.swift
+++ b/BlueprintUI/Tests/ElementContentTests.swift
@@ -74,6 +74,25 @@ class ElementContentTests: XCTestCase {
         )
     }
 
+    func test_measureFunction() {
+        let expectedConstraint = SizeConstraint(width: .atMost(100), height: .atMost(200))
+        let expectedSafeArea = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
+
+        let content = ElementContent { constraint, env -> CGSize in
+            XCTAssertEqual(constraint, expectedConstraint)
+            XCTAssertEqual(env.safeAreaInsets, expectedSafeArea)
+
+            return CGSize(width: 10, height: 20)
+        }
+
+        var env = Environment.empty
+        env.safeAreaInsets = UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
+
+        let size = content.measure(in: expectedConstraint, environment: env)
+
+        XCTAssertEqual(size, CGSize(width: 10, height: 20))
+    }
+
     func test_cacheTree() {
         let size1 = CGSize(width: 10, height: 15)
         let size2 = CGSize(width: 20, height: 25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an `ElementContent` variant whose `measureFunction` takes in both a `SizeConstraint` and an `Environment`.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
Adds a new variant to `ElementContent`, where the `measureFunction` takes in an `Environment`. This allows us to stop doing things like this:

```swift
public var content: ElementContent {
    ElementContent { constraint -> CGSize in
        makeElement(for: .normal)
            .content
            .measure(in: constraint, environment: .empty)
    }
}
```

And instead pass the correct environment:

```swift
public var content: ElementContent {
    ElementContent { constraint, env -> CGSize in
        makeElement(for: .normal)
            .content
            .measure(in: constraint, environment: env)
    }
}
```