### PR TITLE
Adjust scroll view inset correctly and release bug fix

### DIFF
--- a/BlueprintUICommonControls/Sources/ScrollView.swift
+++ b/BlueprintUICommonControls/Sources/ScrollView.swift
@@ -357,6 +357,7 @@ fileprivate final class ScrollerWrapperView: UIView {
     private func applyContentInset(with scrollView: ScrollView) {
         let contentInset = ScrollView.calculateContentInset(
             scrollViewInsets: scrollView.contentInset,
+            contentInsets: scrollView.contentInset,
             adjustedContentInsets: self.scrollView.adjustedContentInset,
             keyboardBottomInset: bottomContentInsetAdjustmentForKeyboard,
             refreshControlState: scrollView.pullToRefreshBehavior,
@@ -407,12 +408,18 @@ extension ScrollView {
 
     static func calculateContentInset(
         scrollViewInsets: UIEdgeInsets,
+        contentInsets: UIEdgeInsets,
         adjustedContentInsets: UIEdgeInsets,
         keyboardBottomInset: CGFloat,
         refreshControlState: PullToRefreshBehavior,
         refreshControlBounds: CGRect?
     ) -> UIEdgeInsets {
         var finalContentInset = scrollViewInsets
+
+        // The safe area may not actually be applied to the scroll view depending on
+        // the content height and inset adjustment mode. We need to determine the actual applied
+        // safe area insets by subtracting the content inset from the adjusted content inset.
+        let appliedSafeAreaInset = adjustedContentInsets - contentInsets
 
         // Include the keyboard's adjustment at the bottom of the scroll view.
 
@@ -421,7 +428,7 @@ extension ScrollView {
 
             // Exclude the safe area insets, so the content hugs the top of the keyboard.
 
-            finalContentInset.bottom -= adjustedContentInsets.bottom
+            finalContentInset.bottom -= appliedSafeAreaInset.bottom
         }
 
         if #available(iOS 13, *) {
@@ -452,6 +459,7 @@ extension ScrollerWrapperView: KeyboardObserverDelegate {
 
         let contentInset = ScrollView.calculateContentInset(
             scrollViewInsets: representedElement.contentInset,
+            contentInsets: scrollView.contentInset,
             adjustedContentInsets: scrollView.adjustedContentInset,
             keyboardBottomInset: bottomContentInsetAdjustmentForKeyboard,
             refreshControlState: representedElement.pullToRefreshBehavior,
@@ -542,5 +550,16 @@ extension ScrollView {
         public init(provider: @escaping Provider) {
             self.provider = provider
         }
+    }
+}
+
+extension UIEdgeInsets {
+    fileprivate static func - (lhs: UIEdgeInsets, rhs: UIEdgeInsets) -> UIEdgeInsets {
+        UIEdgeInsets(
+            top: lhs.top - rhs.top,
+            left: lhs.left - rhs.left,
+            bottom: lhs.bottom - rhs.bottom,
+            right: lhs.right - rhs.right
+        )
     }
 }

--- a/BlueprintUICommonControls/Tests/Sources/ScrollViewTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/ScrollViewTests.swift
@@ -23,6 +23,7 @@ class ScrollViewTests: XCTestCase {
 
             ScrollView.calculateContentInset(
                 scrollViewInsets: .zero,
+                contentInsets: UIEdgeInsets(top: 5, left: 4, bottom: 3, right: 2),
                 adjustedContentInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),
                 keyboardBottomInset: .zero,
                 refreshControlState: .disabled,
@@ -33,10 +34,11 @@ class ScrollViewTests: XCTestCase {
         // Keyboard Inset
 
         XCTAssertEqual(
-            UIEdgeInsets(top: 10.0, left: 11.0, bottom: 50.0, right: 13.0),
+            UIEdgeInsets(top: 10.0, left: 11.0, bottom: 53.0, right: 13.0),
 
             ScrollView.calculateContentInset(
                 scrollViewInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),
+                contentInsets: UIEdgeInsets(top: 5, left: 4, bottom: 3, right: 2),
                 adjustedContentInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),
                 keyboardBottomInset: 50.0,
                 refreshControlState: .disabled,
@@ -55,10 +57,11 @@ class ScrollViewTests: XCTestCase {
             expectedTopInset = 35.0
         }
         XCTAssertEqual(
-            UIEdgeInsets(top: expectedTopInset, left: 11.0, bottom: 50.0, right: 13.0),
+            UIEdgeInsets(top: expectedTopInset, left: 11.0, bottom: 53.0, right: 13.0),
 
             ScrollView.calculateContentInset(
                 scrollViewInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),
+                contentInsets: UIEdgeInsets(top: 5, left: 4, bottom: 3, right: 2),
                 adjustedContentInsets: UIEdgeInsets(top: 10.0, left: 11.0, bottom: 12.0, right: 13.0),
                 keyboardBottomInset: 50.0,
                 refreshControlState: .refreshing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed an issue where `ScrollView` did not adjust its content inset correctly when the keyboard height or content insets changed.
-
 ### Added
 
 ### Removed
@@ -26,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Misc
 
 # Past Releases
+
+## [0.33.2] - 2021-11-30
+
+### Fixed
+
+- Fixed an issue where `ScrollView` did not adjust its content inset correctly when the keyboard height or content insets changed.
 
 ## [0.33.1] - 2021-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue where `ScrollView` did not adjust its content inset correctly when the keyboard height or content insets changed.
+
 ### Added
 
 ### Removed

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (0.33.1)
-  - BlueprintUI/Tests (0.33.1)
-  - BlueprintUICommonControls (0.33.1):
-    - BlueprintUI (= 0.33.1)
+  - BlueprintUI (0.33.2)
+  - BlueprintUI/Tests (0.33.2)
+  - BlueprintUICommonControls (0.33.2):
+    - BlueprintUI (= 0.33.2)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 11f180c0ac1429efe5b6c742282b31e13259bfc9
-  BlueprintUICommonControls: dd8ab6222332e1cff2d6e62c34c0b5921923796f
+  BlueprintUI: 7aed8950ae54db8ea7aff5c5b9b1b9973c6b7528
+  BlueprintUICommonControls: b13cd0c779baa07520a7c071a424918526484efb
 
 PODFILE CHECKSUM: 63720a1a50b146640cc4fcc4f36d3770895c7e0d
 

--- a/version.rb
+++ b/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '0.33.1'
+BLUEPRINT_VERSION ||= '0.33.2'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))


### PR DESCRIPTION
In my basic test cases I forgot that `adjustedContentInset` _includes_ the `contentInset` - so, if the keyboard height changed, or the insets changed, and the adjustment happened again, it was incorrect. We need to use `adjustedContentInset - contentInset` to determine the applied safe area insets.

Resolves https://square.slack.com/archives/CTJ4UNLHF/p1638230791044100