### PR TITLE
Implicitly animate the Box's shadowPath

### DIFF
--- a/BlueprintUICommonControls/Sources/Box.swift
+++ b/BlueprintUICommonControls/Sources/Box.swift
@@ -334,6 +334,8 @@ fileprivate final class BoxView: UIView {
         }
     }
 
+    /// This method is overridden to provide a `ShadowPathAction` for the `shadowPath` event;
+    /// this ensure the shadow implicitly animates alongside changes in the views size.
     override func action(for layer: CALayer, forKey event: String) -> CAAction? {
         let keyPath = #keyPath(CALayer.shadowPath)
 

--- a/BlueprintUICommonControls/Sources/Box.swift
+++ b/BlueprintUICommonControls/Sources/Box.swift
@@ -334,4 +334,37 @@ fileprivate final class BoxView: UIView {
         }
     }
 
+    override func action(for layer: CALayer, forKey event: String) -> CAAction? {
+        let keyPath = #keyPath(CALayer.shadowPath)
+
+        guard event == keyPath,
+              let currentPath = layer.shadowPath,
+              let sizeAnimation = layer.animation(forKey: "bounds.size") as? CABasicAnimation
+        else {
+            return super.action(for: layer, forKey: event)
+        }
+
+        let animation = sizeAnimation.copy() as! CABasicAnimation
+        animation.keyPath = keyPath
+        animation.fromValue = currentPath
+
+        return ShadowPathAction(pendingAnimation: animation)
+    }
+}
+
+private final class ShadowPathAction: NSObject, CAAction {
+    let pendingAnimation: CABasicAnimation
+
+    init(pendingAnimation: CABasicAnimation) {
+        self.pendingAnimation = pendingAnimation
+    }
+
+    func run(forKey event: String, object anObject: Any, arguments dict: [AnyHashable: Any]?) {
+        guard let layer = anObject as? CALayer else {
+            return
+        }
+
+        pendingAnimation.toValue = layer.shadowPath
+        layer.add(pendingAnimation, forKey: pendingAnimation.keyPath)
+    }
 }

--- a/BlueprintUICommonControls/Sources/Box.swift
+++ b/BlueprintUICommonControls/Sources/Box.swift
@@ -349,24 +349,6 @@ fileprivate final class BoxView: UIView {
         let animation = sizeAnimation.copy() as! CABasicAnimation
         animation.keyPath = keyPath
         animation.fromValue = currentPath
-
-        return ShadowPathAction(pendingAnimation: animation)
-    }
-}
-
-private final class ShadowPathAction: NSObject, CAAction {
-    let pendingAnimation: CABasicAnimation
-
-    init(pendingAnimation: CABasicAnimation) {
-        self.pendingAnimation = pendingAnimation
-    }
-
-    func run(forKey event: String, object anObject: Any, arguments dict: [AnyHashable: Any]?) {
-        guard let layer = anObject as? CALayer else {
-            return
-        }
-
-        pendingAnimation.toValue = layer.shadowPath
-        layer.add(pendingAnimation, forKey: pendingAnimation.keyPath)
+        return animation
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an issue where `Box` did not implicitly animate its shadow.
+
 ### Added
 
 ### Removed


### PR DESCRIPTION
This approach is different from my fixes in Market, because I did a little more research and this seems more "correct" - rather than having a side effect of starting an animation in `layoutSubviews`, we use the same method that UIKit uses for implicit animations: returning a CAAction that runs the animation. This also ensures the system runs the animation exactly alongside the other implicit animations.

| Before | After |
|-|-|
| ![Kapture 2021-12-01 at 10 12 39](https://user-images.githubusercontent.com/3526783/144290746-f3f0a472-0973-4726-98f4-74b0e3f95613.gif) | ![Kapture 2021-12-01 at 10 14 22](https://user-images.githubusercontent.com/3526783/144290767-8740dcc6-cde7-476b-b9a1-d9b2c459ec3d.gif) |


