### PR TITLE
Introduce AttributedText

### DIFF
--- a/BlueprintUI/Sources/AttributedText/AttributedText.swift
+++ b/BlueprintUI/Sources/AttributedText/AttributedText.swift
@@ -1,0 +1,149 @@
+import UIKit
+
+/// `AttributedText` allows you to apply strongly-typed attributes to strings (much like the `AttributedString` type
+/// introduced in iOS 15). You can then access the `attributedString` property to get an attributed string with those
+/// attributes applied.
+///
+/// For example:
+///
+/// ```swift
+/// var text = AttributedText(string: "Hello, world")
+/// // Apply a font to the entire range
+/// text.font = .systemFont(ofSize: 20)
+///
+/// // Apply a color to part of the string
+/// let range = text.string.range(of: "world")!
+/// text[range].color = .blue
+///
+/// // Render the attributed text
+/// let label = AttributedLabel(attributedText: text.attributedString)
+/// ```
+///
+@dynamicMemberLookup public struct AttributedText {
+
+    /// The wrapped string, with no attributes.
+    public let string: String
+
+    /// An `NSAttributedString` representation of the attributed text.
+    public var attributedString: NSAttributedString {
+        mutableAttributedString
+    }
+
+    private let mutableAttributedString: NSMutableAttributedString
+
+    /// Create some `AttributedText` from a plain string.
+    public init(string: String) {
+        self.string = string
+        self.mutableAttributedString = NSMutableAttributedString(string: string)
+    }
+
+    /// Create some `AttributedText` from an attributed string. The attributes are preserved.
+    public init(attributedString: NSAttributedString) {
+        self.string = attributedString.string
+        self.mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
+    }
+
+    public func range<StringType: StringProtocol>(of aString: StringType) -> Range<String.Index>? {
+        string.range(of: aString)
+    }
+
+    /// Dynamic member getter or setter for any attributes defined on `TextAttributeContainer`.
+    /// Applies the attribute to the entire range of text, for example:
+    ///
+    /// ```swift
+    /// var text = AttributedText(string: "Hello, world")
+    /// text.font = .systemFont(ofSize: 20)
+    /// ```
+    /// Note that only attributes applying to the entire range will be returned. For example, if the text
+    /// has two different `font` attributes, then `text.font` will be `nil`.
+    ///
+    public subscript<Value>(dynamicMember keyPath: WritableKeyPath<TextAttributeContainer, Value>) -> Value {
+        get {
+            self[entireRange][keyPath: keyPath]
+        }
+        set {
+            self[entireRange][keyPath: keyPath] = newValue
+        }
+    }
+
+    /// Get or set a `TextAttributeContainer` for the provided range of text. This allows you to set attributes
+    /// for specific ranges using strong types:
+    ///
+    /// ```swift
+    /// var text = AttributedText(string: "Hello, world")
+    /// let range = text.string.range(of: "Hello")!
+    /// text[range].font = .systemFont(ofSize: 20)
+    /// ```
+    ///
+    /// Note that the returned `TextAttributeContainer` will only contain attributes that apply to the entire subscript
+    /// range. (Setting an attribute will set it across the subscript range regardless of any existing contents).
+    ///
+    public subscript(range: Range<String.Index>) -> TextAttributeContainer {
+        get {
+            let range = NSRange(range, in: string)
+            return makeAttributeStore(range: range)
+        }
+        set {
+            let range = NSRange(range, in: string)
+            mutableAttributedString.addAttributes(newValue.storage, range: range)
+        }
+    }
+
+    /// Concatenate two pieces of `AttributedText` together.
+    ///
+    public static func + (lhs: AttributedText, rhs: AttributedText) -> AttributedText {
+        let newString = NSMutableAttributedString(attributedString: lhs.mutableAttributedString)
+        newString.append(rhs.mutableAttributedString)
+        return AttributedText(attributedString: newString)
+    }
+
+    private var entireRange: Range<String.Index> {
+        string.startIndex..<string.endIndex
+    }
+
+    /// The implementation of this function may not be intuitive, but is necessary due to how enumerating attributes
+    /// works. For example, consider the string "Block" with the font attribute set for the whole string, the color
+    /// red set for the range of "Blo" and the color blue set for the range of "ck".
+    ///
+    /// If we get the attributes for the entire range of the string, the desired output is a
+    /// `TextAttributeContainer` with only the `font` specified, since it's the only attribute that applies to that
+    /// whole range. If we enumerate the attributes of the string however, the system will give us two results:
+    ///
+    /// - The range of "Blo" with the font and red color in the dictionary
+    /// - The range of "ck" with the font and the blue color in the dictionary
+    ///
+    /// Now we need to "merge" attributes that match across the whole range, but in practice we cannot do that: the
+    /// dictionary contains values of type "any" so we cannot compare them. We know that a font attribute is present
+    /// in both the first range and second range, but we don't know if the value is equal, and therefor valid for
+    /// the entire range.
+    ///
+    /// This leads the implementation below: first, collect the attributes present in the range at all. Secondly,
+    /// enumerate the attributes individually. The system finds the longest effective range of attributes for us, so
+    /// if the range of the found attribute matches the range we're checking, add the attribute to our text container.
+    ///
+    private func makeAttributeStore(range: NSRange) -> TextAttributeContainer {
+        var store = TextAttributeContainer.empty
+        var attributesInRange: Set<NSAttributedString.Key> = []
+
+        mutableAttributedString.enumerateAttributes(
+            in: range,
+            options: []
+        ) { attributes, _, _ in
+            attributesInRange.formUnion(attributes.keys)
+        }
+
+        for attribute in attributesInRange {
+            mutableAttributedString.enumerateAttribute(
+                attribute,
+                in: range,
+                options: []
+            ) { value, attributeRange, _ in
+                if let value = value, attributeRange == range {
+                    store.storage[attribute] = value
+                }
+            }
+        }
+
+        return store
+    }
+}

--- a/BlueprintUI/Sources/AttributedText/AttributedText.swift
+++ b/BlueprintUI/Sources/AttributedText/AttributedText.swift
@@ -30,6 +30,27 @@ import UIKit
         NSAttributedString(attributedString: mutableAttributedString)
     }
 
+    /// An iterable view into segments of the attributed string, each of which indicates where a run of identical
+    /// attributes begins or ends.
+    ///
+    public var runs: [Run] {
+        var runs: [Run] = []
+
+        mutableAttributedString.enumerateAttributes(
+            in: NSRange(entireRange, in: string),
+            options: []
+        ) { attributes, range, _ in
+            guard let range = Range(range, in: string) else {
+                return
+            }
+
+            let attributes = TextAttributeContainer(storage: attributes)
+            runs.append(Run(range: range, attributes: attributes))
+        }
+
+        return runs
+    }
+
     private var mutableAttributedString: NSMutableAttributedString
 
     /// Create some `AttributedText` from a plain string.
@@ -98,27 +119,6 @@ import UIKit
         return AttributedText(newString)
     }
 
-    /// Enumerates ranges of the provided attribute key, calling the provided closure with each value found in the
-    /// string and the range of that value. The longest effective range of an attribute may not be used, meaning that
-    /// the block may be called with consecutive attribute ranges that have the same value.
-    ///
-    public func enumerate<AttributeKey: AttributedTextKey>(
-        _ key: AttributeKey.Type,
-        using block: (AttributeKey.Value, Range<String.Index>) -> Void
-    ) {
-        mutableAttributedString.enumerateAttribute(
-            key.name,
-            in: NSRange(entireRange, in: string),
-            options: [.longestEffectiveRangeNotRequired]
-        ) { attribute, range, _ in
-            guard let range = Range(range, in: string), let attribute = attribute as? AttributeKey.Value else {
-                return
-            }
-
-            block(attribute, range)
-        }
-    }
-
     private var entireRange: Range<String.Index> {
         string.startIndex..<string.endIndex
     }
@@ -184,5 +184,26 @@ import UIKit
         }
 
         return store
+    }
+}
+
+extension AttributedText {
+
+    /// A Run represents a range of identical attributes in the attributed text.
+    ///
+    /// You can access any properties of `TextAttributeContainer` on this type using dynamic member lookup.
+    ///
+    @dynamicMemberLookup public struct Run {
+        /// The range of the run of attributes.
+        ///
+        public let range: Range<String.Index>
+
+        private let attributes: TextAttributeContainer
+
+        /// Dynamic member getter for the `TextAttributeContainer` of this run.
+        ///
+        public subscript<Value>(dynamicMember keyPath: KeyPath<TextAttributeContainer, Value>) -> Value {
+            attributes[keyPath: keyPath]
+        }
     }
 }

--- a/BlueprintUI/Sources/AttributedText/AttributedText.swift
+++ b/BlueprintUI/Sources/AttributedText/AttributedText.swift
@@ -26,6 +26,7 @@ import UIKit
 
     /// An `NSAttributedString` representation of the attributed text.
     public var attributedString: NSAttributedString {
+        // Returns a copy so that you can't mutate the underlying storage.
         NSAttributedString(attributedString: mutableAttributedString)
     }
 

--- a/BlueprintUI/Sources/AttributedText/AttributedText.swift
+++ b/BlueprintUI/Sources/AttributedText/AttributedText.swift
@@ -107,6 +107,15 @@ import UIKit
             mutableAttributedString = NSMutableAttributedString(attributedString: mutableAttributedString)
         }
 
+        let oldAttributes = makeAttributeStore(range: range)
+        let oldKeys = Set(oldAttributes.storage.keys)
+        let newKeys = Set(attributes.storage.keys)
+        let removedKeys = oldKeys.subtracting(newKeys)
+
+        for key in removedKeys {
+            mutableAttributedString.removeAttribute(key, range: range)
+        }
+
         mutableAttributedString.addAttributes(attributes.storage, range: range)
     }
 

--- a/BlueprintUI/Sources/AttributedText/AttributedText.swift
+++ b/BlueprintUI/Sources/AttributedText/AttributedText.swift
@@ -78,12 +78,13 @@ import UIKit
     /// Note that the returned `TextAttributeContainer` will only contain attributes that apply to the entire subscript
     /// range. (Setting an attribute will set it across the subscript range regardless of any existing contents).
     ///
-    public subscript(range: Range<String.Index>) -> TextAttributeContainer {
+    public subscript<R>(range: R) -> TextAttributeContainer where R: RangeExpression, R.Bound == String.Index {
         get {
             let range = NSRange(range, in: string)
             return makeAttributeStore(range: range)
         }
         set {
+            let range = NSRange(range, in: string)
             addAttributes(attributes: newValue, to: range)
         }
     }
@@ -100,9 +101,7 @@ import UIKit
         string.startIndex..<string.endIndex
     }
 
-    private mutating func addAttributes(attributes: TextAttributeContainer, to range: Range<String.Index>) {
-        let range = NSRange(range, in: string)
-
+    private mutating func addAttributes(attributes: TextAttributeContainer, to range: NSRange) {
         if !isKnownUniquelyReferenced(&mutableAttributedString) {
             mutableAttributedString = NSMutableAttributedString(attributedString: mutableAttributedString)
         }

--- a/BlueprintUI/Sources/AttributedText/AttributedText.swift
+++ b/BlueprintUI/Sources/AttributedText/AttributedText.swift
@@ -26,19 +26,19 @@ import UIKit
 
     /// An `NSAttributedString` representation of the attributed text.
     public var attributedString: NSAttributedString {
-        mutableAttributedString
+        NSAttributedString(attributedString: mutableAttributedString)
     }
 
     private var mutableAttributedString: NSMutableAttributedString
 
     /// Create some `AttributedText` from a plain string.
-    public init(string: String) {
+    public init(_ string: String) {
         self.string = string
         self.mutableAttributedString = NSMutableAttributedString(string: string)
     }
 
     /// Create some `AttributedText` from an attributed string. The attributes are preserved.
-    public init(attributedString: NSAttributedString) {
+    public init(_ attributedString: NSAttributedString) {
         self.string = attributedString.string
         self.mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
     }
@@ -94,7 +94,7 @@ import UIKit
     public static func + (lhs: AttributedText, rhs: AttributedText) -> AttributedText {
         let newString = NSMutableAttributedString(attributedString: lhs.mutableAttributedString)
         newString.append(rhs.mutableAttributedString)
-        return AttributedText(attributedString: newString)
+        return AttributedText(newString)
     }
 
     private var entireRange: Range<String.Index> {

--- a/BlueprintUI/Sources/AttributedText/AttributedText.swift
+++ b/BlueprintUI/Sources/AttributedText/AttributedText.swift
@@ -98,6 +98,27 @@ import UIKit
         return AttributedText(newString)
     }
 
+    /// Enumerates ranges of the provided attribute key, calling the provided closure with each value found in the
+    /// string and the range of that value. The longest effective range of an attribute may not be used, meaning that
+    /// the block may be called with consecutive attribute ranges that have the same value.
+    ///
+    public func enumerate<AttributeKey: AttributedTextKey>(
+        _ key: AttributeKey.Type,
+        using block: (AttributeKey.Value, Range<String.Index>) -> Void
+    ) {
+        mutableAttributedString.enumerateAttribute(
+            key.name,
+            in: NSRange(entireRange, in: string),
+            options: [.longestEffectiveRangeNotRequired]
+        ) { attribute, range, _ in
+            guard let range = Range(range, in: string), let attribute = attribute as? AttributeKey.Value else {
+                return
+            }
+
+            block(attribute, range)
+        }
+    }
+
     private var entireRange: Range<String.Index> {
         string.startIndex..<string.endIndex
     }

--- a/BlueprintUI/Sources/AttributedText/AttributedText.swift
+++ b/BlueprintUI/Sources/AttributedText/AttributedText.swift
@@ -198,12 +198,22 @@ extension AttributedText {
         ///
         public let range: Range<String.Index>
 
-        private let attributes: TextAttributeContainer
+        /// The attributes that apply to this run.
+        ///
+        /// Note that you can access properties of the attribute container directly on the `Run` itself, since it
+        /// implements dynamic member look up.
+        ///
+        public let attributes: TextAttributeContainer
 
         /// Dynamic member getter for the `TextAttributeContainer` of this run.
         ///
         public subscript<Value>(dynamicMember keyPath: KeyPath<TextAttributeContainer, Value>) -> Value {
             attributes[keyPath: keyPath]
+        }
+
+        init(range: Range<String.Index>, attributes: TextAttributeContainer) {
+            self.range = range
+            self.attributes = attributes
         }
     }
 }

--- a/BlueprintUI/Sources/AttributedText/AttributedText.swift
+++ b/BlueprintUI/Sources/AttributedText/AttributedText.swift
@@ -29,7 +29,7 @@ import UIKit
         mutableAttributedString
     }
 
-    private let mutableAttributedString: NSMutableAttributedString
+    private var mutableAttributedString: NSMutableAttributedString
 
     /// Create some `AttributedText` from a plain string.
     public init(string: String) {
@@ -84,8 +84,7 @@ import UIKit
             return makeAttributeStore(range: range)
         }
         set {
-            let range = NSRange(range, in: string)
-            mutableAttributedString.addAttributes(newValue.storage, range: range)
+            addAttributes(attributes: newValue, to: range)
         }
     }
 
@@ -99,6 +98,16 @@ import UIKit
 
     private var entireRange: Range<String.Index> {
         string.startIndex..<string.endIndex
+    }
+
+    private mutating func addAttributes(attributes: TextAttributeContainer, to range: Range<String.Index>) {
+        let range = NSRange(range, in: string)
+
+        if !isKnownUniquelyReferenced(&mutableAttributedString) {
+            mutableAttributedString = NSMutableAttributedString(attributedString: mutableAttributedString)
+        }
+
+        mutableAttributedString.addAttributes(attributes.storage, range: range)
     }
 
     /// The implementation of this function may not be intuitive, but is necessary due to how enumerating attributes

--- a/BlueprintUI/Sources/AttributedText/AttributedTextKey.swift
+++ b/BlueprintUI/Sources/AttributedText/AttributedTextKey.swift
@@ -42,17 +42,17 @@ extension TextAttributeContainer {
     }
 }
 
-// MARK: Kern
+// MARK: Tracking
 
-public enum KernKey: AttributedTextKey {
+public enum TrackingKey: AttributedTextKey {
     public typealias Value = CGFloat
-    public static var name: NSAttributedString.Key { .kern }
+    public static var name: NSAttributedString.Key { kCTTrackingAttributeName as NSAttributedString.Key }
 }
 
 extension TextAttributeContainer {
-    public var kern: CGFloat? {
-        get { self[KernKey.self] }
-        set { self[KernKey.self] = newValue }
+    public var tracking: CGFloat? {
+        get { self[TrackingKey.self] }
+        set { self[TrackingKey.self] = newValue }
     }
 }
 

--- a/BlueprintUI/Sources/AttributedText/AttributedTextKey.swift
+++ b/BlueprintUI/Sources/AttributedText/AttributedTextKey.swift
@@ -1,0 +1,97 @@
+import UIKit
+
+/// Define `AttributedText` keys using this protocol. Keys must have an attribute name
+/// and an associated type for the attribute.
+///
+/// After defining a key, enable dynamic member access to it by extending `TextAttributeContainer`
+/// with a property for getting and setting setting the value. This property should generally be optional,
+/// since the text may not have that property defined.
+///
+public protocol AttributedTextKey {
+    associatedtype Value: Equatable
+    static var name: NSAttributedString.Key { get }
+}
+
+// MARK: - Built-in attribute keys
+
+// MARK: Font
+
+public enum FontKey: AttributedTextKey {
+    public typealias Value = UIFont
+    public static var name: NSAttributedString.Key { .font }
+}
+
+extension TextAttributeContainer {
+    public var font: UIFont? {
+        get { self[FontKey.self] }
+        set { self[FontKey.self] = newValue }
+    }
+}
+
+// MARK: Color
+
+public enum ColorKey: AttributedTextKey {
+    public typealias Value = UIColor
+    public static var name: NSAttributedString.Key { .foregroundColor }
+}
+
+extension TextAttributeContainer {
+    public var color: UIColor? {
+        get { self[ColorKey.self] }
+        set { self[ColorKey.self] = newValue }
+    }
+}
+
+// MARK: Kern
+
+public enum KernKey: AttributedTextKey {
+    public typealias Value = CGFloat
+    public static var name: NSAttributedString.Key { .kern }
+}
+
+extension TextAttributeContainer {
+    public var kern: CGFloat? {
+        get { self[KernKey.self] }
+        set { self[KernKey.self] = newValue }
+    }
+}
+
+// MARK: Underline
+
+public enum UnderlineStyleKey: AttributedTextKey {
+    public typealias Value = Int
+    public static var name: NSAttributedString.Key { .underlineStyle }
+}
+
+extension TextAttributeContainer {
+    public var underlineStyle: NSUnderlineStyle? {
+        get { self[UnderlineStyleKey.self].flatMap { NSUnderlineStyle(rawValue: $0) } }
+        set { self[UnderlineStyleKey.self] = newValue?.rawValue }
+    }
+}
+
+public enum UnderlineColorKey: AttributedTextKey {
+    public typealias Value = UIColor
+    public static var name: NSAttributedString.Key { .underlineColor }
+}
+
+extension TextAttributeContainer {
+    public var underlineColor: UIColor? {
+        get { self[UnderlineColorKey.self] }
+        set { self[UnderlineColorKey.self] = newValue }
+    }
+}
+
+// MARK: Paragraph style
+
+public enum ParagraphStyleKey: AttributedTextKey {
+    public typealias Value = NSParagraphStyle
+    public static var name: NSAttributedString.Key { .paragraphStyle }
+}
+
+extension TextAttributeContainer {
+    public var paragraphStyle: NSParagraphStyle? {
+        get { self[ParagraphStyleKey.self] }
+        set { self[ParagraphStyleKey.self] = newValue }
+    }
+}

--- a/BlueprintUI/Sources/AttributedText/TextAttributeContainer.swift
+++ b/BlueprintUI/Sources/AttributedText/TextAttributeContainer.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+public struct TextAttributeContainer {
+    public static let empty = Self()
+
+    internal var storage: [NSAttributedString.Key: Any]
+
+    /// Private empty initializer to make the `empty` environment explicit.
+    private init() {
+        storage = [:]
+    }
+
+    /// Get or set for the given `AttributedTextKey`.
+    public subscript<Key>(key: Key.Type) -> Key.Value? where Key: AttributedTextKey {
+        get {
+            if let value = storage[key.name] as? Key.Value {
+                return value
+            } else {
+                return nil
+            }
+        }
+        set {
+            storage[key.name] = newValue
+        }
+    }
+}
+

--- a/BlueprintUI/Sources/AttributedText/TextAttributeContainer.swift
+++ b/BlueprintUI/Sources/AttributedText/TextAttributeContainer.swift
@@ -6,8 +6,12 @@ public struct TextAttributeContainer {
     internal var storage: [NSAttributedString.Key: Any]
 
     /// Private empty initializer to make the `empty` environment explicit.
-    private init() {
+    init() {
         storage = [:]
+    }
+
+    init(storage: [NSAttributedString.Key: Any]) {
+        self.storage = storage
     }
 
     /// Get or set for the given `AttributedTextKey`.

--- a/BlueprintUI/Tests/AttributedTextTests.swift
+++ b/BlueprintUI/Tests/AttributedTextTests.swift
@@ -98,6 +98,13 @@ class AttributedTextTests: XCTestCase {
         XCTAssertEqual(concat[concat.range(of: "ig")!].color, .green)
         XCTAssertEqual(concat[concat.range(of: "right")!].kern, 10)
     }
+
+    func testValueSemantics() {
+        let text = AttributedText(string: "Hello world")
+        var copy = text
+        copy.font = .systemFont(ofSize: 20)
+        XCTAssertNil(text.font)
+    }
 }
 
 extension AttributedText {

--- a/BlueprintUI/Tests/AttributedTextTests.swift
+++ b/BlueprintUI/Tests/AttributedTextTests.swift
@@ -44,6 +44,15 @@ class AttributedTextTests: XCTestCase {
         text[loWo].color = blue
 
         XCTAssertEqual(text[hello].font, font, "The font should be returned when it applies to the whole range")
+        XCTAssertEqual(
+            text[text.range(of: "ell")!].font,
+            font,
+            "The font should be returned when it applies to the whole range"
+        )
+        XCTAssertNil(
+            text[text.range(of: "Hello wo")!].font,
+            "The font should not be returned if it applies to part of the range"
+        )
         XCTAssertNil(text[loWo].font, "The font should not be returned if it applies to part of the range")
 
         XCTAssertEqual(text[loWo].color, blue, "The color should be returned if it applies to the whole range")
@@ -86,17 +95,17 @@ class AttributedTextTests: XCTestCase {
     func testConcatenation() {
         var left = AttributedText(string: "left")
         left.color = .blue
-        left[left.range(of: "le")!].kern = 20
+        left[left.range(of: "le")!].tracking = 20
 
         var right = AttributedText(string: "right")
-        right.kern = 10
+        right.tracking = 10
         right[right.range(of: "ig")!].color = .green
 
         let concat = left + right
         XCTAssertEqual(concat[concat.range(of: "left")!].color, .blue)
-        XCTAssertEqual(concat[concat.range(of: "le")!].kern, 20)
+        XCTAssertEqual(concat[concat.range(of: "le")!].tracking, 20)
         XCTAssertEqual(concat[concat.range(of: "ig")!].color, .green)
-        XCTAssertEqual(concat[concat.range(of: "right")!].kern, 10)
+        XCTAssertEqual(concat[concat.range(of: "right")!].tracking, 10)
     }
 
     func testValueSemantics() {

--- a/BlueprintUI/Tests/AttributedTextTests.swift
+++ b/BlueprintUI/Tests/AttributedTextTests.swift
@@ -141,6 +141,19 @@ class AttributedTextTests: XCTestCase {
         XCTAssertEqual(text[someHiragana].color, .green)
         XCTAssertEqual(text[someKatakana].color, .red)
     }
+
+    func testRemovingAttributes() {
+        var text = AttributedText("Hello")
+        text.font = .systemFont(ofSize: 10)
+        text.color = .blue
+
+        text.font = nil
+        text["H"].color = nil
+
+        XCTAssertNil(text.font)
+        XCTAssertNil(text["H"].color)
+        XCTAssertEqual(text["ello"].color, .blue)
+    }
 }
 
 extension AttributedText {

--- a/BlueprintUI/Tests/AttributedTextTests.swift
+++ b/BlueprintUI/Tests/AttributedTextTests.swift
@@ -7,7 +7,7 @@ class AttributedTextTests: XCTestCase {
         let font = UIFont.systemFont(ofSize: 30)
         let color = UIColor.green
 
-        var text = AttributedText(string: "Hello world")
+        var text = AttributedText("Hello world")
         text.font = font
         text.color = color
 
@@ -32,7 +32,7 @@ class AttributedTextTests: XCTestCase {
         let green = UIColor.green
         let blue = UIColor.blue
 
-        var text = AttributedText(string: "Hello world")
+        var text = AttributedText("Hello world")
 
         let hello = text.range(of: "Hello")!
         let world = text.range(of: "world")!
@@ -93,11 +93,11 @@ class AttributedTextTests: XCTestCase {
     }
 
     func testConcatenation() {
-        var left = AttributedText(string: "left")
+        var left = AttributedText("left")
         left.color = .blue
         left[left.range(of: "le")!].tracking = 20
 
-        var right = AttributedText(string: "right")
+        var right = AttributedText("right")
         right.tracking = 10
         right[right.range(of: "ig")!].color = .green
 
@@ -109,7 +109,7 @@ class AttributedTextTests: XCTestCase {
     }
 
     func testValueSemantics() {
-        let text = AttributedText(string: "Hello world")
+        let text = AttributedText("Hello world")
         var copy = text
         copy.font = .systemFont(ofSize: 20)
         XCTAssertNil(text.font)

--- a/BlueprintUI/Tests/AttributedTextTests.swift
+++ b/BlueprintUI/Tests/AttributedTextTests.swift
@@ -114,9 +114,41 @@ class AttributedTextTests: XCTestCase {
         copy.font = .systemFont(ofSize: 20)
         XCTAssertNil(text.font)
     }
+
+    func testEmoji() {
+        var text = AttributedText("some emoji: 😵‍💫👨‍👩‍👧‍👦🏃🏽 and some hiragana:  あいうえお and some katakana: アイウエオカキクケコ")
+        text.color = .blue
+
+        let partialEmoji = text.range(of: "😵")!
+        text[partialEmoji].color = .brown
+
+        let family = text.range(of: "👨‍👩‍👧‍👦")!
+        text[family].color = .magenta
+
+        let someHiragana = text.range(of: "いうえ")!
+        text[someHiragana].color = .green
+
+        let someKatakana = text.range(of: "ウエオカキク")!
+        text[someKatakana].color = .red
+
+        XCTAssertEqual(text["😵‍💫"].color, nil, "This emoji spans two colors due to changing the color of 😵")
+        XCTAssertEqual(text["🏃🏽"].color, .blue)
+        XCTAssertEqual(text["あ"].color, .blue)
+        XCTAssertEqual(text["アイ"].color, .blue)
+
+        XCTAssertEqual(text[partialEmoji].color, .brown)
+        XCTAssertEqual(text[family].color, .magenta)
+        XCTAssertEqual(text[someHiragana].color, .green)
+        XCTAssertEqual(text[someKatakana].color, .red)
+    }
 }
 
 extension AttributedText {
+    fileprivate subscript(_ string: String) -> TextAttributeContainer {
+        get { self[range(of: string)!] }
+        set { self[range(of: string)!] = newValue }
+    }
+
     fileprivate func nsRange(of string: String) -> NSRange {
         NSRange(range(of: string)!, in: self.string)
     }

--- a/BlueprintUI/Tests/AttributedTextTests.swift
+++ b/BlueprintUI/Tests/AttributedTextTests.swift
@@ -154,6 +154,28 @@ class AttributedTextTests: XCTestCase {
         XCTAssertNil(text["H"].color)
         XCTAssertEqual(text["ello"].color, .blue)
     }
+
+    func testEnumerating() {
+        var text = AttributedText("Hello world")
+
+        text["Hello"].color = .blue
+        text["world"].color = .red
+
+        let blueExpectation = XCTestExpectation(description: "Should find blue")
+        let redExpectation = XCTestExpectation(description: "Should find red")
+
+        text.enumerate(ColorKey.self) { color, range in
+            if color == .blue, range == text.range(of: "Hello") {
+                blueExpectation.fulfill()
+            }
+
+            if color == .red, range == text.range(of: "world") {
+                redExpectation.fulfill()
+            }
+        }
+
+        wait(for: [blueExpectation, redExpectation], timeout: 0)
+    }
 }
 
 extension AttributedText {

--- a/BlueprintUI/Tests/AttributedTextTests.swift
+++ b/BlueprintUI/Tests/AttributedTextTests.swift
@@ -155,26 +155,36 @@ class AttributedTextTests: XCTestCase {
         XCTAssertEqual(text["ello"].color, .blue)
     }
 
-    func testEnumerating() {
+    func testRuns() {
         var text = AttributedText("Hello world")
+        let font = UIFont.systemFont(ofSize: 20)
 
         text["Hello"].color = .blue
         text["world"].color = .red
+        text["lo wo"].font = font
 
-        let blueExpectation = XCTestExpectation(description: "Should find blue")
-        let redExpectation = XCTestExpectation(description: "Should find red")
+        let runs = text.runs
+        XCTAssertEqual(runs.count, 5)
 
-        text.enumerate(ColorKey.self) { color, range in
-            if color == .blue, range == text.range(of: "Hello") {
-                blueExpectation.fulfill()
-            }
+        XCTAssertEqual(runs[0].range, text.range(of: "Hel"))
+        XCTAssertEqual(runs[0].color, .blue)
+        XCTAssertNil(runs[0].font)
 
-            if color == .red, range == text.range(of: "world") {
-                redExpectation.fulfill()
-            }
-        }
+        XCTAssertEqual(runs[1].range, text.range(of: "lo"))
+        XCTAssertEqual(runs[1].color, .blue)
+        XCTAssertEqual(runs[1].font, font)
 
-        wait(for: [blueExpectation, redExpectation], timeout: 0)
+        XCTAssertEqual(runs[2].range, text.range(of: " "))
+        XCTAssertNil(runs[2].color)
+        XCTAssertEqual(runs[2].font, font)
+
+        XCTAssertEqual(runs[3].range, text.range(of: "wo"))
+        XCTAssertEqual(runs[3].color, .red)
+        XCTAssertEqual(runs[3].font, font)
+
+        XCTAssertEqual(runs[4].range, text.range(of: "rld"))
+        XCTAssertEqual(runs[4].color, .red)
+        XCTAssertNil(runs[4].font)
     }
 }
 

--- a/BlueprintUI/Tests/AttributedTextTests.swift
+++ b/BlueprintUI/Tests/AttributedTextTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import BlueprintUI
+
+class AttributedTextTests: XCTestCase {
+
+    func testApplyingAttributes() {
+        let font = UIFont.systemFont(ofSize: 30)
+        let color = UIColor.green
+
+        var text = AttributedText(string: "Hello world")
+        text.font = font
+        text.color = color
+
+        XCTAssertEqual(text[text.range(of: "Hello world")!].font, font)
+        XCTAssertEqual(text[text.range(of: "Hello world")!].color, color)
+
+        XCTAssertEqual(text[text.range(of: "Hello")!].font, font, "Attributes that span the range should be returned")
+        XCTAssertEqual(text[text.range(of: "Hello")!].color, color, "Attributes that span the range should be returned")
+
+        text.attributedString.enumerateAttributes(
+            in: text.attributedString.entireRange,
+            options: []
+        ) { attributes, range, _ in
+            XCTAssertEqual(attributes[.font] as? UIFont, font)
+            XCTAssertEqual(attributes[.foregroundColor] as? UIColor, color)
+            XCTAssertEqual(range, text.attributedString.entireRange)
+        }
+    }
+
+    func testApplyingPartialAttributes() {
+        let font = UIFont.systemFont(ofSize: 30)
+        let green = UIColor.green
+        let blue = UIColor.blue
+
+        var text = AttributedText(string: "Hello world")
+
+        let hello = text.range(of: "Hello")!
+        let world = text.range(of: "world")!
+        let loWo = text.range(of: "lo wo")!
+        let rld = text.range(of: "rld")!
+
+        text[hello].font = font
+        text[world].color = green
+        text[loWo].color = blue
+
+        XCTAssertEqual(text[hello].font, font, "The font should be returned when it applies to the whole range")
+        XCTAssertNil(text[loWo].font, "The font should not be returned if it applies to part of the range")
+
+        XCTAssertEqual(text[loWo].color, blue, "The color should be returned if it applies to the whole range")
+        XCTAssertEqual(text[rld].color, green, "The color should be returned if it applies to the whole range")
+        XCTAssertNil(text[world].color, "The color should not be returned if it applies to part of the range")
+
+        text.attributedString.enumerateAttribute(
+            .font,
+            in: text.attributedString.entireRange,
+            options: []
+        ) { attribute, range, _ in
+            if range == text.nsRange(of: "Hello") {
+                XCTAssertEqual(attribute as? UIFont, font)
+            } else if range == text.nsRange(of: " world") {
+                XCTAssertNil(attribute)
+            } else {
+                XCTFail("Unexpected range for font attribute")
+            }
+        }
+
+        text.attributedString.enumerateAttribute(
+            .foregroundColor,
+            in: text.attributedString.entireRange,
+            options: []
+        ) { attribute, range, _ in
+            let attribute = attribute as? UIColor
+
+            if range == text.nsRange(of: "Hel") {
+                XCTAssertNil(attribute)
+            } else if range == text.nsRange(of: "lo wo") {
+                XCTAssertEqual(attribute, blue)
+            } else if range == text.nsRange(of: "rld") {
+                XCTAssertEqual(attribute, green)
+            } else {
+                XCTFail("Unexpected range for color attribute")
+            }
+        }
+    }
+
+    func testConcatenation() {
+        var left = AttributedText(string: "left")
+        left.color = .blue
+        left[left.range(of: "le")!].kern = 20
+
+        var right = AttributedText(string: "right")
+        right.kern = 10
+        right[right.range(of: "ig")!].color = .green
+
+        let concat = left + right
+        XCTAssertEqual(concat[concat.range(of: "left")!].color, .blue)
+        XCTAssertEqual(concat[concat.range(of: "le")!].kern, 20)
+        XCTAssertEqual(concat[concat.range(of: "ig")!].color, .green)
+        XCTAssertEqual(concat[concat.range(of: "right")!].kern, 10)
+    }
+}
+
+extension AttributedText {
+    fileprivate func nsRange(of string: String) -> NSRange {
+        NSRange(range(of: string)!, in: self.string)
+    }
+}
+
+extension NSAttributedString {
+    fileprivate var entireRange: NSRange {
+        NSRange(location: 0, length: length)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support `CALayerCornerCurve` for `Box` corner styles.
+- Added `AttributedText`, which supports applying strongly-typed attributes to strings (much like the `AttributedString` type introduced in iOS 15).
 
 ### Removed
 


### PR DESCRIPTION
`AttributedText` allows you to apply strongly-typed attributes to strings (much like the `AttributedString` type introduced in iOS 15). You can then access the `attributedString` property to get an attributed string with those attributes applied.

For example:

```swift
var text = AttributedText(string: "Hello, world")
// Apply a font to the entire range
text.font = .systemFont(ofSize: 20)

// Apply a color to part of the string
let range = text.string.range(of: "world")!
text[range].color = .blue

// Render the attributed text
let label = AttributedLabel(attributedText: text.attributedString)
```