### PR TITLE
Use clear background color for ElementPreviews

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/ElementPreview.swift
+++ b/BlueprintUI/Sources/BlueprintView/ElementPreview.swift
@@ -157,6 +157,7 @@
 
             func makeUIView(context: Context) -> BlueprintView {
                 let view = BlueprintView()
+                view.backgroundColor = .clear
                 view.element = element
 
                 return view


### PR DESCRIPTION
Allows for easier composition of previews where you might want to place a background behind an element preview.