### PR TITLE
added helpers for accessibility modifications to elements

### DIFF
--- a/BlueprintUICommonControls/Sources/AccessibilityElement.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityElement.swift
@@ -121,6 +121,77 @@ extension Element {
         )
     }
 
+    /// Wraps the receiver in an accessibility element with the provided values.
+    ///
+    /// - Important: ⚠️: This will remove any previously resolved accessibility hint, identifier, or frame size of the element and all of its children. ⚠️
+    public func accessibilityElement(
+        label: String,
+        value: String,
+        traits: Set<AccessibilityElement.Trait>
+    ) -> AccessibilityElement {
+        AccessibilityElement(
+            label: label,
+            value: value,
+            traits: traits,
+            hint: nil,
+            identifier: nil,
+            accessibilityFrameSize: nil,
+            wrapping: self
+        )
+    }
+
+    /// Wraps the receiver in an accessibility element with the provided values.
+    ///
+    /// - Important: ⚠️: This will remove any previously resolved accessibility hint, identifier, or frame size of the element and all of its children. ⚠️
+    public func accessibilityElement(
+        label: String,
+        traits: Set<AccessibilityElement.Trait>
+    ) -> AccessibilityElement {
+        AccessibilityElement(
+            label: label,
+            value: nil,
+            traits: traits,
+            hint: nil,
+            identifier: nil,
+            accessibilityFrameSize: nil,
+            wrapping: self
+        )
+    }
+
+    /// Wraps the receiver in an accessibility element with the provided values.
+    ///
+    /// - Important: ⚠️: This will remove any previously resolved accessibility hint, identifier, or frame size of the element and all of its children. ⚠️
+    public func accessibilityElement(
+        label: String,
+        value: String
+    ) -> AccessibilityElement {
+        AccessibilityElement(
+            label: label,
+            value: value,
+            traits: [],
+            hint: nil,
+            identifier: nil,
+            accessibilityFrameSize: nil,
+            wrapping: self
+        )
+    }
+
+    /// Wraps the receiver in an accessibility element with the provided values.
+    ///
+    /// - Important: ⚠️: This will remove any previously resolved accessibility value, hint, identifier, or frame size of the element and all of its children. ⚠️
+    public func accessibilityElement(
+        label: String
+    ) -> AccessibilityElement {
+        AccessibilityElement(
+            label: label,
+            value: nil,
+            traits: [],
+            hint: nil,
+            identifier: nil,
+            accessibilityFrameSize: nil,
+            wrapping: self
+        )
+    }
 
     /// Wraps the receiver in an accessibility element with the provided values.
     ///


### PR DESCRIPTION
These four accessibility helper methods cover 85% of the use cases for accessibility configuration as seen in the wild.

> 
![image](https://user-images.githubusercontent.com/219578/152418629-6e504203-1cef-4d7a-8766-4f0eb7d99ccd.png)
