### PR TITLE
Add .fittingConstraint to ScrollView

### DIFF
--- a/BlueprintUICommonControls/Sources/ScrollView.swift
+++ b/BlueprintUICommonControls/Sources/ScrollView.swift
@@ -117,6 +117,11 @@ extension ScrollView {
                         width: .unconstrained,
                         height: constraint.height
                     ))
+
+            case .fittingConstraint:
+                return child.measure(
+                    in: constraint
+                )
             }
         }
 
@@ -185,6 +190,9 @@ extension ScrollView {
 
         /// The content size will be the minimum required to fit the content.
         case fittingContent
+
+        /// The content size will be measured within the layout constraint of the scroll view.
+        case fittingConstraint
 
         /// Manually provided content size.
         case custom(CGSize)
@@ -311,7 +319,7 @@ fileprivate final class ScrollerWrapperView: UIView {
         let contentSize: CGSize
 
         switch scrollView.contentSize {
-        case .fittingWidth, .fittingHeight, .fittingContent:
+        case .fittingWidth, .fittingHeight, .fittingContent, .fittingConstraint:
             contentSize = CGSize(width: contentFrame.maxX, height: contentFrame.maxY)
         case .custom(let customSize):
             contentSize = customSize

--- a/BlueprintUICommonControls/Tests/Sources/ScrollViewTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/ScrollViewTests.swift
@@ -121,6 +121,7 @@ class ScrollViewTests: XCTestCase {
         test(contentSize: .fittingContent)
         test(contentSize: .fittingHeight)
         test(contentSize: .fittingWidth)
+        test(contentSize: .fittingConstraint)
     }
 
     private struct UnderflowElement: ProxyElement {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `ScrollView.ContentSize.fittingConstraint`, to allow measuring content within the fitting size of the scroll view itself.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
This allows, eg, contained `Column`s to include flexible elements which will expand to fill the available space when there's underflow, and have a minimum size on overflow. This also means you could now implement `centersUnderflow` purely via composition of a contained column, instead of needing a special mode on the scroll view:

```
Column(alignment: .fill) {

   row.stackChild(.fixed)
   row.stackChild(.fixed)
   row.stackChild(.fixed)

  Spacer(height: 1.0).stackChild(.grows) // I forget the exact syntax for this.

   row.stackChild(.fixed)
}
.scrollable {
   $0.size = .fittingConstraint
}
```

Etc...