### PR TITLE
Fix voice over rotor crash

### DIFF
--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -140,20 +140,25 @@ extension AttributedLabel {
         override var accessibilityCustomRotors: [UIAccessibilityCustomRotor]? {
             set { fatalError() }
             get {
-                [
-                    UIAccessibilityCustomRotor(systemType: .link) { [weak self] predicate in
-                        guard let self = self else {
-                            return nil
-                        }
+                accessibilityLinks.isEmpty
+                    ? []
+                    : [
+                        UIAccessibilityCustomRotor(systemType: .link) { [weak self] predicate in
+                            guard let self = self, !self.links.isEmpty else {
+                                return nil
+                            }
 
-                        self.accessibilityLinkIndex += predicate.searchDirection == .next ? 1 : -1
-                        self.accessibilityLinkIndex = min(self.accessibilityLinks.count - 1, self.accessibilityLinkIndex)
-                        self.accessibilityLinkIndex = max(0, self.accessibilityLinkIndex)
+                            self.accessibilityLinkIndex += predicate.searchDirection == .next ? 1 : -1
+                            self.accessibilityLinkIndex = min(
+                                self.accessibilityLinks.count - 1,
+                                self.accessibilityLinkIndex
+                            )
+                            self.accessibilityLinkIndex = max(0, self.accessibilityLinkIndex)
 
-                        let link = self.accessibilityLinks[self.accessibilityLinkIndex]
-                        return UIAccessibilityCustomRotorItemResult(targetElement: link, targetRange: nil)
-                    },
-                ]
+                            let link = self.accessibilityLinks[self.accessibilityLinkIndex]
+                            return UIAccessibilityCustomRotorItemResult(targetElement: link, targetRange: nil)
+                        },
+                    ]
             }
         }
 

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -144,7 +144,7 @@ extension AttributedLabel {
                     ? []
                     : [
                         UIAccessibilityCustomRotor(systemType: .link) { [weak self] predicate in
-                            guard let self = self, !self.links.isEmpty else {
+                            guard let self = self, !self.accessibilityLinks.isEmpty else {
                                 return nil
                             }
 
@@ -186,6 +186,7 @@ extension AttributedLabel {
 
             if !isMeasuring, previousAttributedText != attributedText {
                 links = attributedLinks(in: model.attributedText) + detectedDataLinks(in: model.attributedText)
+                accessibilityLinks = accessibilityLinks(for: links, in: model.attributedText)
             }
 
             applyLinkColors()


### PR DESCRIPTION
Fixes an issue where the app would crash if Voice Over attempted to navigate a screen with labels without links (in some cases - couldn't always reproduce). Also doesn't return the rotor at all if there are no links. 