### PR TITLE
Fix doc script for Xcode 13

### DIFF
--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -6,7 +6,7 @@ set -euxo pipefail
 sourcekitten=`gem contents jazzy | grep 'bin/sourcekitten$' | head -1`
 
 platform="iOS Simulator"
-device=`instruments -s -devices | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
+device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | sed 's/Simulator//' | head -1 | awk '{$1=$1;print}'`
 destination="platform=$platform,name=$device"
 
 $sourcekitten doc \


### PR DESCRIPTION
Seems like this broke a while ago because `instruments` went away. New version seems a bit more fragile, as the sim names don't quite line up with what `xcodebuild` thinks, but this works for me locally. 🤷 