### PR TITLE
Aligned positioning for `Decorate`

### DIFF
--- a/BlueprintUI/Sources/Layout/Alignment.swift
+++ b/BlueprintUI/Sources/Layout/Alignment.swift
@@ -1,5 +1,42 @@
 import CoreGraphics
 
+/// An alignment in both axes.
+public struct Alignment: Equatable {
+    /// A guide marking the center of the element.
+    static let center = Alignment(horizontal: .center, vertical: .center)
+
+    /// A guide marking the leading edge of the element.
+    static let leading = Alignment(horizontal: .leading, vertical: .center)
+    /// A guide marking the trailing edge of the element.
+    static let trailing = Alignment(horizontal: .trailing, vertical: .center)
+
+    /// A guide marking the top edge of the element.
+    static let top = Alignment(horizontal: .center, vertical: .top)
+    /// A guide marking the bottom edge of the element.
+    static let bottom = Alignment(horizontal: .center, vertical: .bottom)
+
+    /// A guide marking the top and leading edges of the element.
+    static let topLeading = Alignment(horizontal: .leading, vertical: .top)
+    /// A guide marking the top and trailing edges of the element.
+    static let topTrailing = Alignment(horizontal: .trailing, vertical: .top)
+
+    /// A guide marking the bottom and leading edges of the element.
+    static let bottomLeading = Alignment(horizontal: .leading, vertical: .bottom)
+    /// A guide marking the bottom and trailing edges of the element.
+    static let bottomTrailing = Alignment(horizontal: .trailing, vertical: .bottom)
+
+    /// The alignment on the horizontal axis.
+    public var horizontal: HorizontalAlignment
+    /// The alignment on the vertical axis.
+    public var vertical: VerticalAlignment
+
+    /// Creates an instance with the given horizontal and vertical alignments.
+    public init(horizontal: HorizontalAlignment, vertical: VerticalAlignment) {
+        self.horizontal = horizontal
+        self.vertical = vertical
+    }
+}
+
 /// Types used to identify alignment guides.
 ///
 /// Types conforming to `AlignmentID` have a corresponding alignment guide value,
@@ -104,3 +141,6 @@ extension VerticalAlignment {
     /// A guide marking the bottom edge of the element.
     public static let bottom = VerticalAlignment(Bottom.self)
 }
+
+/// Internal typealias for convenience
+typealias AlignmentGuide = (ElementDimensions) -> CGFloat

--- a/BlueprintUI/Sources/Layout/Decorate.swift
+++ b/BlueprintUI/Sources/Layout/Decorate.swift
@@ -120,6 +120,15 @@ extension Decorate {
         case topRight
         case bottomRight
         case bottomLeft
+
+        var alignment: Alignment {
+            switch self {
+            case .topLeft: return .topLeading
+            case .topRight: return .topTrailing
+            case .bottomLeft: return .bottomLeading
+            case .bottomRight: return .bottomTrailing
+            }
+        }
     }
 
     /// How to position the decoration element relative to the content element.
@@ -208,33 +217,15 @@ extension Decorate {
         /// The decoration element is positioned in the given corner of the
         /// content element, optionally offset by the provided amount.
         public static func corner(_ corner: Corner, _ offset: UIOffset = .zero) -> Self {
-            .custom { context in
-                let contentFrame = CGRect(origin: .zero, size: context.contentSize)
-                let size = context.decorationSize
-
-                let center: CGPoint = {
-                    switch corner {
-                    case .topLeft:
-                        return .zero
-                    case .topRight:
-                        return CGPoint(x: contentFrame.maxX, y: 0)
-                    case .bottomRight:
-                        return CGPoint(x: contentFrame.maxX, y: contentFrame.maxY)
-                    case .bottomLeft:
-                        return CGPoint(x: 0, y: contentFrame.maxY)
-                    }
-                }()
-
-                return CGRect(
-                    origin: CGPoint(
-                        x: center.x - (size.width / 2.0),
-                        y: center.y - (size.height / 2.0)
-                    ),
-                    size: size
-                ).offset(
-                    by: CGPoint(x: offset.horizontal, y: offset.vertical)
-                )
-            }
+            .aligned(
+                to: corner.alignment,
+                horizontalGuide: { dimensions in
+                    dimensions[HorizontalAlignment.center] - offset.horizontal
+                },
+                verticalGuide: { dimensions in
+                    dimensions[VerticalAlignment.center] - offset.vertical
+                }
+            )
         }
 
         /// Allows you to provide custom positioning for the decoration, based on the passed context.

--- a/BlueprintUI/Sources/Layout/Decorate.swift
+++ b/BlueprintUI/Sources/Layout/Decorate.swift
@@ -130,7 +130,11 @@ extension Decorate {
         ///
         /// A positive value for an edge expands the decoration outside of that edge,
         /// whereas a negative inset pushes the the decoration inside that edge.
-        case inset(UIEdgeInsets)
+        public static func inset(_ inset: UIEdgeInsets) -> Self {
+            .custom { context in
+                context.contentFrame.inset(by: inset.negated)
+            }
+        }
 
         /// Provides a `.inset` position where the decoration is inset by the
         /// same amount on each side.
@@ -146,36 +150,10 @@ extension Decorate {
 
         /// The decoration element is positioned in the given corner of the
         /// content element, optionally offset by the provided amount.
-        case corner(Corner, UIOffset = .zero)
-
-        /// Allows you to provide custom positioning for the decoration, based on the passed context.
-        case custom((CustomContext) -> CGRect)
-
-        /// Information provided to the `.custom` positioning type.
-        public struct CustomContext {
-
-            public var decorationSize: CGSize
-
-            /// The frame of the content element within the `Decorate` element.
-            public var contentFrame: CGRect
-
-            /// The environment the element is being rendered in.
-            public var environment: Environment
-        }
-
-        func frame(
-            with contentFrame: CGRect,
-            decoration: Element,
-            environment: Environment
-        ) -> CGRect {
-
-            switch self {
-            case .inset(let inset):
-                return contentFrame.inset(by: inset.negated)
-
-            case .corner(let corner, let offset):
-
-                let size = decoration.content.measure(in: .init(contentFrame.size), environment: environment)
+        public static func corner(_ corner: Corner, _ offset: UIOffset = .zero) -> Self {
+            .custom { context in
+                let contentFrame = context.contentFrame
+                let size = context.decorationSize
 
                 let center: CGPoint = {
                     switch corner {
@@ -199,6 +177,31 @@ extension Decorate {
                 ).offset(
                     by: CGPoint(x: offset.horizontal, y: offset.vertical)
                 )
+            }
+        }
+
+        /// Allows you to provide custom positioning for the decoration, based on the passed context.
+        case custom((CustomContext) -> CGRect)
+
+        /// Information provided to the `.custom` positioning type.
+        public struct CustomContext {
+
+            public var decorationSize: CGSize
+
+            /// The frame of the content element within the `Decorate` element.
+            public var contentFrame: CGRect
+
+            /// The environment the element is being rendered in.
+            public var environment: Environment
+        }
+
+        func frame(
+            with contentFrame: CGRect,
+            decoration: Element,
+            environment: Environment
+        ) -> CGRect {
+
+            switch self {
 
             case .custom(let provider):
 

--- a/BlueprintUI/Sources/Layout/Decorate.swift
+++ b/BlueprintUI/Sources/Layout/Decorate.swift
@@ -80,7 +80,7 @@ public struct Decorate: ProxyElement {
                 )
 
                 let decorationFrame = self.position.frame(
-                    with: contentFrame,
+                    with: contentFrame.size,
                     decoration: self.decoration,
                     environment: environment
                 )
@@ -132,7 +132,7 @@ extension Decorate {
         /// whereas a negative inset pushes the the decoration inside that edge.
         public static func inset(_ inset: UIEdgeInsets) -> Self {
             .custom { context in
-                context.contentFrame.inset(by: inset.negated)
+                CGRect(origin: .zero, size: context.contentSize).inset(by: inset.negated)
             }
         }
 
@@ -187,7 +187,7 @@ extension Decorate {
         ) -> Self {
             return .custom { context in
 
-                let boundingDimensions = ElementDimensions(size: context.contentFrame.size)
+                let boundingDimensions = ElementDimensions(size: context.contentSize)
                 let dimensions = ElementDimensions(size: context.decorationSize)
 
                 func position(of alignment: AlignmentID.Type, guide: AlignmentGuide?) -> CGFloat {
@@ -209,7 +209,7 @@ extension Decorate {
         /// content element, optionally offset by the provided amount.
         public static func corner(_ corner: Corner, _ offset: UIOffset = .zero) -> Self {
             .custom { context in
-                let contentFrame = context.contentFrame
+                let contentFrame = CGRect(origin: .zero, size: context.contentSize)
                 let size = context.decorationSize
 
                 let center: CGPoint = {
@@ -248,8 +248,8 @@ extension Decorate {
             /// The size of the decoration being positioned within the decorated content's bounds.
             public var decorationSize: CGSize
 
-            /// The frame of the content element within the `Decorate` element.
-            public var contentFrame: CGRect
+            /// The size of the content element within the `Decorate` element.
+            public var contentSize: CGSize
 
             /// The environment the element is being rendered in.
             public var environment: Environment
@@ -262,15 +262,15 @@ extension Decorate {
         }
 
         func frame(
-            with contentFrame: CGRect,
+            with contentSize: CGSize,
             decoration: Element,
             environment: Environment
         ) -> CGRect {
-            let size = decoration.content.measure(in: .init(contentFrame.size), environment: environment)
+            let size = decoration.content.measure(in: .init(contentSize), environment: environment)
 
             let context = PositionContext(
                 decorationSize: size,
-                contentFrame: contentFrame,
+                contentSize: contentSize,
                 environment: environment
             )
 

--- a/BlueprintUI/Sources/Layout/Decorate.swift
+++ b/BlueprintUI/Sources/Layout/Decorate.swift
@@ -154,6 +154,8 @@ extension Decorate {
         /// Information provided to the `.custom` positioning type.
         public struct CustomContext {
 
+            public var decorationSize: CGSize
+
             /// The frame of the content element within the `Decorate` element.
             public var contentFrame: CGRect
 
@@ -199,7 +201,16 @@ extension Decorate {
                 )
 
             case .custom(let provider):
-                return provider(.init(contentFrame: contentFrame, environment: environment))
+
+                let size = decoration.content.measure(in: .init(contentFrame.size), environment: environment)
+
+                let context = CustomContext(
+                    decorationSize: size,
+                    contentFrame: contentFrame,
+                    environment: environment
+                )
+
+                return provider(context)
             }
         }
     }

--- a/BlueprintUI/Sources/Layout/Decorate.swift
+++ b/BlueprintUI/Sources/Layout/Decorate.swift
@@ -194,7 +194,7 @@ extension Decorate {
             horizontalGuide: ((ElementDimensions) -> CGFloat)? = nil,
             verticalGuide: ((ElementDimensions) -> CGFloat)? = nil
         ) -> Self {
-            return .custom { context in
+            .custom { context in
 
                 let boundingDimensions = ElementDimensions(size: context.contentSize)
                 let dimensions = ElementDimensions(size: context.decorationSize)

--- a/BlueprintUI/Sources/Layout/Decorate.swift
+++ b/BlueprintUI/Sources/Layout/Decorate.swift
@@ -181,13 +181,14 @@ extension Decorate {
         }
 
         /// Allows you to provide custom positioning for the decoration, based on the passed context.
-        public static func custom(_ position: @escaping (CustomContext) -> CGRect) -> Self {
+        public static func custom(_ position: @escaping (PositionContext) -> CGRect) -> Self {
             Position(position: position)
         }
 
-        /// Information provided to the `.custom` positioning type.
-        public struct CustomContext {
+        /// Information provided to `Position` closures.
+        public struct PositionContext {
 
+            /// The size of the decoration being positioned within the decorated content's bounds.
             public var decorationSize: CGSize
 
             /// The frame of the content element within the `Decorate` element.
@@ -197,9 +198,9 @@ extension Decorate {
             public var environment: Environment
         }
 
-        private var position: (CustomContext) -> CGRect
+        private var position: (PositionContext) -> CGRect
 
-        private init(position: @escaping (CustomContext) -> CGRect) {
+        private init(position: @escaping (PositionContext) -> CGRect) {
             self.position = position
         }
 
@@ -210,7 +211,7 @@ extension Decorate {
         ) -> CGRect {
             let size = decoration.content.measure(in: .init(contentFrame.size), environment: environment)
 
-            let context = CustomContext(
+            let context = PositionContext(
                 decorationSize: size,
                 contentFrame: contentFrame,
                 environment: environment

--- a/BlueprintUI/Sources/Layout/Decorate.swift
+++ b/BlueprintUI/Sources/Layout/Decorate.swift
@@ -148,6 +148,63 @@ extension Decorate {
             .inset(UIEdgeInsets(top: vertical, left: horizontal, bottom: vertical, right: horizontal))
         }
 
+        /// Aligns the decoration according the given alignment option, optionally adjusting it with
+        /// an alignment guide on either axis.
+        ///
+        /// - Parameters:
+        ///   - alignment: Determines the position of the decoration relative to the decorated
+        ///     content.
+        ///
+        ///   - horizontalGuide:
+        ///
+        ///     A closure that can be used to provide a custom alignment guide for decoration along
+        ///     the horizontal axis.
+        ///
+        ///     This closure will be called with an `ElementDimensions` containing the dimensions of
+        ///     the decoration, and should return a value in the decoration's own coordinate space.
+        ///     This value represents the position along the decoration's horizontal axis that
+        ///     should be aligned relative to the decorated content.
+        ///
+        ///     If not specified, the default value is provided by the alignment.
+        ///
+        ///   - verticalGuide:
+        ///
+        ///     A closure that can be used to provide a custom alignment guide for decoration along
+        ///     the vertical axis.
+        ///
+        ///     This closure will be called with an `ElementDimensions` containing the dimensions of
+        ///     the decoration, and should return a value in the decoration's own coordinate space.
+        ///     This value represents the position along the decoration's vertical axis that should
+        ///     be aligned relative to the decorated content.
+        ///
+        ///     If not specified, the default value is provided by the alignment.
+        ///
+        /// - Returns: An aligned position.
+        public static func aligned(
+            to alignment: Alignment,
+            horizontalGuide: ((ElementDimensions) -> CGFloat)? = nil,
+            verticalGuide: ((ElementDimensions) -> CGFloat)? = nil
+        ) -> Self {
+            return .custom { context in
+
+                let boundingDimensions = ElementDimensions(size: context.contentFrame.size)
+                let dimensions = ElementDimensions(size: context.decorationSize)
+
+                func position(of alignment: AlignmentID.Type, guide: AlignmentGuide?) -> CGFloat {
+                    let anchor = alignment.defaultValue(in: boundingDimensions)
+                    let offset = guide?(dimensions) ?? alignment.defaultValue(in: dimensions)
+                    return anchor - offset
+                }
+
+                let position = CGPoint(
+                    x: position(of: alignment.horizontal.id, guide: horizontalGuide),
+                    y: position(of: alignment.vertical.id, guide: verticalGuide)
+                )
+
+                return CGRect(origin: position, size: context.decorationSize)
+            }
+        }
+
         /// The decoration element is positioned in the given corner of the
         /// content element, optionally offset by the provided amount.
         public static func corner(_ corner: Corner, _ offset: UIOffset = .zero) -> Self {

--- a/BlueprintUI/Tests/DecorateTests.swift
+++ b/BlueprintUI/Tests/DecorateTests.swift
@@ -45,6 +45,24 @@ class Decorate_Position_Tests: XCTestCase {
             CGRect(x: 0, y: 0, width: 70, height: 50)
         )
 
+        // .aligned
+
+        let alignedBottom = Decorate.Position.aligned(to: .bottom)
+        XCTAssertEqual(
+            alignedBottom.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
+            CGRect(x: 20, y: 15, width: 10, height: 15)
+        )
+
+        let alignedBottomWithGuides = Decorate.Position.aligned(
+            to: .bottom,
+            horizontalGuide: { d in 3 },
+            verticalGuide: { d in 4 }
+        )
+        XCTAssertEqual(
+            alignedBottomWithGuides.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
+            CGRect(x: 22, y: 26, width: 10, height: 15)
+        )
+
         // .corner
 
         let topLeft = Decorate.Position.corner(.topLeft, .init(horizontal: 1, vertical: 2))

--- a/BlueprintUI/Tests/DecorateTests.swift
+++ b/BlueprintUI/Tests/DecorateTests.swift
@@ -35,21 +35,21 @@ class Decorate_Position_Tests: XCTestCase {
 
     func test_frame() {
 
-        let contentFrame = CGRect(x: 10, y: 10, width: 50, height: 30)
+        let contentSize = CGSize(width: 50, height: 30)
 
         // .inset
 
         let inset = Decorate.Position.inset(UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10))
         XCTAssertEqual(
-            inset.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
-            CGRect(x: 0, y: 0, width: 70, height: 50)
+            inset.frame(with: contentSize, decoration: DecorationElement(), environment: .empty),
+            CGRect(x: -10, y: -10, width: 70, height: 50)
         )
 
         // .aligned
 
         let alignedBottom = Decorate.Position.aligned(to: .bottom)
         XCTAssertEqual(
-            alignedBottom.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
+            alignedBottom.frame(with: contentSize, decoration: DecorationElement(), environment: .empty),
             CGRect(x: 20, y: 15, width: 10, height: 15)
         )
 
@@ -59,7 +59,7 @@ class Decorate_Position_Tests: XCTestCase {
             verticalGuide: { d in 4 }
         )
         XCTAssertEqual(
-            alignedBottomWithGuides.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
+            alignedBottomWithGuides.frame(with: contentSize, decoration: DecorationElement(), environment: .empty),
             CGRect(x: 22, y: 26, width: 10, height: 15)
         )
 
@@ -67,26 +67,26 @@ class Decorate_Position_Tests: XCTestCase {
 
         let topLeft = Decorate.Position.corner(.topLeft, .init(horizontal: 1, vertical: 2))
         XCTAssertEqual(
-            topLeft.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
+            topLeft.frame(with: contentSize, decoration: DecorationElement(), environment: .empty),
             CGRect(x: -4, y: -5.5, width: 10, height: 15)
         )
 
         let topRight = Decorate.Position.corner(.topRight, .init(horizontal: 1, vertical: 2))
         XCTAssertEqual(
-            topRight.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
-            CGRect(x: 56, y: -5.5, width: 10, height: 15)
+            topRight.frame(with: contentSize, decoration: DecorationElement(), environment: .empty),
+            CGRect(x: 46, y: -5.5, width: 10, height: 15)
         )
 
         let bottomRight = Decorate.Position.corner(.bottomRight, .init(horizontal: 1, vertical: 2))
         XCTAssertEqual(
-            bottomRight.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
-            CGRect(x: 56, y: 34.5, width: 10, height: 15)
+            bottomRight.frame(with: contentSize, decoration: DecorationElement(), environment: .empty),
+            CGRect(x: 46, y: 24.5, width: 10, height: 15)
         )
 
         let bottomLeft = Decorate.Position.corner(.bottomLeft, .init(horizontal: 1, vertical: 2))
         XCTAssertEqual(
-            bottomLeft.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
-            CGRect(x: -4, y: 34.5, width: 10, height: 15)
+            bottomLeft.frame(with: contentSize, decoration: DecorationElement(), environment: .empty),
+            CGRect(x: -4, y: 24.5, width: 10, height: 15)
         )
 
         // .custom
@@ -96,7 +96,7 @@ class Decorate_Position_Tests: XCTestCase {
         }
 
         XCTAssertEqual(
-            custom.frame(with: contentFrame, decoration: DecorationElement(), environment: .empty),
+            custom.frame(with: contentSize, decoration: DecorationElement(), environment: .empty),
             CGRect(x: 10, y: 15, width: 20, height: 30)
         )
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Shadows on `Label` and `AttributedLabel`
+- `Decorate` has a new `aligned` positioning, that uses stack-style `Alignment` values and alignment guides.
+- The context vended to custom `Decorate` positions includes the decorated content size.
 
 ### Removed
 
 ### Changed
+
+- The context vended to custom `Decorate` positions was renamed to `PositionContext`, and the `contentFrame` property was replaced with a `contentSize`.
 
 ### Deprecated
 


### PR DESCRIPTION
This PR is a refactor of `Decorate.Position` to support a new `aligned` position.

Instead of an enum, `Position` is a now struct wrapping a closure. Each existing case is a static func. This means that custom and built-in positions are "made of the same stuff" (to quote @bencochran), and custom cases can do anything that the built-in ones can.

This change made it easy for me to build this new option:
```swift
public static func aligned(
    to alignment: Alignment,
    horizontalGuide: ((ElementDimensions) -> CGFloat)? = nil,
    verticalGuide: ((ElementDimensions) -> CGFloat)? = nil
) -> Self
```

Which uses the same alignment types and concepts from stacks.

The diff isn't bad, but you can also view this PR by commit to see how I refactored this step-by-step.