### PR TITLE
Accessibility increment, decrement  as associated values

### DIFF
--- a/BlueprintUICommonControls/Sources/AccessibilityElement.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityElement.swift
@@ -88,6 +88,9 @@ public struct AccessibilityElement: Element {
             {
                 config[\.increment] = incrementAction
                 config[\.decrement] = decrementAction
+            } else {
+                config[\.increment] = nil
+                config[\.decrement] = nil
             }
         }
     }

--- a/BlueprintUICommonControls/Sources/AccessibilityElement.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityElement.swift
@@ -83,13 +83,12 @@ public struct AccessibilityElement: Element {
             config[\.accessibilityFrameSize] = accessibilityFrameSize
             config[\.activate] = accessibilityActivate
 
-            guard let adjustable = traits.first(where: { $0 == .adjustable({}, {}) }),
-                  case let .adjustable(incrementAction, decrementAction) = adjustable
-            else {
-                return
+            if let adjustable = traits.first(where: { $0 == .adjustable({}, {}) }),
+               case let .adjustable(incrementAction, decrementAction) = adjustable
+            {
+                config[\.increment] = incrementAction
+                config[\.decrement] = decrementAction
             }
-            config[\.increment] = incrementAction
-            config[\.decrement] = decrementAction
         }
     }
 
@@ -138,8 +137,9 @@ public struct AccessibilityElement: Element {
 }
 
 extension AccessibilityElement.Trait: Hashable, Equatable {
-
-    public var rawValue: Int {
+    /// This conformance to `Hashable` is provided to allow traits to be included in a `Set`.
+    /// - Important: ⚠️ This implementation does not take equality of associated values on `.adjustable` into account.  ⚠️
+    private var internalValue: Int {
         switch self {
         case .button: return 0
         case .link: return 1
@@ -162,15 +162,11 @@ extension AccessibilityElement.Trait: Hashable, Equatable {
     }
 
     public static func == (lhs: AccessibilityElement.Trait, rhs: AccessibilityElement.Trait) -> Bool {
-        lhs.rawValue == rhs.rawValue
-    }
-
-    public var hashValue: Int {
-        rawValue
+        lhs.internalValue == rhs.internalValue
     }
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(hashValue)
+        hasher.combine(internalValue)
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Accessibility increment, decrement actions have been moved to associated values on the `AccessibilityElement.Trait` enum.
+
 ### Deprecated
 
 ### Security


### PR DESCRIPTION
Suggested by @n8chur, I think this is a good tradeoff of adding slight complexity in dealing with the enum in favor of ensuring that the trait is never applied without the callbacks being available.