### PR TITLE
Add None type as an escape hatch for all builders.

### DIFF
--- a/BlueprintUI/Sources/Layout/Builder.swift
+++ b/BlueprintUI/Sources/Layout/Builder.swift
@@ -44,4 +44,23 @@ public struct Builder<Child> {
     public static func buildExpression(_ children: [Child]) -> Children {
         children
     }
+
+    /// Allow an escape hatch when the control flow requires an output (such as a `switch`).
+    public static func buildExpression(_ children: None) -> Children {
+        []
+    }
+}
+
+/// Empty type that results in no children. This is useful when an expression requires output but no children are applicable (i.e. a switch statement).
+/// Example:
+/// ```
+/// switch item {
+/// case .first:
+///    None()
+/// case .second:
+///     "2"
+/// }
+/// ```
+public struct None {
+    public init() {}
 }

--- a/BlueprintUI/Sources/Layout/Builder.swift
+++ b/BlueprintUI/Sources/Layout/Builder.swift
@@ -46,7 +46,7 @@ public struct Builder<Child> {
     }
 
     /// Allow an escape hatch when the control flow requires an output (such as a `switch`).
-    public static func buildExpression(_ children: None) -> Children {
+    public static func buildExpression(_ children: Nothing) -> Children {
         []
     }
 }
@@ -61,6 +61,6 @@ public struct Builder<Child> {
 ///     "2"
 /// }
 /// ```
-public struct None {
+public struct Nothing {
     public init() {}
 }

--- a/BlueprintUI/Tests/BuilderTests.swift
+++ b/BlueprintUI/Tests/BuilderTests.swift
@@ -138,6 +138,38 @@ class BuilderTests: XCTestCase {
         )
     }
 
+    func tests_none() {
+        enum TestEnum: CaseIterable {
+            case first
+            case second
+            case third
+        }
+
+        let item = TestEnum.first
+
+        let content: [String] = build {
+            switch item {
+            case .first:
+                None()
+            case .second:
+                "2"
+            case .third:
+                "3"
+            }
+
+            None()
+            "1"
+            None()
+            "2"
+            None()
+            "3"
+        }
+
+        XCTAssertEqual(
+            content, ["1", "2", "3"]
+        )
+    }
+
     func test_optional() {
         let optionalNil: String? = nil
         let optional: String? = "1"

--- a/BlueprintUI/Tests/BuilderTests.swift
+++ b/BlueprintUI/Tests/BuilderTests.swift
@@ -150,18 +150,18 @@ class BuilderTests: XCTestCase {
         let content: [String] = build {
             switch item {
             case .first:
-                None()
+                Nothing()
             case .second:
                 "2"
             case .third:
                 "3"
             }
 
-            None()
+            Nothing()
             "1"
-            None()
+            Nothing()
             "2"
-            None()
+            Nothing()
             "3"
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for optionals in builders without unwrapping via `if let`.
+- Added None type for all builders as an escape hatch when control flow (i.e. `switch`) requires output but none is desired.
 
 ### Removed
 


### PR DESCRIPTION
This adds a None type as an escape hatch when control flows such as Switch requires an output but none is desired.