### PR TITLE
Support nil in ElementBuilder

### DIFF
--- a/BlueprintUI/Sources/Layout/Builder.swift
+++ b/BlueprintUI/Sources/Layout/Builder.swift
@@ -23,6 +23,10 @@ public struct Builder<Child> {
         [child]
     }
 
+    /// This function is disfavored in case a builder wants to offer additional `buildExpression` functions to support
+    /// multiple types in their builders. `@_disfavoredOverload` allows the compiler to choose the other function when
+    /// `nil` is built, instead of it being ambiguous.
+    @_disfavoredOverload
     public static func buildExpression(_ child: Child?) -> Children {
         guard let child = child else { return [] }
         return [child]

--- a/BlueprintUI/Tests/BuilderTests.swift
+++ b/BlueprintUI/Tests/BuilderTests.swift
@@ -186,6 +186,38 @@ class BuilderTests: XCTestCase {
         )
     }
 
+    func test_optional_expression() {
+        enum TestEnum: CaseIterable {
+            case first
+            case second
+            case third
+        }
+
+        let item = TestEnum.first
+
+        let content: [String] = build {
+            switch item {
+            case .first:
+                nil
+            case .second:
+                "2"
+            case .third:
+                "3"
+            }
+
+            nil
+            "1"
+            nil
+            "2"
+            nil
+            "3"
+        }
+
+        XCTAssertEqual(
+            content, ["1", "2", "3"]
+        )
+    }
+
     fileprivate func build<Content>(
         @Builder<Content> using builder: () -> [Content]
     ) -> [Content] {

--- a/BlueprintUI/Tests/ElementBuilderTests.swift
+++ b/BlueprintUI/Tests/ElementBuilderTests.swift
@@ -49,12 +49,8 @@ class ElementBuilderTests: XCTestCase {
         }
 
         let gridRow = GridRow {
-            if let element = optionalElement1() {
-                element
-            }
-            if let element = optionalElement2() {
-                element
-            }
+            optionalElement1()
+            optionalElement2()
         }
 
         XCTAssertEqual(gridRow.children.count, 1)
@@ -63,6 +59,38 @@ class ElementBuilderTests: XCTestCase {
         } else {
             XCTAssert(type(of: gridRow.children[0].element) == TestElement2.self)
         }
+    }
+
+    func test_resultBuilder_optional_expression() {
+        enum TestEnum: CaseIterable {
+            case first
+            case second
+            case third
+        }
+
+        let item = TestEnum.first
+
+        let gridRow = GridRow {
+            switch item {
+            case .first:
+                TestElement()
+            case .second:
+                nil
+            case .third:
+                nil
+            }
+
+            switch item {
+            case .first:
+                nil
+            case .second:
+                TestElement()
+            case .third:
+                nil
+            }
+        }
+
+        XCTAssertEqual(gridRow.children.count, 1)
     }
 
     func test_resultBuilder_either_ifelse() {


### PR DESCRIPTION
Support `nil` in all cases in `ElementBuilder` (and any other such specializations of `Builder`) by disfavoring the optional build expression function in `Builder`.