### PR TITLE
Add .grows and .shrinks to StackLayout.Child.Priority

### DIFF
--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -992,13 +992,28 @@ extension StackLayout {
         public let key: AnyHashable?
 
         public enum Priority {
+            /// The element has a fixed size, with a grow and shrink priority of 0.
+            /// The element will neither grow nor shrink during overflow and underflow.
             case fixed
+
+            /// The element has a flexible size, with a grow and shrink priority of 1.
+            /// The element will grow during underflow and shrink during overflow.
             case flexible
+
+            /// The element has a flexible size, it will grow if the stack underflows,
+            /// but it will not shrink if the stack overflows.
+            case grows
+
+            /// The element has a flexible size, it will shrink if the stack overflows,
+            /// but it will not grow if the stack underflows.
+            case shrinks
 
             fileprivate var growPriority: CGFloat {
                 switch self {
                 case .fixed: return 0
                 case .flexible: return 1
+                case .grows: return 1
+                case .shrinks: return 0
                 }
             }
 
@@ -1006,6 +1021,8 @@ extension StackLayout {
                 switch self {
                 case .fixed: return 0
                 case .flexible: return 1
+                case .grows: return 0
+                case .shrinks: return 1
                 }
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `.grows` and `.shrinks` to `StackLayout.Child.Priority`, to allow for extra control over how flexible elements grow and shrink.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
There's no way to find-tune the grow and shrink priorities with the `.stackLayoutChild(...)` APIs, so adding this so we also don't need to directly let people fiddle with the direct priorities.