### PR TITLE
Allow AccessibilityBlocker to take in an isBlocking parameter

### DIFF
--- a/BlueprintUICommonControls/Sources/AccessibilityBlocker.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityBlocker.swift
@@ -7,10 +7,19 @@ import UIKit
 /// hidden from the accessibility system.
 public struct AccessibilityBlocker: Element {
 
+    /// The element whose accessibility information will be blocked.
     public var wrapped: Element
 
+    /// If the `AccessibilityBlocker` is currently blocking accessibility.
+    public var isBlocking: Bool
+
     /// Creates a new `AccessibilityBlocker` wrapping the provided element.
-    public init(wrapping element: Element) {
+    public init(
+        isBlocking: Bool = true,
+        wrapping element: Element
+    ) {
+        self.isBlocking = isBlocking
+
         wrapped = element
     }
 
@@ -24,8 +33,8 @@ public struct AccessibilityBlocker: Element {
 
     public func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
         UIView.describe { config in
-            config[\.isAccessibilityElement] = false
-            config[\.accessibilityElementsHidden] = true
+            config[\.isAccessibilityElement] = !isBlocking
+            config[\.accessibilityElementsHidden] = isBlocking
         }
     }
 }
@@ -36,7 +45,7 @@ extension Element {
     /// Blocks all accessibility on the element, so that it is
     /// is no longer an accessibility element, and its children are
     /// hidden from the accessibility system.
-    public func blockAccessibility() -> AccessibilityBlocker {
-        AccessibilityBlocker(wrapping: self)
+    public func blockAccessibility(isBlocking: Bool = true) -> AccessibilityBlocker {
+        AccessibilityBlocker(isBlocking: isBlocking, wrapping: self)
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `.grows` and `.shrinks` to `StackLayout.Child.Priority`, to allow for extra control over how flexible elements grow and shrink.
+- `AccessibilityBlocker` now takes in a `Bool` to control blocking, to avoid changing the element hierarchy to toggle if blocking is occurring.
 
 ### Removed
 


### PR DESCRIPTION
- This allows toggling this setting conditionally w/o changing the element hierarchy, to avoid blowing away views lower in the tree.