### PR TITLE
Aligned will now constrain content to its max layout width

### DIFF
--- a/BlueprintUI/Sources/Layout/Aligned.swift
+++ b/BlueprintUI/Sources/Layout/Aligned.swift
@@ -75,17 +75,25 @@ public struct Aligned: Element {
         }
 
         func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
-            let contentSize = child.measure(in: SizeConstraint(size))
 
-            var attributes = LayoutAttributes(size: contentSize)
+            let measurement = child.measure(in: SizeConstraint(size))
+
+            let constrainedMeasurement = CGSize(
+                width: min(size.width, measurement.width),
+                height: min(size.height, measurement.height)
+            )
+
+            var attributes = LayoutAttributes(
+                size: constrainedMeasurement
+            )
 
             switch verticalAlignment {
             case .top:
                 attributes.frame.origin.y = 0
             case .center:
-                attributes.frame.origin.y = (size.height - contentSize.height) / 2.0
+                attributes.frame.origin.y = (size.height - constrainedMeasurement.height) / 2.0
             case .bottom:
-                attributes.frame.origin.y = size.height - contentSize.height
+                attributes.frame.origin.y = size.height - constrainedMeasurement.height
             case .fill:
                 attributes.frame.origin.y = 0
                 attributes.frame.size.height = size.height
@@ -95,9 +103,9 @@ public struct Aligned: Element {
             case .leading:
                 attributes.frame.origin.x = 0
             case .center:
-                attributes.frame.origin.x = (size.width - contentSize.width) / 2.0
+                attributes.frame.origin.x = (size.width - constrainedMeasurement.width) / 2.0
             case .trailing:
-                attributes.frame.origin.x = size.width - contentSize.width
+                attributes.frame.origin.x = size.width - constrainedMeasurement.width
             case .fill:
                 attributes.frame.origin.x = 0
                 attributes.frame.size.width = size.width

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Aligned` will now constrain its content to the provided layout frame. If you need content to exceed the layout frame, please use `Decoration`.
+
 ### Deprecated
 
 ### Security


### PR DESCRIPTION
This fixes issues like this, where wrapping content in a `.center` means it grows outside of the bounds of the view (expected on left, actual before this fix on right)

![image](https://user-images.githubusercontent.com/327847/172276355-9dd5f3b4-53ce-4a04-b7fa-06edb8afdded.png)
