### PR TITLE
Only return accessibilityPath when the corner style is non-square

### DIFF
--- a/BlueprintUICommonControls/Sources/AccessibilityElement.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityElement.swift
@@ -108,14 +108,11 @@ public struct AccessibilityElement: Element {
         var decrement: (() -> Void)?
         var activate: (() -> Bool)?
 
-        override var accessibilityPath: UIBezierPath? {
+        override var accessibilityFrame: CGRect {
             get {
                 guard let accessibilityFrameSize = accessibilityFrameSize else {
                     return UIAccessibility.convertToScreenCoordinates(
-                        UIBezierPath(
-                            rect: bounds,
-                            corners: accessibilityFrameCornerStyle
-                        ),
+                        bounds,
                         in: self
                     )
                 }
@@ -126,11 +123,25 @@ public struct AccessibilityElement: Element {
                 )
 
                 return UIAccessibility.convertToScreenCoordinates(
-                    UIBezierPath(
-                        rect: adjustedFrame,
-                        corners: accessibilityFrameCornerStyle
-                    ),
+                    adjustedFrame,
                     in: self
+                )
+            }
+
+            set {
+                fatalError("accessibilityFrame is not settable on AccessibilityView")
+            }
+        }
+
+        override var accessibilityPath: UIBezierPath? {
+            get {
+                guard accessibilityFrameCornerStyle != .square else {
+                    return nil
+                }
+
+                return UIBezierPath(
+                    rect: accessibilityFrame,
+                    corners: accessibilityFrameCornerStyle
                 )
             }
 

--- a/BlueprintUICommonControls/Sources/Box.swift
+++ b/BlueprintUICommonControls/Sources/Box.swift
@@ -128,12 +128,12 @@ public struct Box: Element {
 
 extension Box {
 
-    public enum CornerStyle {
+    public enum CornerStyle: Equatable {
         case square
         case capsule
         case rounded(radius: CGFloat, corners: Corners = .all)
 
-        public struct Corners: OptionSet {
+        public struct Corners: OptionSet, Equatable {
             public let rawValue: UInt8
 
             public init(rawValue: UInt8) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Aligned` will now constrain its content to the provided layout frame. If you need content to exceed the layout frame, please use `Decoration`.
 
+- `AccessibilityElement` will now only return `accessibilityPath` for elements with a non-square corner style. This avoids needlessly changing AccessibilitySnapshot (https://github.com/cashapp/AccessibilitySnapshot) reference images.
+
 ### Deprecated
 
 ### Security


### PR DESCRIPTION
Avoids needlessly updating snapshot reference images, eg like this: 

<img width="830" alt="image" src="https://user-images.githubusercontent.com/327847/172707712-8a5e3bd8-0789-44fe-ab06-d1b40a0c79b7.png">
