### PR TITLE
Allow `Image` to block accessibility descriptions of images

### DIFF
--- a/BlueprintUICommonControls/Sources/Image.swift
+++ b/BlueprintUICommonControls/Sources/Image.swift
@@ -15,15 +15,21 @@ public struct Image: Element {
     /// not precisely match the size that the element is assigned.
     public var contentMode: ContentMode
 
+    /// iOS 14 added support for Image Descriptions using VoiceOver. This is not always apropreate.
+    /// Set this to `true` to prevent VoiceOver from discribing the displayed image.
+    public var blockAccessibilityDiscription: Bool
+
     /// Initializes an image element with the given `UIImage` instance.
     public init(
         image: UIImage?,
         contentMode: ContentMode = .aspectFill,
-        tintColor: UIColor? = nil
+        tintColor: UIColor? = nil,
+        blockAccessibilityDiscription: Bool = false
     ) {
         self.image = image
         self.contentMode = contentMode
         self.tintColor = tintColor
+        self.blockAccessibilityDiscription = blockAccessibilityDiscription
     }
 
     public var content: ElementContent {
@@ -37,6 +43,10 @@ public struct Image: Element {
             config[\.contentMode] = contentMode.uiViewContentMode
             config[\.layer.minificationFilter] = .trilinear
             config[\.tintColor] = tintColor
+            if blockAccessibilityDiscription {
+                // Seting `isAccessibilityElement = false` isn't enough here, VoiceOver is very aggressive in finding images to discribe. We need to explicitly remove the `.image` trait.
+                config[\.accessibilityTraits] = UIAccessibilityTraits.none
+            }
         }
     }
 

--- a/BlueprintUICommonControls/Sources/Image.swift
+++ b/BlueprintUICommonControls/Sources/Image.swift
@@ -15,7 +15,7 @@ public struct Image: Element {
     /// not precisely match the size that the element is assigned.
     public var contentMode: ContentMode
 
-    /// iOS 14 added support for Image Descriptions using VoiceOver. This is not always apropreate.
+    /// iOS 14 added support for Image Descriptions using VoiceOver. This is not always appropriate.
     /// Set this to `true` to prevent VoiceOver from discribing the displayed image.
     public var blockAccessibilityDiscription: Bool
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Image` now provides an override to prevent VoiceOver from generating accessibility descriptions.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
iOS 14 introduced [image descriptions using VoiceOver](https://support.apple.com/en-mn/guide/iphone/iph37e6b3844/ios). This feature uses machine learning magic to provide accurate descriptions of arbitrary images, it's pretty damn impressive.

Unfortunately this is not always desirable, particularly when the app's UI makes heavy use of arbitrary user provided images. Voiceover is particularly aggressive in finding images to describe. 
Any view with `UIAccessibilityTraits.image` will trigger the description regardless of its status as an accessibility element. What's more, the entire view hierarchy containing the view with the `.image` trait  will be analysed by the ML model, including any text that might be overlaid. This can result in a long and duplicative description. 

This PR provides an escape hatch to allow an image to be excluded from accessibility descriptions. 

Check out this screen recording for an example. 

https://user-images.githubusercontent.com/219578/176280560-4bd5905b-ecab-46ef-b2fb-2c617c4b476f.mov

