### PR TITLE
Fix AccessibilityContainer with children that set accessibilityElementsHidden to true

### DIFF
--- a/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
@@ -61,7 +61,9 @@ extension AccessibilityContainer {
 extension UIView {
     func recursiveAccessibleSubviews() -> [Any] {
         subviews.flatMap { subview -> [Any] in
-            if let accessibilityElements = subview.accessibilityElements {
+            if subview.accessibilityElementsHidden {
+                return []
+            } else if let accessibilityElements = subview.accessibilityElements {
                 return accessibilityElements
             } else if subview.isAccessibilityElement {
                 return [subview]

--- a/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
@@ -61,7 +61,7 @@ extension AccessibilityContainer {
 extension UIView {
     func recursiveAccessibleSubviews() -> [Any] {
         subviews.flatMap { subview -> [Any] in
-            if subview.accessibilityElementsHidden {
+            if subview.accessibilityElementsHidden || subview.isHidden {
                 return []
             } else if let accessibilityElements = subview.accessibilityElements {
                 return accessibilityElements

--- a/BlueprintUICommonControls/Tests/Sources/AccessibilityContainerTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AccessibilityContainerTests.swift
@@ -104,4 +104,21 @@ class AccessibilityContainerTests: XCTestCase {
 
         XCTAssertNil(accessibleSubviews.first)
     }
+
+    func test_isHiddenNotAccessible() {
+
+        let accessibleView = UIView()
+        accessibleView.isAccessibilityElement = true
+
+        let wrapperView = UIView()
+        wrapperView.addSubview(accessibleView)
+        wrapperView.isHidden = true
+
+        let containerView = UIView()
+        containerView.addSubview(wrapperView)
+
+        let accessibleSubviews = containerView.recursiveAccessibleSubviews() as! [UIView]
+
+        XCTAssertNil(accessibleSubviews.first)
+    }
 }

--- a/BlueprintUICommonControls/Tests/Sources/AccessibilityContainerTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AccessibilityContainerTests.swift
@@ -87,4 +87,21 @@ class AccessibilityContainerTests: XCTestCase {
         XCTAssertFalse(accessibleSubviews.contains(where: { $0 === undiscoveredViewA }))
         XCTAssertFalse(accessibleSubviews.contains(where: { $0 === undiscoveredViewB }))
     }
+
+    func test_accessibilityElementHiddenNotAccessible() {
+
+        let accessibleView = UIView()
+        accessibleView.isAccessibilityElement = true
+
+        let wrapperView = UIView()
+        wrapperView.addSubview(accessibleView)
+        wrapperView.accessibilityElementsHidden = true
+
+        let containerView = UIView()
+        containerView.addSubview(wrapperView)
+
+        let accessibleSubviews = containerView.recursiveAccessibleSubviews() as! [UIView]
+
+        XCTAssertNil(accessibleSubviews.first)
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `AccessibilityContainer` now omits accessibility elements where `.accessibilityElementsHidden` is `true`.
+
 ### Added
 
 - `Image` now provides an override to prevent VoiceOver from generating accessibility descriptions.


### PR DESCRIPTION
`AccessibilityContainer` now omits accessibility elements where `.accessibilityElementsHidden` is `true`.