### PR TITLE
Fix Cache Tree Cache Misses

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -206,7 +206,10 @@ public final class BlueprintView: UIView {
         let measurement = element.content.measure(
             in: constraint,
             environment: makeEnvironment(),
-            cache: CacheFactory.makeCache(name: "sizeThatFits:\(type(of: element))")
+            cache: CacheFactory.makeCache(
+                name: "sizeThatFits:\(type(of: element))",
+                screenScale: window != nil ? layer.contentsScale : UIScreen.main.scale
+            )
         )
 
         sizesThatFit[constraint] = measurement

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -34,7 +34,7 @@ public struct ElementContent {
         measure(
             in: constraint,
             environment: environment,
-            cache: CacheFactory.makeCache(name: "ElementContent")
+            cache: CacheFactory.makeCache(name: "ElementContent", screenScale: environment.displayScale)
         )
     }
 

--- a/BlueprintUI/Sources/Internal/CacheFactory.swift
+++ b/BlueprintUI/Sources/Internal/CacheFactory.swift
@@ -1,11 +1,12 @@
+import CoreGraphics
 import Foundation
 
 enum CacheFactory {
-    static func makeCache(name: String, signpostRef: AnyObject = SignpostToken()) -> CacheTree {
+    static func makeCache(name: String, signpostRef: AnyObject = SignpostToken(), screenScale: CGFloat) -> CacheTree {
         // to disable caching, use this instead:
         // FakeCache(name: name, signpostRef: signpostRef)
 
-        RenderPassCache(name: name, signpostRef: signpostRef)
+        RenderPassCache(name: name, signpostRef: signpostRef, screenScale: screenScale)
     }
 }
 

--- a/BlueprintUI/Sources/Internal/CacheTree.swift
+++ b/BlueprintUI/Sources/Internal/CacheTree.swift
@@ -12,6 +12,9 @@ protocol CacheTree: AnyObject {
     /// A reference to use for logging
     var signpostRef: AnyObject { get }
 
+    /// The scale of the screen scale, used for rounding to account for loss of float precision.
+    var screenScale: CGFloat { get }
+
     /// The sizes that are contained in this cache, keyed by size constraint.
     subscript(constraint: SizeConstraint) -> CGSize? { get set }
 
@@ -23,18 +26,29 @@ extension CacheTree {
     /// Convenience method to get a cached size, or compute and store one if it is not in the cache.
     func get(_ constraint: SizeConstraint, orStore calculation: (SizeConstraint) -> CGSize) -> CGSize {
 
-        if let size = self[constraint] {
+        /// Due to various math upstream, we can end up with measurements like 210.0 getting
+        /// turned into numbers like 209.99999997 due to loss of precision.
+        ///
+        /// Because we cache by exact values in this cache,
+        /// let's round the key to the nearest screen-scale pixel to avoid a cache miss.
+        ///
+        /// ⚠️ Important! We **do not** want to round the constraint itself, just the key.
+        /// Blueprint allows (and expects) unrounded values – they're rounded / snapped during the view layout pass.
+
+        let key = constraint.roundToNearestPixel(with: screenScale)
+
+        if let size = self[key] {
             return size
         } else {
             let size = calculation(constraint)
 
             /// 1) Cache the measured size for the given constraint.
-            self[constraint] = size
+            self[key] = size
 
-            /// 2) Optimization: Cache the measured size, so if we ask for this
-            /// exact size later on, we don't re-measure the element.
+            /// 2) Optimization: Cache the size itself as its own constraint.
             ///
-            /// This avoids a cache miss later on when a layout lays out an item with a measured size.
+            /// This avoids a cache miss later on when a layout
+            /// lays out an item with this same size.
             self[SizeConstraint(size)] = size
 
             return size

--- a/BlueprintUI/Sources/Internal/FakeCache.swift
+++ b/BlueprintUI/Sources/Internal/FakeCache.swift
@@ -5,10 +5,12 @@ final class FakeCache: CacheTree {
 
     var name: String
     var signpostRef: AnyObject
+    var screenScale: CGFloat
 
-    init(name: String, signpostRef: AnyObject) {
+    init(name: String, signpostRef: AnyObject, screenScale: CGFloat) {
         self.name = name
         self.signpostRef = signpostRef
+        self.screenScale = screenScale
     }
 
     subscript(constraint: SizeConstraint) -> CGSize? {
@@ -17,6 +19,6 @@ final class FakeCache: CacheTree {
     }
 
     func subcache(key: SubcacheKey, name: @autoclosure () -> String) -> CacheTree {
-        FakeCache(name: name(), signpostRef: signpostRef)
+        FakeCache(name: name(), signpostRef: signpostRef, screenScale: screenScale)
     }
 }

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -46,7 +46,7 @@ struct LayoutResultNode {
     }
 
     init(root: Element, layoutAttributes: LayoutAttributes, environment: Environment) {
-        let cache = CacheFactory.makeCache(name: "\(type(of: root))")
+        let cache = CacheFactory.makeCache(name: "\(type(of: root))", screenScale: environment.displayScale)
         self.init(
             element: root,
             layoutAttributes: layoutAttributes,

--- a/BlueprintUI/Sources/Internal/RenderPassCache.swift
+++ b/BlueprintUI/Sources/Internal/RenderPassCache.swift
@@ -5,13 +5,15 @@ final class RenderPassCache: CacheTree {
 
     let name: String
     let signpostRef: AnyObject
+    let screenScale: CGFloat
 
     private var subcaches: [SubcacheKey: RenderPassCache] = [:]
     private var measurements: [SizeConstraint: CGSize] = [:]
 
-    init(name: String, signpostRef: AnyObject) {
+    init(name: String, signpostRef: AnyObject, screenScale: CGFloat) {
         self.name = name
         self.signpostRef = signpostRef
+        self.screenScale = screenScale
     }
 
     subscript(constraint: SizeConstraint) -> CGSize? {
@@ -28,7 +30,7 @@ final class RenderPassCache: CacheTree {
             return subcache
         }
 
-        let subcache = RenderPassCache(name: name(), signpostRef: signpostRef)
+        let subcache = RenderPassCache(name: name(), signpostRef: signpostRef, screenScale: screenScale)
         subcaches[key] = subcache
         return subcache
     }

--- a/BlueprintUI/Sources/Measuring/SizeConstraint.swift
+++ b/BlueprintUI/Sources/Measuring/SizeConstraint.swift
@@ -194,6 +194,28 @@ extension SizeConstraint {
 }
 
 extension SizeConstraint {
+
+    func roundToNearestPixel(with scale: CGFloat) -> Self {
+        .init(
+            width: width.roundToNearestPixel(with: scale),
+            height: height.roundToNearestPixel(with: scale)
+        )
+    }
+}
+
+extension SizeConstraint.Axis {
+
+    func roundToNearestPixel(with scale: CGFloat) -> Self {
+        switch self {
+        case .atMost(let max):
+            return .atMost(max.rounded(.toNearestOrAwayFromZero, by: scale))
+        case .unconstrained:
+            return .unconstrained
+        }
+    }
+}
+
+extension SizeConstraint {
     /// This property wrapper checks the value of `atMost` cases, and turns it into an
     /// `unconstrained` axis if the value equals `greatestFiniteMagnitude` or `isInfinite`.
     @propertyWrapper public struct UnconstrainedInfiniteAxis: Equatable, Hashable {

--- a/BlueprintUI/Tests/Element+Testing.swift
+++ b/BlueprintUI/Tests/Element+Testing.swift
@@ -29,7 +29,7 @@ extension ElementContent {
         performLayout(
             attributes: attributes,
             environment: .empty,
-            cache: CacheFactory.makeCache(name: "test")
+            cache: CacheFactory.makeCache(name: "test", screenScale: 1)
         )
     }
 }

--- a/BlueprintUI/Tests/ElementContentTests.swift
+++ b/BlueprintUI/Tests/ElementContentTests.swift
@@ -323,6 +323,7 @@ private struct MeasureCountingSpacer: Element {
 private class TestCache: CacheTree {
     var name: String
     var signpostRef: AnyObject { self }
+    var screenScale: CGFloat = 1
 
     var measurements: [SizeConstraint: CGSize] = [:]
     var subcaches: [SubcacheKey: TestCache] = [:]

--- a/BlueprintUI/Tests/RenderPassCacheTests.swift
+++ b/BlueprintUI/Tests/RenderPassCacheTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class RenderPassCacheTests: XCTestCase {
     func test_caching() {
-        let cache = RenderPassCache(name: "test", signpostRef: self)
+        let cache = RenderPassCache(name: "test", signpostRef: self, screenScale: 1)
 
         XCTAssertEqual(cache.name, "test")
         XCTAssert(cache.signpostRef === self)
@@ -34,7 +34,7 @@ final class RenderPassCacheTests: XCTestCase {
     }
 
     func test_subcaches() {
-        let cache = RenderPassCache(name: "test", signpostRef: self)
+        let cache = RenderPassCache(name: "test", signpostRef: self, screenScale: 1)
 
         let subcache1 = cache.subcache(key: 0, name: "1")
         let subcache2 = cache.subcache(key: 1, name: "2")
@@ -68,7 +68,7 @@ final class RenderPassCacheTests: XCTestCase {
 
     /// Test the get(_: orStore:) convenience method
     func test_getOrStore() {
-        let cache = RenderPassCache(name: "test", signpostRef: self)
+        let cache = RenderPassCache(name: "test", signpostRef: self, screenScale: 1)
 
         let size1 = CGSize(width: 1, height: 1)
 
@@ -99,7 +99,7 @@ final class RenderPassCacheTests: XCTestCase {
         }
 
         do {
-            let cache = RenderPassCache(name: "test", signpostRef: self)
+            let cache = RenderPassCache(name: "test", signpostRef: self, screenScale: 1)
 
             let singletonSubcache = cache.subcache(element: Empty())
             XCTAssertEqual(singletonSubcache.name, "test.Empty")
@@ -107,7 +107,7 @@ final class RenderPassCacheTests: XCTestCase {
         }
 
         do {
-            let cache = RenderPassCache(name: "test", signpostRef: self)
+            let cache = RenderPassCache(name: "test", signpostRef: self, screenScale: 1)
 
             let singletonSubcache = cache.subcache(index: 0, of: 1, element: Empty())
             XCTAssertEqual(singletonSubcache.name, "test.Empty")
@@ -115,7 +115,7 @@ final class RenderPassCacheTests: XCTestCase {
         }
 
         do {
-            let cache = RenderPassCache(name: "test", signpostRef: self)
+            let cache = RenderPassCache(name: "test", signpostRef: self, screenScale: 1)
 
             let subcache1 = cache.subcache(index: 0, of: 2, element: Empty())
             let subcache2 = cache.subcache(index: 1, of: 2, element: Empty())


### PR DESCRIPTION
Due to float addition and subtraction that happens throughout layout, it was common to end up with `210.0` getting turned into `209.999997` (etc) throughout. This was causing needless cache misses. To resolve, I introduced pixel-based rounding to the cache tree so the cached constraint keys land on a display pixel.