### PR TITLE
Bail early from logging methods if logging is disabled

### DIFF
--- a/BlueprintUI/Sources/Internal/Logger.swift
+++ b/BlueprintUI/Sources/Internal/Logger.swift
@@ -7,6 +7,9 @@ enum Logger {}
 /// BlueprintView signposts
 extension Logger {
     static func logLayoutStart(view: BlueprintView) {
+
+        guard BlueprintLogging.isEnabled else { return }
+
         os_signpost(
             .begin,
             log: .active,
@@ -18,6 +21,9 @@ extension Logger {
     }
 
     static func logLayoutEnd(view: BlueprintView) {
+
+        guard BlueprintLogging.isEnabled else { return }
+
         os_signpost(
             .end,
             log: .active,
@@ -27,6 +33,9 @@ extension Logger {
     }
 
     static func logViewUpdateStart(view: BlueprintView) {
+
+        guard BlueprintLogging.isEnabled else { return }
+
         os_signpost(
             .begin,
             log: .active,
@@ -38,6 +47,9 @@ extension Logger {
     }
 
     static func logViewUpdateEnd(view: BlueprintView) {
+
+        guard BlueprintLogging.isEnabled else { return }
+
         os_signpost(
             .end,
             log: .active,
@@ -47,6 +59,9 @@ extension Logger {
     }
 
     static func logElementAssigned(view: BlueprintView) {
+
+        guard BlueprintLogging.isEnabled else { return }
+
         os_signpost(
             .event,
             log: .active,
@@ -61,6 +76,9 @@ extension Logger {
 /// Measuring signposts
 extension Logger {
     static func logMeasureStart(object: AnyObject, description: String, constraint: SizeConstraint) {
+
+        guard BlueprintLogging.isEnabled else { return }
+
         os_signpost(
             .begin,
             log: .active,
@@ -75,6 +93,9 @@ extension Logger {
     }
 
     static func logMeasureEnd(object: AnyObject) {
+
+        guard BlueprintLogging.isEnabled else { return }
+
         os_signpost(
             .end,
             log: .active,

--- a/BlueprintUI/Sources/Internal/OSLog+Blueprint.swift
+++ b/BlueprintUI/Sources/Internal/OSLog+Blueprint.swift
@@ -6,16 +6,17 @@ extension OSLog {
     static let blueprint = OSLog(subsystem: "com.squareup.Blueprint", category: "Blueprint")
 
     /// The log to be used for `os_log` and `os_signpost` logging.
-    static var active: OSLog = OSLog.disabled
+    fileprivate(set) static var active: OSLog = OSLog.disabled
 }
 
 /// Namespace for logging config.
 public enum BlueprintLogging {
+
     /// If enabled, Blueprint will emit signpost logs. You can view these logs in Instruments to
     /// aid in debugging or performance tuning.
     ///
     /// Signpost logging is disabled by default.
-    public static var enabled: Bool {
+    public static var isEnabled: Bool {
         get {
             OSLog.active === OSLog.blueprint
         }


### PR DESCRIPTION
I noticed that we still call the `os_signpost` log methods even if logging is disabled (albeit, with the `.disabled` log), but there's still some formatting, access, etc, that goes on when calling the method, so I figured this can't hurt.