### PR TITLE
[SPL] `LayoutMode` flag

### DIFF
--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -34,11 +34,22 @@ public struct ElementContent {
         measure(
             in: constraint,
             environment: environment,
-            cache: CacheFactory.makeCache(name: "ElementContent")
+            cache: CacheFactory.makeCache(name: "ElementContent"),
+            layoutMode: RenderContext.current?.layoutMode ?? environment.layoutMode
         )
     }
 
-    func measure(in constraint: SizeConstraint, environment: Environment, cache: CacheTree) -> CGSize {
+    func measure(
+        in constraint: SizeConstraint,
+        environment: Environment,
+        cache: CacheTree,
+        layoutMode: LayoutMode
+    ) -> CGSize {
+        // TODO: switch on layoutMode
+        storage.measure(in: constraint, environment: environment, cache: cache)
+    }
+
+    fileprivate func measure(in constraint: SizeConstraint, environment: Environment, cache: CacheTree) -> CGSize {
         storage.measure(in: constraint, environment: environment, cache: cache)
     }
 

--- a/BlueprintUI/Sources/Internal/LayoutModeKey.swift
+++ b/BlueprintUI/Sources/Internal/LayoutModeKey.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum LayoutModeKey: EnvironmentKey {
+    static let defaultValue: LayoutMode = .default
+}
+
+extension Environment {
+    /// This mode will be inherited by descendant BlueprintViews that do not have an explicit
+    /// mode set.
+    var layoutMode: LayoutMode {
+        get { self[LayoutModeKey.self] }
+        set { self[LayoutModeKey.self] = newValue }
+    }
+}

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -17,6 +17,10 @@ extension Element {
         )
     }
 
+    func layout(frame: CGRect, environment: Environment, layoutMode: LayoutMode) -> LayoutResultNode {
+        // TODO: switch on layoutMode
+        layout(layoutAttributes: LayoutAttributes(frame: frame), environment: environment)
+    }
 }
 
 /// Represents a tree of elements with complete layout attributes

--- a/BlueprintUI/Sources/Internal/RenderContext.swift
+++ b/BlueprintUI/Sources/Internal/RenderContext.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Stores info about the currently running render pass, if there is one.
+///
+/// The render context is available statically, which allows "out of band" operations like
+/// calls to ``ElementContent/measure(in:environment:)`` to get some context without having it
+/// passed in explicitly. This depends entirely on the render pass running exclusively on the main
+/// thread.
+struct RenderContext {
+    /// The current render context, if there is one.
+    private(set) static var current: Self?
+    
+    var layoutMode: LayoutMode
+    
+    /// Perform the given block with this as the current render context, restoring the previous
+    /// context before returning.
+    func perform<Result>(block: () throws -> Result) rethrows -> Result {
+        let previous = Self.current
+        defer { Self.current = previous }
+
+        Self.current = self
+
+        return try block()
+    }
+}

--- a/BlueprintUI/Sources/Layout/LayoutMode.swift
+++ b/BlueprintUI/Sources/Layout/LayoutMode.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public enum LayoutMode: Equatable {
+    public static let `default`: Self = .standard
+    
+    case standard
+    case singlePass
+}

--- a/BlueprintUI/Tests/ElementContentTests.swift
+++ b/BlueprintUI/Tests/ElementContentTests.swift
@@ -106,7 +106,8 @@ class ElementContentTests: XCTestCase {
             _ = container.measure(
                 in: SizeConstraint(containerSize),
                 environment: .empty,
-                cache: cache
+                cache: cache,
+                layoutMode: .standard
             )
 
             return (cache, counts)

--- a/BlueprintUI/Tests/RenderContextTests.swift
+++ b/BlueprintUI/Tests/RenderContextTests.swift
@@ -1,0 +1,36 @@
+@testable import BlueprintUI
+import Foundation
+import XCTest
+
+final class RenderContextTests: XCTestCase {
+    func test_mode() {
+        let view = BlueprintView()
+        XCTAssertNil(view.layoutMode)
+        
+        // If the default ever changes we'll need to update this test
+        XCTAssertEqual(LayoutMode.default, .standard)
+
+        var contextualMode: LayoutMode?
+
+        view.element = EnvironmentReader { _ in
+
+            // this element measurement is "out-of-band", meaning the enclosing render doesn't
+            // know about it and can't explicitly pass it any info
+            _ = EnvironmentReader { _ in
+                contextualMode = RenderContext.current?.layoutMode
+                return Empty()
+            }
+            .content
+            .measure(in: .unconstrained, environment: .empty)
+            
+            return Empty()
+        }
+        
+        view.ensureLayoutPass()
+        XCTAssertEqual(contextualMode, .default)
+        
+        view.layoutMode = .singlePass
+        view.ensureLayoutPass()
+        XCTAssertEqual(contextualMode, .singlePass)
+    }
+}


### PR DESCRIPTION
A new `LayoutMode` type to switch between standard and single-pass.

- You can set this on a `BlueprintView`. It doesn't do anything yet.
- If it's not set, the view will inherit the mode of its nearest ancestor (via the current plumbing for environments)
- If there's no ancestor, the global default is `standard`.
- The global default cannot be changed at runtime (yet?).

The layout mode also needs to be bridged to "out-of-band" operations (e.g. measuring elements in a GeometryReader). To facilitate that, there's also a new `RenderContext` type that is available statically during a render pass. Currently it only holds the layout mode but it might also be useful later to bridge the CacheTree or other stuff.

Note that this PR targets a feature branch.