### PR TITLE
`AttributedLabel` Performance Improvements

### DIFF
--- a/BlueprintUICommonControls/Sources/Label.swift
+++ b/BlueprintUICommonControls/Sources/Label.swift
@@ -113,6 +113,12 @@ public struct Label: ProxyElement {
                 // do nothing, use default behavior
                 break
             }
+
+            label.needsTextNormalization = NSAttributedString.needsNormalizingForView(
+                hasLinks: false,
+                lineLimit: numberOfLines,
+                lineBreaks: lineBreakMode
+            )
         }
     }
 }

--- a/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
@@ -496,7 +496,12 @@ struct TextContainerBox: Element {
 
         func update(model: AttributedLabel, environment: Environment) {
             self.model = model
-            labelView.update(model: model, environment: environment, isMeasuring: false)
+            labelView.update(
+                model: model,
+                text: model.displayableAttributedText,
+                environment: environment,
+                isMeasuring: false
+            )
         }
     }
 }

--- a/BlueprintUICommonControls/Tests/Sources/PerformancePlayground.swift
+++ b/BlueprintUICommonControls/Tests/Sources/PerformancePlayground.swift
@@ -24,19 +24,28 @@ class PerformancePlayground: XCTestCase {
 
     override func invokeTest() {
         // Uncomment this line to run performance metrics, eg in Instruments.app.
-        // super.invokeTest()
+        super.invokeTest()
     }
 
     func test_repeated_layouts() {
-        let element = Column { col in
-            for index in 1...1000 {
-                col.add(child: Label(text: "This is test label number #\(index)"))
+        let element = Column(alignment: .fill) {
+
+            for index in 1...500 {
+                Row(alignment: .fill) {
+                    Box(backgroundColor: .red)
+                        .constrainedTo(size: CGSize(width: 100, height: 100))
+                        .stackLayoutChild(priority: .fixed)
+
+                    Label(text: "This is test label number #\(index)")
+                        .stackLayoutChild(priority: .flexible)
+                }
             }
         }
+        .scrollable()
 
         let view = BlueprintView(frame: CGRect(x: 0.0, y: 0.0, width: 200.0, height: 500.0))
 
-        determineAverage(for: 10.0) {
+        determineAverage(for: 3.0) {
             view.element = element
             view.layoutIfNeeded()
         }
@@ -119,15 +128,17 @@ class PerformancePlayground: XCTestCase {
 
         var iterations: Int = 0
 
+        var lastUpdateDate = Date()
+
         repeat {
-            let iterationStart = Date()
             block()
-            let iterationEnd = Date()
-            let duration = iterationEnd.timeIntervalSince(iterationStart)
 
             iterations += 1
 
-            print("Iteration: \(iterations), Duration : \(duration)")
+            if Date().timeIntervalSince(lastUpdateDate) >= 1 {
+                lastUpdateDate = Date()
+                print("Continuing Test: \(iterations) Iterations...")
+            }
 
         } while Date() < start + seconds
 
@@ -153,3 +164,4 @@ private struct NonCachingLabel: UIViewElement {
         view.text = text
     }
 }
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Past Releases
 
+## [0.45.1]
+
+### Fixed
+
+- Improve `AttributedLabel` rendering performance.
+
 ## [0.45.0]
 
 ### Fixed
@@ -885,7 +891,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/0.45.0...HEAD
+[main]: https://github.com/square/Blueprint/compare/0.45.1...HEAD
+[0.45.1]: https://github.com/square/Blueprint/compare/0.45.0...0.45.1
 [0.45.0]: https://github.com/square/Blueprint/compare/0.44.1...0.45.0
 [0.44.1]: https://github.com/square/Blueprint/compare/0.44.0...0.44.1
 [0.44.0]: https://github.com/square/Blueprint/compare/0.43.0...0.44.0

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (0.45.0)
-  - BlueprintUI/Tests (0.45.0)
-  - BlueprintUICommonControls (0.45.0):
-    - BlueprintUI (= 0.45.0)
+  - BlueprintUI (0.45.1)
+  - BlueprintUI/Tests (0.45.1)
+  - BlueprintUICommonControls (0.45.1):
+    - BlueprintUI (= 0.45.1)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 93a2cb4c435df2eee064634cd6cfc25d135fa094
-  BlueprintUICommonControls: ec80ccd2ea2d8b7f4e554c6c0a7ab68812da9010
+  BlueprintUI: 985b44504eb2bffda18b17b62a0f4101b10646b9
+  BlueprintUICommonControls: b151b07f774df08c1ae7c38947888d5d6aa612fa
 
 PODFILE CHECKSUM: 63720a1a50b146640cc4fcc4f36d3770895c7e0d
 

--- a/version.rb
+++ b/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '0.45.0'
+BLUEPRINT_VERSION ||= '0.45.1'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))


### PR DESCRIPTION
1) Allow opting out of string normalization via SPI for labels that can cheaply determine they do not need it. 
2) Do not allocate strings as frequently by pulling them out of the measurement block, and into `content`.
3) A couple other small optimizations when applying the attributed label's backing string.

This provides significant performance benefit for `test_repeated_layouts`:
```
Before: Iterations: 13, Average Time: 0.2476892379614023
After: Iterations: 20, Average Time: 0.1516169488430023 (Normalization On)
After: Iterations: 26, Average Time: 0.11809442135003898 (Normalization Off)
```