### PR TITLE
[SPL] Debug and test helpers

### DIFF
--- a/BlueprintUI/Sources/Internal/ElementIdentifier.swift
+++ b/BlueprintUI/Sources/Internal/ElementIdentifier.swift
@@ -41,24 +41,24 @@
 
  You will note that the identifiers remain stable, which ultimately ensures that views are reused.
  */
-struct ElementIdentifier: Hashable, CustomDebugStringConvertible {
+struct ElementIdentifier: Hashable, CustomStringConvertible {
 
-    let elementType: ObjectIdentifier
+    let elementType: Metatype
     let key: AnyHashable?
 
     let count: Int
 
     init(elementType: Element.Type, key: AnyHashable?, count: Int) {
 
-        self.elementType = ObjectIdentifier(elementType)
+        self.elementType = Metatype(elementType)
         self.key = key
 
         self.count = count
     }
 
-    var debugDescription: String {
+    var description: String {
         if let key = self.key {
-            return "\(elementType).\(String(describing: key)).\(count)"
+            return "\(elementType).\(key).\(count)"
         } else {
             return "\(elementType).\(count)"
         }

--- a/BlueprintUI/Sources/Internal/ElementPath.swift
+++ b/BlueprintUI/Sources/Internal/ElementPath.swift
@@ -1,6 +1,6 @@
 /// Represents a path into an element hierarchy.
 /// Used for disambiguation during diff operations.
-struct ElementPath: Hashable, CustomDebugStringConvertible {
+struct ElementPath: Hashable, CustomStringConvertible {
 
     private var identifiersHash: Int? = nil
 
@@ -43,12 +43,15 @@ struct ElementPath: Hashable, CustomDebugStringConvertible {
     func hash(into hasher: inout Hasher) {
         hasher.combine(identifiersHash)
     }
+    
+    /// True if this path's description matches the given regex
+    func matches(expression: String) -> Bool {
+        "\(self)".range(of: expression, options: .regularExpression) != nil
+    }
 
-    // MARK: CustomDebugStringConvertible
+    // MARK: CustomStringConvertible
 
-    var debugDescription: String {
-        identifiers.map { $0.debugDescription }.joined()
+    var description: String {
+        identifiers.map(\.description).joined(separator: "/")
     }
 }
-
-

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -130,4 +130,24 @@ extension LayoutResultNode {
 
     }
 
+    /// Recursively dump layout tree, for debugging. By default, prints to stdout.
+    @_spi(Debugging)
+    public func dump(
+        depth: Int = 0,
+        visit: ((_ depth: Int, _ identifier: String, _ frame: CGRect) -> Void) = { depth, identifier, frame in
+            let origin = "x \(frame.origin.x), y \(frame.origin.y)"
+            let size = "\(frame.size.width) × \(frame.size.height)"
+            let indent = String(repeating: "  ", count: depth)
+            print("\(indent)\(identifier) \(origin), \(size)")
+        }
+    ) {
+        for child in children {
+            let attributes = child.node.layoutAttributes
+
+            visit(depth, "\(child.identifier)", attributes.frame)
+
+            child.node.dump(depth: depth + 1, visit: visit)
+        }
+    }
+
 }

--- a/BlueprintUI/Sources/Internal/Metatype.swift
+++ b/BlueprintUI/Sources/Internal/Metatype.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// A wrapper to make metatypes easier to work with, providing Equatable, Hashable, and
+/// CustomStringConvertible.
+struct Metatype: Hashable, CustomStringConvertible {
+    var type: Any.Type
+
+    init(_ type: Any.Type) {
+        self.type = type
+    }
+
+    var description: String {
+        "\(type)"
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(type))
+    }
+
+    static func == (lhs: Metatype, rhs: Metatype) -> Bool {
+        lhs.type == rhs.type
+    }
+}


### PR DESCRIPTION
I pulled these out of some other work, because I think they'll be handy.

First a `Metatype` wrapper that makes element IDs and paths readable. Given a path like this:
```swift
let path = ElementPath()
    .appending(identifier: .init(elementType: Row.self, key: nil, count: 0))
    .appending(identifier: .init(elementType: Column.self, key: nil, count: 1))
    .appending(identifier: .init(elementType: Empty.self, key: "k", count: 0))
```
Before:
`ObjectIdentifier(0x0000000103407fc0).0ObjectIdentifier(0x0000000103406210).1ObjectIdentifier(0x0000000103406c60).k.0`
After:
`Row.0/Column.1/Empty.k.0`

Second, a couple methods that we can hook into for external tests: `BlueprintView.forceSynchronousLayout` and `LayoutResultNode.dump`. Both of these are behind `@_spi(Debugging)`.