### PR TITLE
Fix greater than zero check

### DIFF
--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -499,7 +499,7 @@ extension StackLayout {
 
             let flexibleMagnitude: SizeConstraint.Axis = constraint.axis(on: axis) - fixedMagnitude - minimumTotalSpacing
 
-            if flexibleMagnitude > 0 {
+            if flexibleMagnitude.isGreaterThanZero {
                 let flexibleConstraint: SizeConstraint = {
                     switch axis {
                     case .horizontal:

--- a/BlueprintUI/Sources/Measuring/SizeConstraint.swift
+++ b/BlueprintUI/Sources/Measuring/SizeConstraint.swift
@@ -156,9 +156,9 @@ extension SizeConstraint {
             }
         }
 
-        /// Checks if the axis is greater than zero.
-        public static func > (lhs: SizeConstraint.Axis, rhs: CGFloat) -> Bool {
-            switch lhs {
+        /// If the `Axis` is greater than zero.
+        public var isGreaterThanZero: Bool {
+            switch self {
             case .atMost(let limit):
                 return limit > 0
             case .unconstrained:

--- a/BlueprintUI/Tests/SizeConstraintAxisTests.swift
+++ b/BlueprintUI/Tests/SizeConstraintAxisTests.swift
@@ -146,4 +146,12 @@ class SizeConstraintAxisTests: XCTestCase {
         }
 
     }
+
+    func test_isGreaterThanZero() {
+
+        XCTAssertFalse(SizeConstraint.Axis.atMost(-1).isGreaterThanZero)
+        XCTAssertFalse(SizeConstraint.Axis.atMost(0).isGreaterThanZero)
+        XCTAssertTrue(SizeConstraint.Axis.atMost(1).isGreaterThanZero)
+        XCTAssertTrue(SizeConstraint.Axis.unconstrained.isGreaterThanZero)
+    }
 }


### PR DESCRIPTION
I realized this was (a) implemented wrong, and (b) adding `>` for axis is sort of weird, because `.unconstrained > .unconstrained` is sort of meaningless. Going to just replace the the `>` with `isGreaterThanZero`.