### PR TITLE
[Caching] Adds changes to Environment and EnvironmentKey needed for cross-render caching

### DIFF
--- a/BlueprintUI/Sources/Environment/EnvironmentKey.swift
+++ b/BlueprintUI/Sources/Environment/EnvironmentKey.swift
@@ -26,4 +26,28 @@ public protocol EnvironmentKey {
     /// The default value that will be vended by an `Environment` for this key if no other value
     /// has been set.
     static var defaultValue: Self.Value { get }
+
+    /// Equivalency check on the `Value`s of `EnvironmentKey`s. This should return false if the
+    /// difference in values affects the measurement or layout of consuming elements.
+    static func isEquivalent(_ lhs: Value, _ rhs: Value) -> Bool
+}
+
+extension EnvironmentKey where Value: Equatable {
+
+    public static func isEquivalent(_ lhs: Value, _ rhs: Value) -> Bool {
+        lhs == rhs
+    }
+}
+
+extension EnvironmentKey {
+    static func areValuesEqual(_ lhs: Any?, _ rhs: Any?) -> Bool {
+        if lhs == nil && rhs == nil { return true }
+
+        guard let lhs = lhs as? Value,
+              let rhs = rhs as? Value
+        else {
+            return false
+        }
+        return Self.isEquivalent(lhs, rhs)
+    }
 }

--- a/BlueprintUI/Tests/EnvironmentKeyTests.swift
+++ b/BlueprintUI/Tests/EnvironmentKeyTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import BlueprintUI
+
+final class EnvironmentKeyTests: XCTestCase {
+    func test_isEquivalent() {
+        XCTAssertTrue(EquatableKey.isEquivalent(1, 1))
+        XCTAssertFalse(EquatableKey.isEquivalent(1, 2))
+    }
+
+    func test_areValuesEqual() {
+        XCTAssertTrue(EquatableKey.areValuesEqual(1, 1))
+        XCTAssertFalse(EquatableKey.areValuesEqual(1, 2))
+    }
+}
+
+fileprivate struct EquatableKey: EnvironmentKey, Equatable {
+    typealias Value = Int
+    static let defaultValue: Int = 1
+}

--- a/BlueprintUI/Tests/EnvironmentTests.swift
+++ b/BlueprintUI/Tests/EnvironmentTests.swift
@@ -179,6 +179,188 @@ class EnvironmentTests: XCTestCase {
         enum RHSTestKey: EnvironmentKey { static let defaultValue: Int? = nil }
     }
 
+    func test_onDidRead() throws {
+
+        // Happy path
+        do {
+            var environment = Environment.empty
+
+            var readKey: Environment.StorageKey? = nil
+            let exp = expectation(description: "onDidRead")
+
+            environment.subscribeToReads(for: .layout) { key in
+                readKey = key
+                exp.fulfill()
+            }
+
+            environment[TestKey.self] = .right
+            _ = environment[TestKey.self]
+
+            wait(for: [exp], timeout: 0.1)
+            XCTAssertNotNil(readKey)
+            let key = try XCTUnwrap(readKey)
+            XCTAssertEqual(Environment.StorageKey(TestKey.self), key)
+        }
+
+        // .measure `LayoutPass` only allows one `onDidRead`
+        do {
+            var environment = Environment.empty
+
+            var firstCallCount = 0
+            var secondCallCount = 0
+
+            environment.subscribeToReads(for: .measurement) { key in
+                firstCallCount += 1
+            }
+
+            environment.subscribeToReads(for: .measurement) { key in
+                secondCallCount += 1
+            }
+
+            environment[TestKey.self] = .right
+            _ = environment[TestKey.self]
+
+            XCTAssertEqual(firstCallCount, 0)
+            XCTAssertEqual(secondCallCount, 1)
+        }
+
+        // .layout `LayoutPass` allows multiple `onDidRead`s
+        do {
+            var environment = Environment.empty
+
+            var firstCallCount = 0
+            var secondCallCount = 0
+
+            environment.subscribeToReads(for: .layout) { key in
+                firstCallCount += 1
+            }
+
+            environment.subscribeToReads(for: .layout) { key in
+                secondCallCount += 1
+            }
+
+            environment[TestKey.self] = .right
+            _ = environment[TestKey.self]
+
+            XCTAssertEqual(firstCallCount, 1)
+            XCTAssertEqual(secondCallCount, 1)
+        }
+
+        // .measure subscription should not override .layout subscription
+        do {
+            var environment = Environment.empty
+
+            var firstCallCount = 0
+            var secondCallCount = 0
+
+            environment.subscribeToReads(for: .layout) { key in
+                firstCallCount += 1
+            }
+
+            environment.subscribeToReads(for: .measurement) { key in
+                secondCallCount += 1
+            }
+
+            environment[TestKey.self] = .right
+            _ = environment[TestKey.self]
+
+            XCTAssertEqual(firstCallCount, 1)
+            XCTAssertEqual(secondCallCount, 1)
+        }
+    }
+
+    func test_equality() {
+
+        // Not equal
+        do {
+            var lhs = Environment.empty
+            lhs[TestKey.self] = .wrong
+            lhs[LHSTestKey.self] = 2
+
+
+            var rhs = Environment.empty
+            rhs[TestKey.self] = .right
+            rhs[RHSTestKey.self] = 3
+
+            XCTAssertNotEqual(lhs, rhs)
+
+        }
+
+        // Not equal
+        do {
+            var lhs = Environment.empty
+            lhs[TestKey.self] = .wrong
+            lhs[LHSTestKey.self] = 2
+
+
+            var rhs = Environment.empty
+            rhs[TestKey.self] = .wrong
+            rhs[RHSTestKey.self] = 2
+
+            XCTAssertNotEqual(lhs, rhs)
+        }
+
+        // Equal
+        do {
+            var lhs = Environment.empty
+            lhs[TestKey.self] = .wrong
+            lhs[LHSTestKey.self] = 2
+
+
+            var rhs = Environment.empty
+            rhs[TestKey.self] = .wrong
+            rhs[LHSTestKey.self] = 2
+
+            XCTAssertEqual(lhs, rhs)
+        }
+
+        enum LHSTestKey: EnvironmentKey { static let defaultValue: Int? = nil }
+        enum RHSTestKey: EnvironmentKey { static let defaultValue: Int? = nil }
+    }
+
+    func test_subset() {
+
+        var environment = Environment.empty
+
+        environment[Key1.self] = 1
+        environment[Key2.self] = 2
+        environment[Key3.self] = 3
+
+        let subset = environment.subset(with: Set([Key1.storageKey, Key2.storageKey, Key4.storageKey]))
+        XCTAssertEqual(subset?.values.count, 2)
+        let keys = Set(subset!.values.keys)
+        XCTAssertTrue(keys.contains(Key1.storageKey))
+        XCTAssertTrue(keys.contains(Key2.storageKey))
+        enum Key1: EnvironmentKey { static let defaultValue: Int? = nil }
+        enum Key2: EnvironmentKey { static let defaultValue: Int? = nil }
+        enum Key3: EnvironmentKey { static let defaultValue: Int? = nil }
+        enum Key4: EnvironmentKey { static let defaultValue: Int? = nil }
+    }
+
+    func test_valuesEqual() {
+
+        var environment = Environment.empty
+
+        environment[Key1.self] = 1
+        environment[Key2.self] = 2
+        environment[Key3.self] = 3
+
+        let subset1 = environment.subset(with: Set([Key1.storageKey, Key2.storageKey]))
+        let subset2 = environment.subset(with: Set([Key1.storageKey, Key2.storageKey, Key3.storageKey]))
+
+        var matchEnvironment = Environment.empty
+        matchEnvironment[Key1.self] = 1
+        matchEnvironment[Key2.self] = 2
+
+        XCTAssertTrue(matchEnvironment.valuesEqual(to: subset1))
+        XCTAssertFalse(matchEnvironment.valuesEqual(to: subset2))
+
+
+        enum Key1: EnvironmentKey { static let defaultValue: Int? = nil }
+        enum Key2: EnvironmentKey { static let defaultValue: Int? = nil }
+        enum Key3: EnvironmentKey { static let defaultValue: Int? = nil }
+    }
+
     func leafAttributes(in node: LayoutResultNode) -> LayoutAttributes {
         if let childNode = node.children.first?.node {
             return leafAttributes(in: childNode)
@@ -321,5 +503,12 @@ extension Environment {
     fileprivate var testValue: TestValue {
         get { self[TestKey.self] }
         set { self[TestKey.self] = newValue }
+    }
+}
+
+
+extension EnvironmentKey {
+    fileprivate static var storageKey: Environment.StorageKey {
+        .init(Self.self)
     }
 }

--- a/BlueprintUICommonControls/Sources/AttributedLabel+Environment.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel+Environment.swift
@@ -15,16 +15,25 @@ import UIKit
 ///
 public protocol URLHandler {
     func onTap(url: URL)
+    func isEquivalent(to other: URLHandler) -> Bool
 }
 
 struct DefaultURLHandler: URLHandler {
     func onTap(url: URL) {
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
+
+    func isEquivalent(to other: URLHandler) -> Bool {
+        true
+    }
 }
 
 public struct URLHandlerEnvironmentKey: EnvironmentKey {
     public static let defaultValue: URLHandler = DefaultURLHandler()
+
+    public static func isEquivalent(_ lhs: URLHandler, _ rhs: URLHandler) -> Bool {
+        lhs.isEquivalent(to: rhs)
+    }
 }
 
 extension Environment {
@@ -40,5 +49,9 @@ struct ClosureURLHandler: URLHandler {
 
     func onTap(url: URL) {
         onTap(url)
+    }
+
+    func isEquivalent(to other: URLHandler) -> Bool {
+        true
     }
 }

--- a/BlueprintUICommonControls/Sources/AttributedLabel+Environment.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel+Environment.swift
@@ -15,16 +15,11 @@ import UIKit
 ///
 public protocol URLHandler {
     func onTap(url: URL)
-    func isEquivalent(to other: URLHandler) -> Bool
 }
 
 struct DefaultURLHandler: URLHandler {
     func onTap(url: URL) {
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
-    }
-
-    func isEquivalent(to other: URLHandler) -> Bool {
-        true
     }
 }
 
@@ -32,7 +27,7 @@ public struct URLHandlerEnvironmentKey: EnvironmentKey {
     public static let defaultValue: URLHandler = DefaultURLHandler()
 
     public static func isEquivalent(_ lhs: URLHandler, _ rhs: URLHandler) -> Bool {
-        lhs.isEquivalent(to: rhs)
+        true
     }
 }
 
@@ -49,9 +44,5 @@ struct ClosureURLHandler: URLHandler {
 
     func onTap(url: URL) {
         onTap(url)
-    }
-
-    func isEquivalent(to other: URLHandler) -> Bool {
-        true
     }
 }


### PR DESCRIPTION
This PR adds updates to `Environment` and `EnvironmentKey` that needed for [cross-render caching](https://docs.google.com/document/d/1ozD6XaZYZ2a8xRudJrZ-4m3tcH6d8N4bBdtFTjks4QM/edit#heading=h.qmr9cyd5p0i7). 

Summary of changes:
* Makes `Environment` equatable and adds equivalency to `EnvironmentKey`
* Adds default equivalency implementations to `Environment` and `EnvironmentKeys`
* Adds ability to get a `Subset` of keys from `Environment` and  compare an `Environment` with a `Subset` 
* We can now subscribe to `Environment` reads through `subscribeToReads()`