### PR TITLE
[Caching] Add ElementState and ComparableElement types

### DIFF
--- a/BlueprintUI/Sources/Element/ComparableElement.swift
+++ b/BlueprintUI/Sources/Element/ComparableElement.swift
@@ -1,0 +1,86 @@
+//
+//  ComparableElement.swift
+//  BlueprintUI
+//
+//  Created by Kyle Van Essen on 7/3/21.
+//
+
+import Foundation
+import UIKit
+
+
+/// An `ComparableElement` is an element which can cache its
+/// measurements and layouts across layout passes in order to dramatically improve
+/// performance of repeated layouts.
+///
+/// Some element types within Blueprint already conform to `ComparableElement`.
+/// If your element can be easily compared for equality, consider making your
+/// it conform to `ComparableElement` for improved performance across layouts.
+public protocol ComparableElement: AnyComparableElement {
+
+    ///
+    /// Indicates if the element is equivalent to the other provided element.
+    /// Return true if the elements are the same, or return false if something about
+    /// the element changed, such as attributes that affect measurement or layout.
+    ///
+    /// Note that even if this method returns true, the `ViewDescription`
+    /// backing the element will still be re-applied to the on-screen view.
+    ///
+    /// A `ComparableElementContext` parameter is provided, in case
+    /// you need access to the `Environment`, etc, to perform your comparison.
+    /// This is useful, for example, if your `Element` contains builders that are used to
+    /// build the final element structure.
+    ///
+    /// If your element conforms to `Equatable`, this method is synthesized automatically.
+    ///
+    func isEquivalent(to other: Self, in context: ComparableElementContext) -> Bool
+}
+
+
+/// A context object pased to `isEquivalent(to:in:)` that contains
+/// contextual information in which the `Element` is being compared. This
+/// is useful, for example, if you need information from the `Environment`
+/// to perform the comparison.
+public struct ComparableElementContext {
+
+    /// The `Environment` in which the comparison is being performed.
+    public var environment: Environment
+
+    /// Creates a new context object.
+    public init(
+        environment: Environment
+    ) {
+        self.environment = environment
+    }
+}
+
+
+/// Provides a default `ComparableElement` implementation for `Equatable` elements.
+extension ComparableElement where Self: Equatable {
+
+    public func isEquivalent(to other: Self, in context: ComparableElementContext) -> Bool {
+        self == other
+    }
+}
+
+
+/// A type-erased version of `ComparableElement`, allowing the comparison
+/// of two arbitrary elements, and allowing direct access to methods, without self or associated type constraints.
+///
+/// ## Note
+/// You do not need to implement this protocol yourself. It is implemented by Blueprint on `ComparableElement`.
+public protocol AnyComparableElement: Element {
+
+    /// Returns true if the two elements are the same type, and are equivalent.
+    func anyIsEquivalent(to other: AnyComparableElement, in context: ComparableElementContext) -> Bool
+}
+
+
+extension ComparableElement {
+
+    public func anyIsEquivalent(to other: AnyComparableElement, in context: ComparableElementContext) -> Bool {
+        guard let other = other as? Self else { return false }
+
+        return isEquivalent(to: other, in: context)
+    }
+}

--- a/BlueprintUI/Sources/Element/ComparableElement.swift
+++ b/BlueprintUI/Sources/Element/ComparableElement.swift
@@ -20,45 +20,24 @@ public protocol ComparableElement: AnyComparableElement {
 
     ///
     /// Indicates if the element is equivalent to the other provided element.
-    /// Return true if the elements are the same, or return false if something about
-    /// the element changed, such as attributes that affect measurement or layout.
+    /// Return `true` if the elements are the same, or return `false` if something about
+    /// the element changed that will affect measurement or layout.
     ///
-    /// Note that even if this method returns true, the `ViewDescription`
+    /// ## Note
+    /// Even if this method returns true, the `ViewDescription`
     /// backing the element will still be re-applied to the on-screen view.
     ///
-    /// A `ComparableElementContext` parameter is provided, in case
-    /// you need access to the `Environment`, etc, to perform your comparison.
-    /// This is useful, for example, if your `Element` contains builders that are used to
-    /// build the final element structure.
-    ///
+    /// ## Equatable
     /// If your element conforms to `Equatable`, this method is synthesized automatically.
     ///
-    func isEquivalent(to other: Self, in context: ComparableElementContext) -> Bool
-}
-
-
-/// A context object pased to `isEquivalent(to:in:)` that contains
-/// contextual information in which the `Element` is being compared. This
-/// is useful, for example, if you need information from the `Environment`
-/// to perform the comparison.
-public struct ComparableElementContext {
-
-    /// The `Environment` in which the comparison is being performed.
-    public var environment: Environment
-
-    /// Creates a new context object.
-    public init(
-        environment: Environment
-    ) {
-        self.environment = environment
-    }
+    func isEquivalent(to other: Self) -> Bool
 }
 
 
 /// Provides a default `ComparableElement` implementation for `Equatable` elements.
 extension ComparableElement where Self: Equatable {
 
-    public func isEquivalent(to other: Self, in context: ComparableElementContext) -> Bool {
+    public func isEquivalent(to other: Self) -> Bool {
         self == other
     }
 }
@@ -72,15 +51,15 @@ extension ComparableElement where Self: Equatable {
 public protocol AnyComparableElement: Element {
 
     /// Returns true if the two elements are the same type, and are equivalent.
-    func anyIsEquivalent(to other: AnyComparableElement, in context: ComparableElementContext) -> Bool
+    func anyIsEquivalent(to other: AnyComparableElement) -> Bool
 }
 
 
 extension ComparableElement {
 
-    public func anyIsEquivalent(to other: AnyComparableElement, in context: ComparableElementContext) -> Bool {
+    public func anyIsEquivalent(to other: AnyComparableElement) -> Bool {
         guard let other = other as? Self else { return false }
 
-        return isEquivalent(to: other, in: context)
+        return isEquivalent(to: other)
     }
 }

--- a/BlueprintUI/Sources/Element/ElementState.swift
+++ b/BlueprintUI/Sources/Element/ElementState.swift
@@ -22,17 +22,8 @@ final class ElementStateTree {
     /// A human readable name that represents the tree. Useful for debugging.
     let name: String
 
-    /// The kind of the tree.
-    var kind: Kind
-
-    init(name: String, kind: Kind) {
+    init(name: String) {
         self.name = name
-        self.kind = kind
-    }
-
-    enum Kind {
-        case blueprintView(String)
-        case measurement
     }
 
     /// Updates, replaces, or removes the root node depending on the type of the new element.
@@ -52,17 +43,15 @@ final class ElementStateTree {
         if root == nil, let element = element {
             /// Transition from no root element, to root element.
             makeRoot(with: element)
-        } else if let root = self.root, element == nil {
+        } else if root != nil, element == nil {
             /// Transition from a root element, to no root element.
-            root.teardown()
-            self.root = nil
+            root = nil
         } else if let root = self.root, let element = element {
             if type(of: root.element.value) == type(of: element) {
                 /// The type of the new element is the same, update inline.
                 root.update(with: element, in: environment, identifier: root.identifier)
             } else {
                 /// The type of the root element changed, replace it.
-                root.teardown()
                 makeRoot(with: element)
             }
         }
@@ -107,6 +96,8 @@ final class ElementState {
     let name: String
 
     /// The element represented by this object.
+    /// This value is a reference type – the inner element value
+    /// will change after updates.
     let element: ElementSnapshot
 
     /// How and if the element should be compared during updates.
@@ -286,14 +277,6 @@ final class ElementState {
 
         /// If the update was equivalent. Used for debugging.
         wasUpdateEquivalent = isEquivalent
-    }
-
-    func setup() {
-        // TODO:
-    }
-
-    func teardown() {
-        // TODO:
     }
 
     /// Represents a cached measurement, which contains
@@ -490,8 +473,6 @@ final class ElementState {
         for (key, state) in children {
 
             if state.wasVisited { continue }
-
-            state.teardown()
 
             children.removeValue(forKey: key)
         }

--- a/BlueprintUI/Sources/Element/ElementState.swift
+++ b/BlueprintUI/Sources/Element/ElementState.swift
@@ -91,10 +91,6 @@ final class ElementState {
     /// at the end of the layout cycle.
     private(set) var wasVisited: Bool
 
-    /// If the update during this layout cycle was equivalent.
-    /// Useful for debugging.
-    private(set) var wasUpdateEquivalent: Bool
-
     /// The cached measurements for the current node.
     /// Measurements are cached by a `SizeConstraint` key, meaning that
     /// there can be multiple cached measurements for the same element.
@@ -196,7 +192,6 @@ final class ElementState {
         self.name = name
 
         wasVisited = true
-        wasUpdateEquivalent = false
     }
 
     /// Assigned once per layout cycle, this value represents the
@@ -284,9 +279,6 @@ final class ElementState {
         /// have access to the latest `backingViewDescription`.
 
         element.latest = newElement
-
-        /// If the update was equivalent. Used for debugging.
-        wasUpdateEquivalent = isEquivalent
     }
 
     /// Represents a cached measurement, which contains
@@ -382,6 +374,9 @@ final class ElementState {
         during toTrack: (Environment) -> Output
     ) -> (Output, Environment.Subset?) {
 
+        /// We only need to append a read observer if we are a `comparableElement`.
+        /// If we're a `.childOfComparableElement`, the read subscription
+        /// from the upstream comparable element will still be applied.
         guard comparability == .comparableElement else {
             return (toTrack(environment), nil)
         }
@@ -437,7 +432,6 @@ final class ElementState {
     func prepareForLayout() {
         recursiveForEach {
             $0.wasVisited = false
-            $0.wasUpdateEquivalent = false
         }
     }
 

--- a/BlueprintUI/Sources/Element/ElementState.swift
+++ b/BlueprintUI/Sources/Element/ElementState.swift
@@ -509,6 +509,9 @@ final class ElementState {
                 $0.clearAllCachedData()
             }
 
+            /// **TODO:** Should we cache this across layout cycles too? I think no,
+            /// because we're already caching layout nodes, so this shouldn't even be called.
+            /// But we should verify that!
             $0.cachedContent = nil
         }
     }

--- a/BlueprintUI/Sources/Element/ElementState.swift
+++ b/BlueprintUI/Sources/Element/ElementState.swift
@@ -1,0 +1,601 @@
+//
+//  ElementState.swift
+//  BlueprintUI
+//
+//  Created by Kyle Van Essen on 6/24/21.
+//
+
+import Foundation
+import UIKit
+
+
+/// The root node in an `ElementState` tree, which is used by `BlueprintView`
+/// to maintain state across multiple layout passes.
+final class ElementStateTree {
+
+    /// The root element in the tree. Nil if there is no element.
+    private(set) var root: ElementState?
+
+    /// A signpost token used for logging signposts to `os_log`.
+    private let signpostRef: SignpostToken = .init()
+
+    /// A human readable name that represents the tree. Useful for debugging.
+    let name: String
+
+    /// The kind of the tree.
+    var kind: Kind
+
+    init(name: String, kind: Kind) {
+        self.name = name
+        self.kind = kind
+    }
+
+    enum Kind {
+        case blueprintView(String)
+        case measurement
+    }
+
+    /// Updates, replaces, or removes the root node depending on the type of the new element.
+    func update(with element: Element?, in environment: Environment) {
+
+        func makeRoot(with element: Element) {
+            root = ElementState(
+                parent: nil,
+                identifier: .init(elementType: type(of: element), key: nil, count: 1),
+                element: element,
+                depth: 0,
+                signpostRef: signpostRef,
+                name: name
+            )
+        }
+
+        if root == nil, let element = element {
+            /// Transition from no root element, to root element.
+            makeRoot(with: element)
+        } else if let root = self.root, element == nil {
+            /// Transition from a root element, to no root element.
+            root.teardown()
+            self.root = nil
+        } else if let root = self.root, let element = element {
+            if type(of: root.element.value) == type(of: element) {
+                /// The type of the new element is the same, update inline.
+                root.update(with: element, in: environment, identifier: root.identifier)
+            } else {
+                /// The type of the root element changed, replace it.
+                root.teardown()
+                makeRoot(with: element)
+            }
+        }
+    }
+}
+
+
+/// A reference type passed through to `LayoutResultNode` and `NativeViewNode`,
+/// so that even when returning cached layouts, we can get to the latest version of the element
+/// that their originating `ElementState` represents.
+final class ElementSnapshot {
+
+    fileprivate(set) var value: Element
+
+    init(_ value: Element) {
+        self.value = value
+    }
+}
+
+
+/// Represents the live, on screen state for a given element in the element tree.
+///
+/// `ElementState` is updated with the newest state of its backing `Element`
+/// during the layout pass, and retains cached information such as measurements
+/// and layouts either to the end of the layout pass, or until the equivalency of the `Element`
+/// changes, for comparable elements.
+final class ElementState {
+
+    /// The parent element that owns this element.
+    private(set) weak var parent: ElementState?
+
+    /// The identifier of the element. Eg, `Inset.1` or `Inset.1.Key`.
+    let identifier: ElementIdentifier
+
+    /// The depth of the element within the element tree.
+    let depth: Int
+
+    /// The signpost ref used when logging to `os_log`.
+    let signpostRef: AnyObject
+
+    /// The name of the owning tree. Useful for debugging.
+    let name: String
+
+    /// The element represented by this object.
+    let element: ElementSnapshot
+
+    /// How and if the element should be compared during updates.
+    let comparability: Comparability
+
+    /// If the node has been visited this layout cycle.
+    /// If `false`, the node will be torn down and garbage collected
+    /// at the end of the layout cycle.
+    private(set) var wasVisited: Bool
+
+    /// If the update during this layout cycle was equivalent.
+    /// Useful for debugging.
+    private(set) var wasUpdateEquivalent: Bool
+
+    /// The cached measurements for the current node.
+    /// Measurements are cached by a `SizeConstraint` key, meaning that
+    /// there can be multiple cached measurements for the same element.
+    private var measurements: [SizeConstraint: CachedMeasurement] = [:]
+
+    /// The cached layouts for the current node.
+    /// Layouts are cached by a `CGSize` key, meaning that
+    /// we can preserve multiple layouts if the containing element or containing
+    /// view's size changes, eg when rotating from portait to landscape.
+    private var layouts: [CGSize: CachedLayout] = [:]
+
+    /// The children of the `ElementState`, cached by element identifier.
+    private var children: [ElementIdentifier: ElementState] = [:]
+
+    /// Indicates the comparability behavior of the element.
+    enum Comparability: Equatable {
+        /// The element is not comparable, and it is not the child of a comparable element.
+        case notComparable
+
+        /// The element is comparable itself; it conforms to `ComparableElement`.
+        case comparableElement
+
+        /// The element is the child of a `ComparableElement`, meaning its comparability
+        /// is determined by the comparability of that parent element.
+        case childOfComparableElement
+
+        /// If the element is either directly comparable, or the child of a `ComparableElement`.
+        var isComparable: Bool {
+            switch self {
+            case .notComparable: return false
+            case .comparableElement: return true
+            case .childOfComparableElement: return true
+            }
+        }
+    }
+
+    /// Creates a new `ElementState` instance.
+    init(
+        parent: ElementState?,
+        identifier: ElementIdentifier,
+        element: Element,
+        depth: Int,
+        signpostRef: AnyObject,
+        name: String
+    ) {
+        self.parent = parent
+        self.identifier = identifier
+        self.element = ElementSnapshot(element)
+
+        if element is AnyComparableElement {
+            comparability = .comparableElement
+        } else {
+            if let parent = parent {
+                switch parent.comparability {
+                case .notComparable:
+                    comparability = .notComparable
+                case .comparableElement, .childOfComparableElement:
+                    comparability = .childOfComparableElement
+                }
+            } else {
+                comparability = .notComparable
+            }
+        }
+
+        self.depth = depth
+        self.signpostRef = signpostRef
+        self.name = name
+
+        wasVisited = true
+        wasUpdateEquivalent = false
+    }
+
+    /// Assigned once per layout cycle, this value represents the
+    /// `Element.content` value from the represented element.
+    /// This value is cached to improve performance (fewer allocations and
+    /// less repeated content building), as well as improves debuggability.
+    private var cachedContent: ElementContent?
+
+    /// Allows the layout system in `ElementContent` to access the `ElementContent`
+    /// of the element, returning a cached version after the first access during a layout cycle.
+    var elementContent: ElementContent {
+        if let cachedContent = cachedContent {
+            return cachedContent
+        } else {
+            let content = element.value.content
+            cachedContent = content
+            return content
+        }
+    }
+
+    /// Updates the element state with the new element and new environment,
+    /// throwing away cached values if needed.
+    ///
+    /// This method takes into account the `Comparability` of the element.
+    ///
+    /// ## Note
+    /// This method may only be called once per layout cycle.
+    fileprivate func update(
+        with newElement: Element,
+        in newEnvironment: Environment,
+        identifier: ElementIdentifier
+    ) {
+        precondition(wasVisited == false)
+        precondition(self.identifier == identifier)
+        precondition(type(of: newElement) == type(of: element.value))
+
+        let isEquivalent: Bool
+
+        switch comparability {
+        case .notComparable:
+            isEquivalent = false
+
+        case .comparableElement:
+            isEquivalent = Self.elementsEquivalent(
+                element.value, newElement,
+                in: ComparableElementContext(
+                    environment: newEnvironment
+                )
+            )
+
+        case .childOfComparableElement:
+            /// We're always, equivalent, because our parent
+            /// determines our equatability from its state.
+            /// It will also invalidate and throw away _our_ caches if its
+            /// equivalency changes.
+            isEquivalent = true
+        }
+
+        /// If `isEquivalent` is false, we want to blow away all cached data.
+        if isEquivalent == false {
+            /// Clear our own cached data.
+            clearAllCachedData()
+
+            /// 2) If _we_ are a `ComparableElement`, or children which are `.childOfComparableElement`
+            /// depend on us to invalidate their measurements; so do so here. It's important to note
+            /// that we only clear child caches if those elements themselves are **not** `ComparableElement`.
+            if comparability == .comparableElement {
+                recursiveForEach {
+                    $0.clearAllCachedDataIfNotComparable()
+                }
+            }
+        } else {
+
+            /// If we are equivalent, we still need to throw out any measurements
+            /// and layouts that are dependent on the `Environment`. Compare
+            /// the stored `Environment.Subset` values to see if any
+            /// of the values that we care about are no longer equivalent.
+
+            measurements.removeAll { _, measurement in
+                newEnvironment.valuesEqual(to: measurement.dependencies) == false
+            }
+
+            layouts.removeAll { _, layout in
+                newEnvironment.valuesEqual(to: layout.dependencies) == false
+            }
+        }
+
+        /// Update our `ElementSnapshot` to the element's new value.
+        /// This will allow cached `LayoutResultNodes` to ensure they
+        /// have access to the latest `backingViewDescription`.
+
+        element.value = newElement
+
+        /// If the update was equivalent. Used for debugging.
+        wasUpdateEquivalent = isEquivalent
+    }
+
+    func setup() {
+        // TODO:
+    }
+
+    func teardown() {
+        // TODO:
+    }
+
+    /// Represents a cached measurement, which contains
+    /// both the output measurements and the dependencies
+    /// from the `Environment`, if any.
+    private struct CachedMeasurement {
+        var size: CGSize
+        var dependencies: Environment.Subset?
+    }
+
+    /// Invoked by `ElementContent` to generate a measurement via the `measurer`,
+    /// or return a cached measurement if one exists.
+    func measure(
+        in constraint: SizeConstraint,
+        with environment: Environment,
+        using measurer: (Environment) -> CGSize
+    ) -> CGSize {
+        /// We already have a cached measurement, reuse that.
+        if let existing = measurements[constraint] {
+            return existing.size
+        }
+
+        /// Perform the measurement and track the environment dependencies.
+        let (size, dependencies) = trackEnvironmentReads(for: .measurement, with: environment, in: measurer)
+
+        /// Save the measurement for next time.
+        measurements[constraint] = .init(
+            size: size,
+            dependencies: dependencies
+        )
+
+        return size
+    }
+
+    /// Represents a cached `LayoutResultNode` tree of all children,
+    /// which contains both child tree, and the dependencies
+    /// from the `Environment`, if any.
+    private struct CachedLayout {
+        var layout: [LayoutResultNode]
+        var dependencies: Environment.Subset?
+    }
+
+    /// Invoked by `ElementContent` to generate a layout tree via the `layout`,
+    /// or return a cached layout tree if one exists.
+    func layout(
+        in size: CGSize,
+        with environment: Environment,
+        using layout: (Environment) -> [LayoutResultNode]
+    ) -> [LayoutResultNode] {
+
+        /// Layout is only invoked once per cycle. If we're not a `ComparableElement`,
+        /// there's no point in caching this value, so just return the `layout` directly.
+        guard comparability == .comparableElement else {
+            return layout(environment)
+        }
+
+        /// We already have a cached layout, reuse that.
+        if let existing = layouts[size] {
+            return existing.layout
+        }
+
+        /// Perform the layout and track the environment dependencies.
+        let (layout, dependencies) = trackEnvironmentReads(for: .layout, with: environment, in: layout)
+
+        /// Save the layout for next time.
+        layouts[size] = .init(
+            layout: layout,
+            dependencies: dependencies
+        )
+
+        return layout
+    }
+
+    /// Used by measurement and layout to track the dependencies they have on the `Environment`.
+    /// The method returns the output from your `toTrack` callback, as well as
+    /// an `Environment.Subset` that represents the measurement or layout's dependencies on the `Environment`.
+    ///
+    /// If there are no dependencies (`toTrack` did not read from the `Environment`), no subset is returned.
+    /// Additionally, if the element is not comparable, no subset is returned.
+    private func trackEnvironmentReads<Output>(
+        for layoutPass: Environment.LayoutPass,
+        with environment: Environment,
+        in toTrack: (Environment) -> Output
+    ) -> (Output, Environment.Subset?) {
+
+        switch layoutPass {
+        case .measurement:
+            if comparability.isComparable {
+                break
+            } else {
+                return (toTrack(environment), nil)
+            }
+        case .layout:
+            if comparability == .comparableElement {
+                break
+            } else {
+                return (toTrack(environment), nil)
+            }
+        }
+
+        var environment = environment
+        var observedKeys = Set<Environment.StorageKey>()
+
+        environment.subscribeToReads(for: layoutPass) { key in
+            observedKeys.insert(key)
+        }
+
+        let output = toTrack(environment)
+
+        return (output, environment.subset(with: observedKeys))
+    }
+
+    func childState(
+        for child: Element,
+        in environment: Environment,
+        with identifier: ElementIdentifier
+    ) -> ElementState {
+
+        if let existing = children[identifier] {
+            existing.wasVisited = true
+
+            if existing.wasVisited == false {
+                existing.update(with: child, in: environment, identifier: identifier)
+                existing.wasVisited = true
+            }
+
+            return existing
+        } else {
+            let new = ElementState(
+                parent: self,
+                identifier: identifier,
+                element: child,
+                depth: depth + 1,
+                signpostRef: signpostRef,
+                name: name
+            )
+
+            children[identifier] = new
+
+            return new
+        }
+    }
+
+    func prepareForLayout() {
+        recursiveForEach {
+            $0.wasVisited = false
+            $0.wasUpdateEquivalent = false
+        }
+    }
+
+    func finishedLayout() {
+        recursiveRemoveOldChildren()
+        recursiveClearCaches()
+    }
+
+    private func clearAllCachedData() {
+        measurements.removeAll()
+        layouts.removeAll()
+    }
+
+    private func clearAllCachedDataIfNotComparable() {
+        if comparability != .comparableElement {
+            clearAllCachedData()
+        }
+    }
+
+    func recursiveForEach(_ perform: (ElementState) -> Void) {
+        perform(self)
+
+        children.forEach { _, child in
+            child.recursiveForEach(perform)
+        }
+    }
+
+    private func recursiveRemoveOldChildren() {
+
+        for (key, state) in children {
+
+            if state.wasVisited { continue }
+
+            state.teardown()
+
+            children.removeValue(forKey: key)
+        }
+
+        children.forEach { _, state in
+            state.recursiveRemoveOldChildren()
+        }
+    }
+
+    private func recursiveClearCaches() {
+        recursiveForEach {
+            if $0.comparability.isComparable == false {
+                $0.clearAllCachedData()
+            }
+
+            $0.cachedContent = nil
+        }
+    }
+}
+
+
+extension CGSize: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(width)
+        hasher.combine(height)
+    }
+}
+
+
+/// A token reference type that can be used to group associated signpost logs using `OSSignpostID`.
+private final class SignpostToken {}
+
+
+extension ElementState {
+
+    static func elementsEquivalent(_ lhs: Element?, _ rhs: Element?, in context: ComparableElementContext) -> Bool {
+
+        if lhs == nil && rhs == nil { return true }
+
+        guard let lhs = lhs as? AnyComparableElement else { return false }
+        guard let rhs = rhs as? AnyComparableElement else { return false }
+
+        if lhs.anyIsEquivalent(to: rhs, in: context) {
+            return true
+        } else {
+            return false
+        }
+    }
+}
+
+
+extension Dictionary {
+
+    fileprivate mutating func removeAll(where shouldRemove: (Key, Value) -> Bool) {
+
+        for (key, value) in self {
+            if shouldRemove(key, value) {
+                print("Removing \(key)")
+                removeValue(forKey: key)
+            }
+        }
+    }
+}
+
+
+//
+// MARK: CustomDebugStringConvertible
+//
+
+
+extension ElementState: CustomDebugStringConvertible {
+
+    public var debugDescription: String {
+
+        var debugRepresentations = [ElementState.DebugRepresentation]()
+
+        children.values.forEach {
+            $0.appendDebugDescriptions(to: &debugRepresentations, at: 0)
+        }
+
+        let strings: [String] = debugRepresentations.map { child in
+            Array(repeating: "  ", count: child.depth).joined() + child.debugDescription
+        }
+
+        let all = ["<ElementState: \(address(of: self))>"] + strings
+
+        return all.joined(separator: "\n")
+    }
+}
+
+
+extension ElementState {
+
+    private func appendDebugDescriptions(to: inout [DebugRepresentation], at depth: Int) {
+
+        let info = DebugRepresentation(
+            objectIdentifier: ObjectIdentifier(self),
+            depth: depth,
+            identifier: identifier,
+            element: element.value,
+            measurements: measurements
+        )
+
+        to.append(info)
+
+        children.values.forEach { child in
+            child.appendDebugDescriptions(to: &to, at: depth + 1)
+        }
+    }
+
+    private struct DebugRepresentation: CustomDebugStringConvertible {
+        var objectIdentifier: ObjectIdentifier
+        var depth: Int
+        var identifier: ElementIdentifier
+        var element: Element
+        var measurements: [SizeConstraint: CachedMeasurement]
+
+        var debugDescription: String {
+            "\(type(of: element)) #\(identifier.count): \(measurements.count) Measurements"
+        }
+    }
+}
+
+

--- a/BlueprintUI/Sources/Element/ElementState.swift
+++ b/BlueprintUI/Sources/Element/ElementState.swift
@@ -34,7 +34,6 @@ final class ElementStateTree {
                 parent: nil,
                 identifier: .init(elementType: type(of: element), key: nil, count: 1),
                 element: element,
-                depth: 0,
                 signpostRef: signpostRef,
                 name: name
             )
@@ -46,7 +45,7 @@ final class ElementStateTree {
         } else if root != nil, element == nil {
             /// Transition from a root element, to no root element.
             root = nil
-        } else if let root = self.root, let element = element {
+        } else if let root = root, let element = element {
             if type(of: root.element.value) == type(of: element) {
                 /// The type of the new element is the same, update inline.
                 root.update(with: element, in: environment, identifier: root.identifier)
@@ -85,9 +84,6 @@ final class ElementState {
 
     /// The identifier of the element. Eg, `Inset.1` or `Inset.1.Key`.
     let identifier: ElementIdentifier
-
-    /// The depth of the element within the element tree.
-    let depth: Int
 
     /// The signpost ref used when logging to `os_log`.
     let signpostRef: AnyObject
@@ -153,7 +149,6 @@ final class ElementState {
         parent: ElementState?,
         identifier: ElementIdentifier,
         element: Element,
-        depth: Int,
         signpostRef: AnyObject,
         name: String
     ) {
@@ -176,7 +171,6 @@ final class ElementState {
             }
         }
 
-        self.depth = depth
         self.signpostRef = signpostRef
         self.name = name
 
@@ -415,7 +409,6 @@ final class ElementState {
                 parent: self,
                 identifier: identifier,
                 element: child,
-                depth: depth + 1,
                 signpostRef: signpostRef,
                 name: name
             )

--- a/BlueprintUI/Sources/Element/ElementState.swift
+++ b/BlueprintUI/Sources/Element/ElementState.swift
@@ -578,7 +578,7 @@ extension ElementState: CustomDebugStringConvertible {
             Array(repeating: "  ", count: child.depth).joined() + child.debugDescription
         }
 
-        let all = ["<ElementState: \(address(of: self))>"] + strings
+        let all = ["<ElementState \(address(of: self)): \(identifier.debugDescription)>"] + strings
 
         return all.joined(separator: "\n")
     }

--- a/BlueprintUI/Sources/Element/ElementState.swift
+++ b/BlueprintUI/Sources/Element/ElementState.swift
@@ -402,12 +402,12 @@ final class ElementState {
     ) -> ElementState {
 
         if let existing = children[identifier] {
-            existing.wasVisited = true
 
             if existing.wasVisited == false {
                 existing.update(with: child, in: environment, identifier: identifier)
-                existing.wasVisited = true
             }
+
+            existing.wasVisited = true
 
             return existing
         } else {

--- a/BlueprintUI/Tests/ComparableElementTests.swift
+++ b/BlueprintUI/Tests/ComparableElementTests.swift
@@ -14,10 +14,8 @@ class ComparableElementTests: XCTestCase {
 
     func test_equatable_conformance() {
 
-        let context = ComparableElementContext(environment: .empty)
-
-        XCTAssertTrue(EquatableElement1(text: "1").isEquivalent(to: EquatableElement1(text: "1"), in: context))
-        XCTAssertFalse(EquatableElement1(text: "1").isEquivalent(to: EquatableElement1(text: "2"), in: context))
+        XCTAssertTrue(EquatableElement1(text: "1").isEquivalent(to: EquatableElement1(text: "1")))
+        XCTAssertFalse(EquatableElement1(text: "1").isEquivalent(to: EquatableElement1(text: "2")))
     }
 }
 
@@ -25,13 +23,11 @@ class ComparableElementTests: XCTestCase {
 class AnyComparableElementTests: XCTestCase {
 
     func test_anyIsEquivalent() {
-        let context = ComparableElementContext(environment: .empty)
+        XCTAssertTrue(EquatableElement1(text: "1").anyIsEquivalent(to: EquatableElement1(text: "1")))
+        XCTAssertFalse(EquatableElement1(text: "1").anyIsEquivalent(to: EquatableElement1(text: "2")))
 
-        XCTAssertTrue(EquatableElement1(text: "1").anyIsEquivalent(to: EquatableElement1(text: "1"), in: context))
-        XCTAssertFalse(EquatableElement1(text: "1").anyIsEquivalent(to: EquatableElement1(text: "2"), in: context))
-
-        XCTAssertFalse(EquatableElement1(text: "1").anyIsEquivalent(to: EquatableElement2(text: "1"), in: context))
-        XCTAssertFalse(EquatableElement1(text: "1").anyIsEquivalent(to: EquatableElement2(text: "2"), in: context))
+        XCTAssertFalse(EquatableElement1(text: "1").anyIsEquivalent(to: EquatableElement2(text: "1")))
+        XCTAssertFalse(EquatableElement1(text: "1").anyIsEquivalent(to: EquatableElement2(text: "2")))
     }
 }
 

--- a/BlueprintUI/Tests/ComparableElementTests.swift
+++ b/BlueprintUI/Tests/ComparableElementTests.swift
@@ -1,0 +1,56 @@
+//
+//  ComparableElementTests.swift
+//
+//
+//  Created by Kyle Van Essen on 11/3/22.
+//
+
+import Foundation
+import XCTest
+@testable import BlueprintUI
+
+
+class ComparableElementTests: XCTestCase {
+
+    func test_equatable_conformance() {
+
+        let context = ComparableElementContext(environment: .empty)
+
+        XCTAssertTrue(EquatableElement1(text: "1").isEquivalent(to: EquatableElement1(text: "1"), in: context))
+        XCTAssertFalse(EquatableElement1(text: "1").isEquivalent(to: EquatableElement1(text: "2"), in: context))
+    }
+}
+
+
+class AnyComparableElementTests: XCTestCase {
+
+    func test_anyIsEquivalent() {
+        let context = ComparableElementContext(environment: .empty)
+
+        XCTAssertTrue(EquatableElement1(text: "1").anyIsEquivalent(to: EquatableElement1(text: "1"), in: context))
+        XCTAssertFalse(EquatableElement1(text: "1").anyIsEquivalent(to: EquatableElement1(text: "2"), in: context))
+
+        XCTAssertFalse(EquatableElement1(text: "1").anyIsEquivalent(to: EquatableElement2(text: "1"), in: context))
+        XCTAssertFalse(EquatableElement1(text: "1").anyIsEquivalent(to: EquatableElement2(text: "2"), in: context))
+    }
+}
+
+
+fileprivate struct EquatableElement1: ProxyElement, ComparableElement, Equatable {
+
+    var text: String
+
+    var elementRepresentation: Element {
+        Empty()
+    }
+}
+
+
+fileprivate struct EquatableElement2: ProxyElement, ComparableElement, Equatable {
+
+    var text: String
+
+    var elementRepresentation: Element {
+        Empty()
+    }
+}

--- a/BlueprintUI/Tests/ElementStateTests.swift
+++ b/BlueprintUI/Tests/ElementStateTests.swift
@@ -41,7 +41,7 @@ class ElementStateTreeTests: XCTestCase {
 
         // Also make sure that we actually update the contained element.
 
-        XCTAssertEqual((state1.element.value as! Element1).text, "1.1")
+        XCTAssertEqual((state1.element.latest as! Element1).text, "1.1")
 
         // Updating with a new type should tear down the state.
 

--- a/BlueprintUI/Tests/ElementStateTests.swift
+++ b/BlueprintUI/Tests/ElementStateTests.swift
@@ -78,7 +78,6 @@ class ElementStateTests: XCTestCase {
             )
 
             XCTAssertTrue(state.wasVisited)
-            XCTAssertFalse(state.wasUpdateEquivalent)
         }
 
         // TODO: additional codepaths testing.

--- a/BlueprintUI/Tests/ElementStateTests.swift
+++ b/BlueprintUI/Tests/ElementStateTests.swift
@@ -71,7 +71,7 @@ class ElementStateTests: XCTestCase {
         testcase("default property values") {
             let state = ElementState(
                 parent: nil,
-                identifier: .init(elementType: Element1.self, key: nil, count: 1),
+                identifier: .identifier(for: Element1(text: "test"), key: nil, count: 1),
                 element: Element1(text: "1"),
                 signpostRef: NSObject(),
                 name: ""

--- a/BlueprintUI/Tests/ElementStateTests.swift
+++ b/BlueprintUI/Tests/ElementStateTests.swift
@@ -73,7 +73,6 @@ class ElementStateTests: XCTestCase {
                 parent: nil,
                 identifier: .init(elementType: Element1.self, key: nil, count: 1),
                 element: Element1(text: "1"),
-                depth: 0,
                 signpostRef: NSObject(),
                 name: ""
             )

--- a/BlueprintUI/Tests/ElementStateTests.swift
+++ b/BlueprintUI/Tests/ElementStateTests.swift
@@ -12,25 +12,161 @@ import XCTest
 
 class ElementStateTreeTests: XCTestCase {
 
-    func test_update() {}
+    func test_update() throws {
+
+        let tree = ElementStateTree(name: "Testing")
+        let element1 = Element1(text: "1")
+        let element1b = Element1(text: "1.1")
+        let element2 = Element2(text: "2")
+
+        XCTAssertNil(tree.root)
+
+        // Initial update should create a state.
+
+        tree.testingUpdate {
+            tree.update(with: element1, in: .empty)
+        }
+
+        let state1 = try XCTUnwrap(tree.root)
+
+        // Updating with the same element of the same type should keep the same state.
+
+        tree.testingUpdate {
+            tree.update(with: element1b, in: .empty)
+        }
+
+        let state2 = try XCTUnwrap(tree.root)
+
+        XCTAssertTrue(state1 === state2)
+
+        // Also make sure that we actually update the contained element.
+
+        XCTAssertEqual((state1.element.value as! Element1).text, "1.1")
+
+        // Updating with a new type should tear down the state.
+
+        tree.testingUpdate {
+            tree.update(with: element2, in: .empty)
+        }
+
+        let state3 = try XCTUnwrap(tree.root)
+
+        XCTAssertFalse(state2 === state3)
+
+        // Updating with nil should tear down the state.
+
+        tree.testingUpdate {
+            tree.update(with: nil, in: .empty)
+        }
+
+        XCTAssertNil(tree.root)
+    }
 }
 
 
 class ElementStateTests: XCTestCase {
 
-    func test_init() {}
+    func test_init() {
 
-    func test_elementContent() {}
+        testcase("default property values") {
+            let state = ElementState(
+                parent: nil,
+                identifier: .init(elementType: Element1.self, key: nil, count: 1),
+                element: Element1(text: "1"),
+                depth: 0,
+                signpostRef: NSObject(),
+                name: ""
+            )
 
-    func test_measure() {}
+            XCTAssertTrue(state.wasVisited)
+            XCTAssertFalse(state.wasUpdateEquivalent)
+        }
 
-    func test_layout() {}
+        // TODO: additional codepaths testing.
+    }
 
-    func test_childState() {}
+    func test_elementContent() {
+        // TODO:
+    }
 
-    func test_prepareForLayout() {}
+    func test_measure() {
+        // TODO:
+    }
 
-    func test_finishedLayout() {}
+    func test_layout() {
+        // TODO:
+    }
 
-    func test_recursiveForEach() {}
+    func test_childState() {
+        // TODO:
+    }
+
+    func test_prepareForLayout() {
+        // TODO:
+    }
+
+    func test_finishedLayout() {
+        // TODO:
+    }
+
+    func test_recursiveForEach() {
+        // TODO:
+    }
+}
+
+
+fileprivate struct Element1: ProxyElement {
+
+    var text: String
+
+    var elementRepresentation: Element {
+        Empty()
+    }
+}
+
+
+fileprivate struct Element2: ProxyElement {
+
+    var text: String
+
+    var elementRepresentation: Element {
+        Empty()
+    }
+}
+
+
+fileprivate struct EquatableElement1: ProxyElement, ComparableElement, Equatable {
+
+    var text: String
+
+    var elementRepresentation: Element {
+        Empty()
+    }
+}
+
+
+fileprivate struct EquatableElement2: ProxyElement, ComparableElement, Equatable {
+
+    var text: String
+
+    var elementRepresentation: Element {
+        Empty()
+    }
+}
+
+
+extension ElementStateTree {
+
+    func testingUpdate<Output>(_ block: () -> Output) -> Output {
+
+        root?.prepareForLayout()
+
+        let output = block()
+
+        defer {
+            self.root?.finishedLayout()
+        }
+
+        return output
+    }
 }

--- a/BlueprintUI/Tests/ElementStateTests.swift
+++ b/BlueprintUI/Tests/ElementStateTests.swift
@@ -1,0 +1,36 @@
+//
+//  ElementStateTests.swift
+//
+//
+//  Created by Kyle Van Essen on 11/3/22.
+//
+
+import Foundation
+import XCTest
+@testable import BlueprintUI
+
+
+class ElementStateTreeTests: XCTestCase {
+
+    func test_update() {}
+}
+
+
+class ElementStateTests: XCTestCase {
+
+    func test_init() {}
+
+    func test_elementContent() {}
+
+    func test_measure() {}
+
+    func test_layout() {}
+
+    func test_childState() {}
+
+    func test_prepareForLayout() {}
+
+    func test_finishedLayout() {}
+
+    func test_recursiveForEach() {}
+}

--- a/BlueprintUI/Tests/LayoutPassTestFixture.swift
+++ b/BlueprintUI/Tests/LayoutPassTestFixture.swift
@@ -1,0 +1,40 @@
+//
+//  LayoutPassTestFixture.swift
+//
+//
+//  Created by Kyle Van Essen on 11/3/22.
+//
+
+import Foundation
+
+final class LayoutPassTestFixture {
+
+    private(set) var events: [Event] = []
+
+    func removeAll() {
+        events.removeAll()
+    }
+}
+
+
+extension LayoutPassTestFixture {
+
+    enum Event {
+        enum Element: Equatable {
+            case accessedContent
+        }
+
+        enum ComparableElement: Equatable {
+            case isEquivalent
+        }
+
+        enum ElementState: Equatable {
+            case updated
+            case measure
+            case layout
+            case created
+        }
+
+        enum NativeViewController: Equatable {}
+    }
+}

--- a/BlueprintUI/Tests/XCTestCaseAdditions.swift
+++ b/BlueprintUI/Tests/XCTestCaseAdditions.swift
@@ -1,0 +1,21 @@
+//
+//  XCTestCaseAdditions.swift
+//
+//
+//  Created by Kyle Van Essen on 11/3/22.
+//
+
+import Foundation
+import XCTest
+
+extension XCTestCase {
+
+    /// Provides scoping within a single `func test...()` method, eg
+    /// if you want to test multiple cases / permutations with a label.
+    public func testcase(
+        _ name: String = "",
+        _ block: () throws -> Void
+    ) rethrows {
+        try block()
+    }
+}


### PR DESCRIPTION
- Copies over `ElementState` and `ComparableElement` types, and adds documentation for both of them.
- Adds `ComparableElement` tests.
- Adds tests for `ElementStateTree`.
- Adds skeleton tests for `ElementState`. To keep the PR from gaining another 1k lines, these tests will follow in the next PR.