### PR TITLE
feat: [UIViewElement] Include environment in context

### DIFF
--- a/BlueprintUI/Sources/Element/UIViewElement.swift
+++ b/BlueprintUI/Sources/Element/UIViewElement.swift
@@ -98,8 +98,12 @@ extension UIViewElement {
     /// Defer to the reused measurement view to provide the size of the element.
     public var content: ElementContent {
 
-        ElementContent {
-            UIViewElementMeasurer.shared.measure(element: self, in: $0)
+        ElementContent { constraint, environment in
+            UIViewElementMeasurer.shared.measure(
+                element: self,
+                constraint: constraint,
+                environment: environment
+            )
         }
     }
 
@@ -111,7 +115,13 @@ extension UIViewElement {
             }
 
             config.apply { view in
-                self.updateUIView(view, with: .init(isMeasuring: false))
+                self.updateUIView(
+                    view,
+                    with: .init(
+                        isMeasuring: false,
+                        environment: context.environment
+                    )
+                )
             }
         }
     }
@@ -122,6 +132,9 @@ public struct UIViewElementContext {
     /// This bool indicates whether the view being updated is the static measuring instance. You may
     /// not want to perform certain updates if it is (such as updating field trigger references).
     public var isMeasuring: Bool
+
+    /// The environment the element is rendered in.
+    public var environment: Environment
 }
 
 /// An private type which caches `UIViewElement` views to be reused for sizing and measurement.
@@ -131,13 +144,17 @@ private final class UIViewElementMeasurer {
     static let shared = UIViewElementMeasurer()
 
     /// Provides the size for the provided element by using a cached measurement view.
-    func measure<ViewElement: UIViewElement>(element: ViewElement, in constraint: SizeConstraint) -> CGSize {
+    func measure<ViewElement: UIViewElement>(
+        element: ViewElement,
+        constraint: SizeConstraint,
+        environment: Environment
+    ) -> CGSize {
 
         let bounds = CGRect(origin: .zero, size: constraint.maximum)
 
         let view = measurementView(for: element)
 
-        element.updateUIView(view, with: .init(isMeasuring: true))
+        element.updateUIView(view, with: .init(isMeasuring: true, environment: environment))
 
         return element.size(bounds.size, thatFits: view)
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `UIViewElementContext` now passes through an `environment` property, enabling environment-dependent measurements and layouts.  
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
### Summary

It is sometimes the case that an element's measurement, layout, or both is dependent on the state of the `Environment`. While this is generally available to `Element` adopters, it was previously not exposed by `UIViewElement`. 

This PR updates `UIViewElement` to pass through the environment in its pre-existing `UIViewElementContext` object, allowing users access to this information without requiring that they drop to `Element` to receive it.