### PR TITLE
[Caching] ElementIdentifier caching

### DIFF
--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -265,7 +265,7 @@ extension ElementContent {
                 return []
             }
 
-            let layoutItems = self.layoutItems(in: environment, cache: cache)
+            let layoutItems = layoutItems(in: environment, cache: cache)
             let childAttributes = layout.layout(size: attributes.bounds.size, items: layoutItems)
 
             var result: [(identifier: ElementIdentifier, node: LayoutResultNode)] = []
@@ -294,7 +294,7 @@ extension ElementContent {
                 )
 
                 let identifier = identifierFactory.nextIdentifier(
-                    for: type(of: currentChild.element),
+                    for: currentChild.element,
                     key: currentChild.key
                 )
 
@@ -364,7 +364,7 @@ private struct EnvironmentAdaptingStorage: ContentStorage {
 
         let childAttributes = LayoutAttributes(size: attributes.bounds.size)
 
-        let identifier = ElementIdentifier(elementType: type(of: child), key: nil, count: 1)
+        let identifier = ElementIdentifier.identifier(for: child, key: nil, count: 1)
 
         let node = LayoutResultNode(
             element: child,
@@ -413,7 +413,7 @@ private struct LazyStorage: ContentStorage {
         let child = buildChild(for: .layout, in: constraint, environment: environment)
         let childAttributes = LayoutAttributes(size: attributes.bounds.size)
 
-        let identifier = ElementIdentifier(elementType: type(of: child), key: nil, count: 1)
+        let identifier = ElementIdentifier.identifier(for: child, key: nil, count: 1)
 
         let node = LayoutResultNode(
             element: child,
@@ -543,7 +543,7 @@ extension Array {
     /// to 25% for large collections, so prefer it when needing an indexed `map` in areas where performance is critical.
     @inlinable func indexedMap<Mapped>(_ map: (Int, Element) -> Mapped) -> [Mapped] {
 
-        let count = self.count
+        let count = count
 
         var mapped = [Mapped]()
         mapped.reserveCapacity(count)

--- a/BlueprintUI/Tests/ElementIdentifierTests.swift
+++ b/BlueprintUI/Tests/ElementIdentifierTests.swift
@@ -9,31 +9,55 @@ class ElementIdentifierTests: XCTestCase {
         // Equal
 
         XCTAssertEqual(
-            ElementIdentifier(elementType: A.self, key: nil, count: 0),
-            ElementIdentifier(elementType: A.self, key: nil, count: 0)
+            ElementIdentifier.identifier(for: A(), key: nil, count: 0),
+            ElementIdentifier.identifier(for: A(), key: nil, count: 0)
         )
 
         XCTAssertEqual(
-            ElementIdentifier(elementType: A.self, key: "aKey", count: 0),
-            ElementIdentifier(elementType: A.self, key: "aKey", count: 0)
+            ElementIdentifier.identifier(for: A(), key: "aKey", count: 0),
+            ElementIdentifier.identifier(for: A(), key: "aKey", count: 0)
         )
 
         // Not Equal
 
         XCTAssertNotEqual(
-            ElementIdentifier(elementType: A.self, key: nil, count: 0),
-            ElementIdentifier(elementType: B.self, key: nil, count: 0)
+            ElementIdentifier.identifier(for: A(), key: nil, count: 0),
+            ElementIdentifier.identifier(for: B(), key: nil, count: 0)
         )
 
         XCTAssertNotEqual(
-            ElementIdentifier(elementType: A.self, key: nil, count: 0),
-            ElementIdentifier(elementType: A.self, key: nil, count: 1)
+            ElementIdentifier.identifier(for: A(), key: nil, count: 0),
+            ElementIdentifier.identifier(for: A(), key: nil, count: 1)
         )
 
         XCTAssertNotEqual(
-            ElementIdentifier(elementType: A.self, key: nil, count: 0),
-            ElementIdentifier(elementType: A.self, key: "aKey", count: 0)
+            ElementIdentifier.identifier(for: A(), key: nil, count: 0),
+            ElementIdentifier.identifier(for: A(), key: "aKey", count: 0)
         )
+    }
+
+    func test_elementIdentifierCaching() {
+        let id1 = ElementIdentifier.identifier(for: A(), key: nil, count: 0)
+        let id2 = ElementIdentifier.identifier(for: B(), key: nil, count: 0)
+        let id3 = ElementIdentifier.identifier(for: A(), key: "unique", count: 0)
+        let id4 = ElementIdentifier.identifier(for: A(), key: nil, count: 1)
+        let id5 = ElementIdentifier.identifier(for: A(), key: nil, count: 0)
+        let id6 = ElementIdentifier.identifier(for: B(), key: nil, count: 0)
+
+        var set = Set([id1.objectIdentifier])
+        XCTAssertFalse(set.contains(id2.objectIdentifier))
+        set.insert(id2.objectIdentifier)
+        XCTAssertFalse(set.contains(id3.objectIdentifier))
+        set.insert(id3.objectIdentifier)
+        XCTAssertFalse(set.contains(id4.objectIdentifier))
+        set.insert(id4.objectIdentifier)
+        XCTAssertTrue(set.contains(id5.objectIdentifier))
+        set.insert(id5.objectIdentifier)
+        XCTAssertTrue(set.contains(id6.objectIdentifier))
+
+        XCTAssertEqual(id1.objectIdentifier, id5.objectIdentifier)
+        XCTAssertEqual(id2.objectIdentifier, id6.objectIdentifier)
+        XCTAssertNotEqual(id5.objectIdentifier, id6.objectIdentifier)
     }
 }
 
@@ -42,25 +66,25 @@ class ElementIdentifier_FactoryTests: XCTestCase {
     func test_factory() {
         var factory = ElementIdentifier.Factory(elementCount: 10)
 
-        let identifierA1 = factory.nextIdentifier(for: A.self, key: nil)
-        let identifierA2 = factory.nextIdentifier(for: A.self, key: nil)
-        let identifierA3 = factory.nextIdentifier(for: A.self, key: "aKey")
-        let identifierA4 = factory.nextIdentifier(for: A.self, key: "aKey")
+        let identifierA1 = factory.nextIdentifier(for: A(), key: nil)
+        let identifierA2 = factory.nextIdentifier(for: A(), key: nil)
+        let identifierA3 = factory.nextIdentifier(for: A(), key: "aKey")
+        let identifierA4 = factory.nextIdentifier(for: A(), key: "aKey")
 
-        let identifierB1 = factory.nextIdentifier(for: B.self, key: nil)
-        let identifierB2 = factory.nextIdentifier(for: B.self, key: nil)
-        let identifierB3 = factory.nextIdentifier(for: B.self, key: "aKey")
-        let identifierB4 = factory.nextIdentifier(for: B.self, key: "aKey")
+        let identifierB1 = factory.nextIdentifier(for: B(), key: nil)
+        let identifierB2 = factory.nextIdentifier(for: B(), key: nil)
+        let identifierB3 = factory.nextIdentifier(for: B(), key: "aKey")
+        let identifierB4 = factory.nextIdentifier(for: B(), key: "aKey")
 
-        XCTAssertEqual(identifierA1, ElementIdentifier(elementType: A.self, key: nil, count: 1))
-        XCTAssertEqual(identifierA2, ElementIdentifier(elementType: A.self, key: nil, count: 2))
-        XCTAssertEqual(identifierA3, ElementIdentifier(elementType: A.self, key: "aKey", count: 1))
-        XCTAssertEqual(identifierA4, ElementIdentifier(elementType: A.self, key: "aKey", count: 2))
+        XCTAssertEqual(identifierA1, ElementIdentifier.identifier(for: A(), key: nil, count: 1))
+        XCTAssertEqual(identifierA2, ElementIdentifier.identifier(for: A(), key: nil, count: 2))
+        XCTAssertEqual(identifierA3, ElementIdentifier.identifier(for: A(), key: "aKey", count: 1))
+        XCTAssertEqual(identifierA4, ElementIdentifier.identifier(for: A(), key: "aKey", count: 2))
 
-        XCTAssertEqual(identifierB1, ElementIdentifier(elementType: B.self, key: nil, count: 1))
-        XCTAssertEqual(identifierB2, ElementIdentifier(elementType: B.self, key: nil, count: 2))
-        XCTAssertEqual(identifierB3, ElementIdentifier(elementType: B.self, key: "aKey", count: 1))
-        XCTAssertEqual(identifierB4, ElementIdentifier(elementType: B.self, key: "aKey", count: 2))
+        XCTAssertEqual(identifierB1, ElementIdentifier.identifier(for: B(), key: nil, count: 1))
+        XCTAssertEqual(identifierB2, ElementIdentifier.identifier(for: B(), key: nil, count: 2))
+        XCTAssertEqual(identifierB3, ElementIdentifier.identifier(for: B(), key: "aKey", count: 1))
+        XCTAssertEqual(identifierB4, ElementIdentifier.identifier(for: B(), key: "aKey", count: 2))
     }
 }
 
@@ -87,4 +111,10 @@ fileprivate struct B: Element {
         nil
     }
 
+}
+
+extension ElementIdentifier {
+    var objectIdentifier: ObjectIdentifier {
+        .init(self)
+    }
 }

--- a/BlueprintUI/Tests/ElementIdentifierTests.swift
+++ b/BlueprintUI/Tests/ElementIdentifierTests.swift
@@ -71,7 +71,23 @@ class ElementIdentifierTests: XCTestCase {
         )
     }
 
-    func test_debugDescription() {}
+    func test_debugDescription() {
+
+        XCTAssertEqual(
+            ElementIdentifier.identifier(for: A(), key: nil, count: 0).debugDescription,
+            "A.0"
+        )
+
+        XCTAssertEqual(
+            ElementIdentifier.identifier(for: A(), key: nil, count: 1).debugDescription,
+            "A.1"
+        )
+
+        XCTAssertEqual(
+            ElementIdentifier.identifier(for: A(), key: "Key", count: 1).debugDescription,
+            "A.Key.1"
+        )
+    }
 
     func test_elementIdentifierCaching() {
 

--- a/BlueprintUI/Tests/ElementIdentifierTests.swift
+++ b/BlueprintUI/Tests/ElementIdentifierTests.swift
@@ -14,8 +14,28 @@ class ElementIdentifierTests: XCTestCase {
         )
 
         XCTAssertEqual(
+            hash(for: ElementIdentifier.identifier(for: A(), key: nil, count: 0)),
+            hash(for: ElementIdentifier.identifier(for: A(), key: nil, count: 0))
+        )
+
+        XCTAssertEqual(
             ElementIdentifier.identifier(for: A(), key: "aKey", count: 0),
             ElementIdentifier.identifier(for: A(), key: "aKey", count: 0)
+        )
+
+        XCTAssertEqual(
+            hash(for: ElementIdentifier.identifier(for: A(), key: "aKey", count: 0)),
+            hash(for: ElementIdentifier.identifier(for: A(), key: "aKey", count: 0))
+        )
+
+        XCTAssertEqual(
+            ElementIdentifier.identifier(for: A(), key: "aKey", count: 1),
+            ElementIdentifier.identifier(for: A(), key: "aKey", count: 1)
+        )
+
+        XCTAssertEqual(
+            hash(for: ElementIdentifier.identifier(for: A(), key: "aKey", count: 1)),
+            hash(for: ElementIdentifier.identifier(for: A(), key: "aKey", count: 1))
         )
 
         // Not Equal
@@ -26,38 +46,77 @@ class ElementIdentifierTests: XCTestCase {
         )
 
         XCTAssertNotEqual(
+            hash(for: ElementIdentifier.identifier(for: A(), key: nil, count: 0)),
+            hash(for: ElementIdentifier.identifier(for: B(), key: nil, count: 0))
+        )
+
+        XCTAssertNotEqual(
             ElementIdentifier.identifier(for: A(), key: nil, count: 0),
             ElementIdentifier.identifier(for: A(), key: nil, count: 1)
+        )
+
+        XCTAssertNotEqual(
+            hash(for: ElementIdentifier.identifier(for: A(), key: nil, count: 0)),
+            hash(for: ElementIdentifier.identifier(for: A(), key: nil, count: 1))
         )
 
         XCTAssertNotEqual(
             ElementIdentifier.identifier(for: A(), key: nil, count: 0),
             ElementIdentifier.identifier(for: A(), key: "aKey", count: 0)
         )
+
+        XCTAssertNotEqual(
+            hash(for: ElementIdentifier.identifier(for: A(), key: nil, count: 0)),
+            hash(for: ElementIdentifier.identifier(for: A(), key: "aKey", count: 0))
+        )
     }
 
+    func test_debugDescription() {}
+
     func test_elementIdentifierCaching() {
+
         let id1 = ElementIdentifier.identifier(for: A(), key: nil, count: 0)
         let id2 = ElementIdentifier.identifier(for: B(), key: nil, count: 0)
-        let id3 = ElementIdentifier.identifier(for: A(), key: "unique", count: 0)
         let id4 = ElementIdentifier.identifier(for: A(), key: nil, count: 1)
         let id5 = ElementIdentifier.identifier(for: A(), key: nil, count: 0)
         let id6 = ElementIdentifier.identifier(for: B(), key: nil, count: 0)
 
+        let uncachedId1 = ElementIdentifier.identifier(for: A(), key: "unique", count: 0)
+        let uncachedId2 = ElementIdentifier.identifier(for: A(), key: "unique", count: 0)
+
+        /// We'll use `ObjectIdentifier` to check the actual
+        /// pointer values of each `ElementIdentifier`.
+
         var set = Set([id1.objectIdentifier])
+
         XCTAssertFalse(set.contains(id2.objectIdentifier))
         set.insert(id2.objectIdentifier)
-        XCTAssertFalse(set.contains(id3.objectIdentifier))
-        set.insert(id3.objectIdentifier)
+
         XCTAssertFalse(set.contains(id4.objectIdentifier))
         set.insert(id4.objectIdentifier)
+
         XCTAssertTrue(set.contains(id5.objectIdentifier))
         set.insert(id5.objectIdentifier)
+
         XCTAssertTrue(set.contains(id6.objectIdentifier))
+
+        XCTAssertFalse(set.contains(uncachedId1.objectIdentifier))
+        set.insert(uncachedId1.objectIdentifier)
+
+        XCTAssertFalse(set.contains(uncachedId2.objectIdentifier))
+        set.insert(uncachedId2.objectIdentifier)
 
         XCTAssertEqual(id1.objectIdentifier, id5.objectIdentifier)
         XCTAssertEqual(id2.objectIdentifier, id6.objectIdentifier)
         XCTAssertNotEqual(id5.objectIdentifier, id6.objectIdentifier)
+
+        XCTAssertNotEqual(uncachedId1.objectIdentifier, uncachedId2.objectIdentifier)
+    }
+
+    func hash<Value: Hashable>(for value: Value) -> Int {
+        var hasher = Hasher()
+        hasher.combine(value)
+        return hasher.finalize()
     }
 }
 

--- a/BlueprintUI/Tests/ElementPathTests.swift
+++ b/BlueprintUI/Tests/ElementPathTests.swift
@@ -7,7 +7,7 @@ class ElementPathTests: XCTestCase {
 
         XCTAssertEqual(ElementPath.empty, ElementPath.empty)
 
-        let testPath = ElementPath().appending(identifier: ElementIdentifier(elementType: A.self, key: nil, count: 0))
+        let testPath = ElementPath().appending(identifier: ElementIdentifier.identifier(for: A(), key: nil, count: 0))
 
         XCTAssertNotEqual(testPath, .empty)
 
@@ -17,10 +17,10 @@ class ElementPathTests: XCTestCase {
 
     func test_copyOnWrite() {
 
-        let testPath = ElementPath().appending(identifier: ElementIdentifier(elementType: A.self, key: nil, count: 0))
+        let testPath = ElementPath().appending(identifier: ElementIdentifier.identifier(for: A(), key: nil, count: 0))
 
         var otherPath = testPath
-        otherPath.prepend(identifier: ElementIdentifier(elementType: B.self, key: nil, count: 1))
+        otherPath.prepend(identifier: ElementIdentifier.identifier(for: B(), key: nil, count: 1))
 
         XCTAssertNotEqual(testPath, otherPath)
     }


### PR DESCRIPTION
This PR adds optimizations to `ElementIdentifier` that are needed cross-render caching.
With [cross-render caching](https://docs.google.com/document/d/1ozD6XaZYZ2a8xRudJrZ-4m3tcH6d8N4bBdtFTjks4QM/edit#heading=h.si9yctdme18g) we will be using `ElementIdentifier` more frequently than we currently do which results in many unnecessary memory allocations for identifiers that are essentially the same.

We now cache `ElementIdentifier` by type and count. This should significantly reduce memory allocation of identifiers during layout passes. Key-based identifiers are never cached.