### PR TITLE
Make Label and AttributedLabel comparable

### DIFF
--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -2,7 +2,7 @@ import BlueprintUI
 import Foundation
 import UIKit
 
-public struct AttributedLabel: Element, Hashable {
+public struct AttributedLabel: ComparableElement, Hashable {
 
     /// The attributed text to render in the label.
     ///

--- a/BlueprintUICommonControls/Sources/Label.swift
+++ b/BlueprintUICommonControls/Sources/Label.swift
@@ -3,7 +3,7 @@ import UIKit
 
 
 /// Displays text content.
-public struct Label: ProxyElement {
+public struct Label: ProxyElement, ComparableElement, Equatable {
 
     /// The text to be displayed.
     public var text: String


### PR DESCRIPTION
Conforms `Label` and `AttributedLabel` to `ComparableElement`. Both elements are already `Equatable` and thus are tested with the default `ComparableElement` tests.