### PR TITLE
[SPL] misc performance changes

### DIFF
--- a/BlueprintUI/Sources/Element/ElementContent+SPL.swift
+++ b/BlueprintUI/Sources/Element/ElementContent+SPL.swift
@@ -13,17 +13,19 @@ extension ElementContent.Builder {
 
     func sizeThatFits(proposal: SizeConstraint, context: MeasureContext) -> CGSize {
         
-        let subviews = children.indexedMap { index, child in
-            LayoutSubview(
-                element: child.element,
-                content: child.content,
-                measureContext: .init(
-                    cache: context.cache.subcache(key: index),
-                    environment: context.environment
-                ),
-                traits: child.traits,
-                layoutType: LayoutType.self
-            )
+        let subviews = context.cache.layoutSubviews {
+            children.indexedMap { index, child in
+                LayoutSubview(
+                    element: child.element,
+                    content: child.content,
+                    measureContext: .init(
+                        cache: context.cache.subcache(key: index),
+                        environment: context.environment
+                    ),
+                    traits: child.traits,
+                    layoutType: LayoutType.self
+                )
+            }
         }
         return layout.sizeThatFits(proposal: proposal, subviews: subviews)
     }
@@ -31,17 +33,19 @@ extension ElementContent.Builder {
     func performSinglePassLayout(proposal: SizeConstraint, context: SPLayoutContext) -> [IdentifiedNode] {
         guard children.isEmpty == false else { return [] }
 
-        let subviews = children.indexedMap { index, child in
-            LayoutSubview(
-                element: child.element,
-                content: child.content,
-                measureContext: .init(
-                    cache: context.cache.subcache(key: index),
-                    environment: context.environment
-                ),
-                traits: child.traits,
-                layoutType: LayoutType.self
-            )
+        let subviews = context.cache.layoutSubviews {
+            children.indexedMap { index, child in
+                LayoutSubview(
+                    element: child.element,
+                    content: child.content,
+                    measureContext: .init(
+                        cache: context.cache.subcache(key: index),
+                        environment: context.environment
+                    ),
+                    traits: child.traits,
+                    layoutType: LayoutType.self
+                )
+            }
         }
 
         let attributes = context.attributes

--- a/BlueprintUI/Sources/Element/ElementContent+SPL.swift
+++ b/BlueprintUI/Sources/Element/ElementContent+SPL.swift
@@ -12,7 +12,8 @@ extension ElementContent: Sizable {
 extension ElementContent.Builder {
 
     func sizeThatFits(proposal: SizeConstraint, context: MeasureContext) -> CGSize {
-        let subviews = zip(children, children.indices).map { child, index in
+        
+        let subviews = children.indexedMap { index, child in
             LayoutSubview(
                 element: child.element,
                 content: child.content,
@@ -30,7 +31,7 @@ extension ElementContent.Builder {
     func performSinglePassLayout(proposal: SizeConstraint, context: SPLayoutContext) -> [IdentifiedNode] {
         guard children.isEmpty == false else { return [] }
 
-        let subviews = zip(children, children.indices).map { child, index in
+        let subviews = children.indexedMap { index, child in
             LayoutSubview(
                 element: child.element,
                 content: child.content,
@@ -54,8 +55,7 @@ extension ElementContent.Builder {
 
         var identifierFactory = ElementIdentifier.Factory(elementCount: children.count)
 
-        let identifiedNodes: [IdentifiedNode] = children.indices.map { index in
-            let child = children[index]
+        let identifiedNodes: [IdentifiedNode] = children.indexedMap { index, child in
             let subview = subviews[index]
 
             let placement = subview.placement

--- a/BlueprintUI/Sources/Internal/SPL/SPCacheTree.swift
+++ b/BlueprintUI/Sources/Internal/SPL/SPCacheTree.swift
@@ -29,6 +29,18 @@ final class SPCacheTree<Key, Value, SubcacheKey> where Key: Hashable, SubcacheKe
         subcaches[key] = subcache
         return subcache
     }
+    
+    var layoutSubviews: [LayoutSubview]?
+    
+    // TODO: generalize hanging anything off this cache
+    func layoutSubviews(create: () -> [LayoutSubview]) -> [LayoutSubview] {
+        if let layoutSubviews = layoutSubviews {
+            return layoutSubviews
+        }
+        let layoutSubviews = create()
+        self.layoutSubviews = layoutSubviews
+        return layoutSubviews
+    }
 }
 
 

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -909,7 +909,7 @@ extension StackLayout {
 
         let frames = _frames(for: subviews.map(StackLayoutItem.init), in: constraint)
 
-        for i in subviews.indices {
+        for i in 0..<subviews.count {
             let vectorFrame = frames[i]
             let subview = subviews[i]
 

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -379,7 +379,7 @@ extension StackLayout {
         // During layout the constraints are always `.exactly` to fit the provided size
         let vectorConstraint = size.vectorConstraint(axis: axis)
 
-        let frames = _frames(for: items.map(MeasurableLayoutItem.init), in: vectorConstraint)
+        let frames = _frames(for: items.map(StackLayoutItem.init), in: vectorConstraint)
 
         return frames.map { frame in
             LayoutAttributes(frame: frame.rect(axis: axis))
@@ -392,7 +392,7 @@ extension StackLayout {
         // During measurement the constraints may be `.atMost` or `.unconstrained` to fit the measurement constraint
         let vectorConstraint = constraint.vectorConstraint(on: axis)
 
-        let frames = _frames(for: items.map(MeasurableLayoutItem.init), in: vectorConstraint)
+        let frames = _frames(for: items.map(StackLayoutItem.init), in: vectorConstraint)
 
         let vector = frames.reduce(Vector.zero) { vector, frame -> Vector in
             Vector(
@@ -891,7 +891,7 @@ extension StackLayout {
 
         let constraint = proposal.vectorConstraint(on: axis)
 
-        let frames = _frames(for: subviews, in: constraint)
+        let frames = _frames(for: subviews.map(StackLayoutItem.init), in: constraint)
 
         let vector = frames.reduce(Vector.zero) { vector, frame -> Vector in
             Vector(
@@ -907,7 +907,7 @@ extension StackLayout {
 
         let constraint = bounds.size.vectorConstraint(axis: axis)
 
-        let frames = _frames(for: subviews, in: constraint)
+        let frames = _frames(for: subviews.map(StackLayoutItem.init), in: constraint)
 
         for i in subviews.indices {
             let vectorFrame = frames[i]
@@ -940,36 +940,24 @@ extension StackLayout {
         }
     }
     
-    private struct MeasurableLayoutItem: StackLayoutItem {
+    private struct StackLayoutItem {
         
         let traits: Traits
-        let measurable: Measurable
+        private let measure: (SizeConstraint) -> CGSize
         
         init(_ tuple: (Traits, Measurable)) {
             traits = tuple.0
-            measurable = tuple.1
+            measure = tuple.1.measure(in:)
+        }
+        
+        init(_ subview: LayoutSubview) {
+            traits = subview.stackLayoutTraits
+            measure = subview.sizeThatFits(_:)
         }
         
         func measure(in constraint: SizeConstraint) -> CGSize {
-            measurable.measure(in: constraint)
+            measure(constraint)
         }
-    }
-}
-
-
-private protocol StackLayoutItem {
-    
-    var traits: StackLayout.Traits { get }
-    func measure(in constraint: SizeConstraint) -> CGSize
-}
-
-
-extension LayoutSubview: StackLayoutItem {
-    
-    var traits: StackLayout.Traits { stackLayoutTraits }
-    
-    func measure(in constraint: SizeConstraint) -> CGSize {
-        sizeThatFits(constraint)
     }
 }
 


### PR DESCRIPTION
Rollup of some optimizations made during pairing:
- a common abstraction in stack layouts for both modes to call into
- faster iterations
- re-use subviews between measuring and layout