### PR TITLE
Extension Safe Methods: Add Extension-Safe flag to podspecs

### DIFF
--- a/BlueprintUI.podspec
+++ b/BlueprintUI.podspec
@@ -19,6 +19,10 @@ Pod::Spec.new do |s|
 
   s.weak_framework = 'SwiftUI'
 
+  s.pod_target_xcconfig = {
+    'APPLICATION_EXTENSION_API_ONLY' => 'YES',
+  }
+
   s.test_spec 'Tests' do |test_spec|
     test_spec.library = 'swiftsimd'
     test_spec.source_files = 'BlueprintUI/Tests/**/*.swift'

--- a/BlueprintUICommonControls.podspec
+++ b/BlueprintUICommonControls.podspec
@@ -18,4 +18,8 @@ Pod::Spec.new do |s|
   s.source_files = 'BlueprintUICommonControls/Sources/**/*.swift'
 
   s.dependency 'BlueprintUI', BLUEPRINT_VERSION
+
+  s.pod_target_xcconfig = {
+    'APPLICATION_EXTENSION_API_ONLY' => 'YES',
+  }
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated minimum deployment target from iOS 12 to iOS 14.
 - `URLHandlerEnvironmentKey.defaultValue` is now settable.
+- Marks pod as `APPLICATION_EXTENSION_API_ONLY`
 
 ### Deprecated
 


### PR DESCRIPTION
This marks these targets as explicitly extension safe.

Depends upon https://github.com/square/Blueprint/pull/408