### PR TITLE
Cross-layout caching feature flag

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -27,9 +27,9 @@ import UIKit
 /// ```
 public final class BlueprintView: UIView {
     
-    public static var useCrossLayoutCaching: Bool = false {
+    public static var enableCrossLayoutCaching: Bool = false {
         didSet {
-            ElementState.useCaching = useCrossLayoutCaching
+            ElementState.enableCrossLayoutCaching = enableCrossLayoutCaching
         }
     }
 

--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -26,7 +26,7 @@ import UIKit
 /// }
 /// ```
 public final class BlueprintView: UIView {
-    
+
     public static var enableCrossLayoutCaching: Bool = false {
         didSet {
             ElementState.enableCrossLayoutCaching = enableCrossLayoutCaching
@@ -427,7 +427,7 @@ public final class BlueprintView: UIView {
         rootFrame: CGRect
     ) -> [(path: ElementPath, node: NativeViewNode)] {
 
-        if let element = self.element {
+        if let element = element {
             let (_, node) = rootState.performUpdate(with: element, in: environment) { state in
                 LayoutResultNode(
                     identifier: .identifierFor(singleChild: element),
@@ -467,7 +467,7 @@ public final class BlueprintView: UIView {
             }
         }()
 
-        var environment = inherited.merged(prioritizing: self.environment)
+        var environment = inherited.merged(prioritizing: environment)
 
         if let displayScale = window?.screen.scale {
             environment.displayScale = displayScale

--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -26,6 +26,13 @@ import UIKit
 /// }
 /// ```
 public final class BlueprintView: UIView {
+    
+    public static var useCrossLayoutCaching: Bool = false {
+        didSet {
+            ElementState.useCaching = useCrossLayoutCaching
+        }
+    }
+
 
     private(set) var needsViewHierarchyUpdate: Bool = true
     private var hasUpdatedViewHierarchy: Bool = false

--- a/BlueprintUI/Sources/Element/ElementState.swift
+++ b/BlueprintUI/Sources/Element/ElementState.swift
@@ -136,6 +136,8 @@ final class ElementStateTree {
 /// and layouts either to the end of the layout pass, or until the equivalency of the `Element`
 /// changes, for comparable elements.
 final class ElementState {
+    
+    static var useCaching = false
 
     /// The parent element that owns this element.
     private(set) weak var parent: ElementState?
@@ -456,6 +458,16 @@ final class ElementState {
         with environment: Environment,
         using layout: (Environment) -> [LayoutResultNode]
     ) -> [LayoutResultNode] {
+        
+        if !Self.useCaching {
+            let nodes = layout(environment)
+
+            delegate.ifDebug {
+                $0.treeDidPerformLayout(nodes, size: size, for: self)
+            }
+
+            return nodes
+        }
 
         /// Layout is only invoked once per cycle. If we're not a `ComparableElement`,
         /// there's no point in caching this value, so just return the `layout` directly.
@@ -622,6 +634,9 @@ final class ElementState {
             $0.wasVisited = false
             $0.hasUpdatedChildrenDuringLayout = false
             $0.clearOrderedChildren()
+            if !Self.useCaching {
+                $0.clearAllCachedData()
+            }
         }
     }
 

--- a/BlueprintUI/Sources/Element/ElementState.swift
+++ b/BlueprintUI/Sources/Element/ElementState.swift
@@ -137,7 +137,7 @@ final class ElementStateTree {
 /// changes, for comparable elements.
 final class ElementState {
     
-    static var useCaching = false
+    static var enableCrossLayoutCaching = false
 
     /// The parent element that owns this element.
     private(set) weak var parent: ElementState?
@@ -459,7 +459,7 @@ final class ElementState {
         using layout: (Environment) -> [LayoutResultNode]
     ) -> [LayoutResultNode] {
         
-        if !Self.useCaching {
+        if !Self.enableCrossLayoutCaching {
             let nodes = layout(environment)
 
             delegate.ifDebug {
@@ -634,7 +634,7 @@ final class ElementState {
             $0.wasVisited = false
             $0.hasUpdatedChildrenDuringLayout = false
             $0.clearOrderedChildren()
-            if !Self.useCaching {
+            if !Self.enableCrossLayoutCaching {
                 $0.clearAllCachedData()
             }
         }

--- a/BlueprintUI/Sources/Element/ElementState.swift
+++ b/BlueprintUI/Sources/Element/ElementState.swift
@@ -136,7 +136,7 @@ final class ElementStateTree {
 /// and layouts either to the end of the layout pass, or until the equivalency of the `Element`
 /// changes, for comparable elements.
 final class ElementState {
-    
+
     static var enableCrossLayoutCaching = false
 
     /// The parent element that owns this element.
@@ -458,7 +458,7 @@ final class ElementState {
         with environment: Environment,
         using layout: (Environment) -> [LayoutResultNode]
     ) -> [LayoutResultNode] {
-        
+
         if !Self.enableCrossLayoutCaching {
             let nodes = layout(environment)
 

--- a/BlueprintUI/Sources/Element/ElementState.swift
+++ b/BlueprintUI/Sources/Element/ElementState.swift
@@ -634,9 +634,6 @@ final class ElementState {
             $0.wasVisited = false
             $0.hasUpdatedChildrenDuringLayout = false
             $0.clearOrderedChildren()
-            if !Self.enableCrossLayoutCaching {
-                $0.clearAllCachedData()
-            }
         }
     }
 
@@ -645,7 +642,12 @@ final class ElementState {
     /// or throw out caches which should not be maintained across layout cycles.
     fileprivate func finishedLayout() {
         recursiveRemoveOldChildren()
-        recursiveClearCaches()
+
+        if Self.enableCrossLayoutCaching {
+            recursiveClearCaches()
+        } else {
+            clearAllCachedData()
+        }
     }
 
     /// Clears all cached measurements, layouts, etc.

--- a/BlueprintUI/Tests/AdaptedEnvironmentTests.swift
+++ b/BlueprintUI/Tests/AdaptedEnvironmentTests.swift
@@ -10,11 +10,11 @@ import XCTest
 
 
 class AdaptedEnvironmentTests: XCTestCase {
-    
+
     override func setUp() {
         BlueprintView.enableCrossLayoutCaching = true
     }
-    
+
     override func tearDown() {
         BlueprintView.enableCrossLayoutCaching = false
     }

--- a/BlueprintUI/Tests/AdaptedEnvironmentTests.swift
+++ b/BlueprintUI/Tests/AdaptedEnvironmentTests.swift
@@ -10,6 +10,14 @@ import XCTest
 
 
 class AdaptedEnvironmentTests: XCTestCase {
+    
+    override func setUp() {
+        BlueprintView.enableCrossLayoutCaching = true
+    }
+    
+    override func tearDown() {
+        BlueprintView.enableCrossLayoutCaching = false
+    }
 
     func test_adapting() {
         let view = BlueprintView()

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -2,6 +2,14 @@ import XCTest
 @testable import BlueprintUI
 
 class BlueprintViewTests: XCTestCase {
+    
+    override func setUp() {
+        BlueprintView.enableCrossLayoutCaching = true
+    }
+    
+    override func tearDown() {
+        BlueprintView.enableCrossLayoutCaching = false
+    }
 
     func test_sizeThatFits() {
 

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -2,11 +2,11 @@ import XCTest
 @testable import BlueprintUI
 
 class BlueprintViewTests: XCTestCase {
-    
+
     override func setUp() {
         BlueprintView.enableCrossLayoutCaching = true
     }
-    
+
     override func tearDown() {
         BlueprintView.enableCrossLayoutCaching = false
     }
@@ -390,7 +390,7 @@ class BlueprintViewTests: XCTestCase {
             var child: Element?
 
             var content: ElementContent {
-                if let child = self.child {
+                if let child = child {
                     return .init(child: child)
                 } else {
                     return .init(intrinsicSize: .zero)
@@ -398,7 +398,7 @@ class BlueprintViewTests: XCTestCase {
             }
 
             func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
-                guard let view = self.view else {
+                guard let view = view else {
                     return nil
                 }
 

--- a/BlueprintUI/Tests/ElementStateTests.swift
+++ b/BlueprintUI/Tests/ElementStateTests.swift
@@ -31,6 +31,14 @@ extension ElementStateTree {
 
 
 class ElementStateTreeTests: XCTestCase {
+    
+    override func setUp() {
+        BlueprintView.enableCrossLayoutCaching = true
+    }
+    
+    override func tearDown() {
+        BlueprintView.enableCrossLayoutCaching = false
+    }
 
     func test_integration() {
 
@@ -541,7 +549,7 @@ class ElementStateTests: XCTestCase {
         // TODO:
     }
 
-    func test_childState() throws {
+    func disable_test_childState() throws {
         let delegate = TestDelegate()
 
         let root = Element1(text: "root")

--- a/BlueprintUI/Tests/ElementStateTests.swift
+++ b/BlueprintUI/Tests/ElementStateTests.swift
@@ -31,11 +31,11 @@ extension ElementStateTree {
 
 
 class ElementStateTreeTests: XCTestCase {
-    
+
     override func setUp() {
         BlueprintView.enableCrossLayoutCaching = true
     }
-    
+
     override func tearDown() {
         BlueprintView.enableCrossLayoutCaching = false
     }

--- a/BlueprintUI/Tests/ElementStateTests.swift
+++ b/BlueprintUI/Tests/ElementStateTests.swift
@@ -549,7 +549,7 @@ class ElementStateTests: XCTestCase {
         // TODO:
     }
 
-    func disable_test_childState() throws {
+    func test_childState() throws {
         let delegate = TestDelegate()
 
         let root = Element1(text: "root")

--- a/BlueprintUI/Tests/KeyedTests.swift
+++ b/BlueprintUI/Tests/KeyedTests.swift
@@ -10,6 +10,14 @@ import XCTest
 
 
 class KeyedTests: XCTestCase {
+    
+    override func setUp() {
+        BlueprintView.enableCrossLayoutCaching = true
+    }
+    
+    override func tearDown() {
+        BlueprintView.enableCrossLayoutCaching = false
+    }
 
     func test_measure() {
         let element = TestElement().keyed("the-key")

--- a/BlueprintUI/Tests/KeyedTests.swift
+++ b/BlueprintUI/Tests/KeyedTests.swift
@@ -10,11 +10,11 @@ import XCTest
 
 
 class KeyedTests: XCTestCase {
-    
+
     override func setUp() {
         BlueprintView.enableCrossLayoutCaching = true
     }
-    
+
     override func tearDown() {
         BlueprintView.enableCrossLayoutCaching = false
     }

--- a/BlueprintUI/Tests/LayoutWriterTests.swift
+++ b/BlueprintUI/Tests/LayoutWriterTests.swift
@@ -11,6 +11,14 @@ import XCTest
 
 
 class LayoutWriterTests: XCTestCase {
+    
+    override func setUp() {
+        BlueprintView.enableCrossLayoutCaching = true
+    }
+    
+    override func tearDown() {
+        BlueprintView.enableCrossLayoutCaching = false
+    }
 
     func test_buildCount() {
 

--- a/BlueprintUI/Tests/LayoutWriterTests.swift
+++ b/BlueprintUI/Tests/LayoutWriterTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 
 class LayoutWriterTests: XCTestCase {
-    
+
     override func setUp() {
         BlueprintView.enableCrossLayoutCaching = true
     }
-    
+
     override func tearDown() {
         BlueprintView.enableCrossLayoutCaching = false
     }

--- a/BlueprintUI/Tests/UIViewElementTests.swift
+++ b/BlueprintUI/Tests/UIViewElementTests.swift
@@ -11,11 +11,11 @@ import XCTest
 
 
 class UIViewElementTests: XCTestCase {
-    
+
     override func setUp() {
         BlueprintView.enableCrossLayoutCaching = true
     }
-    
+
     override func tearDown() {
         BlueprintView.enableCrossLayoutCaching = false
     }

--- a/BlueprintUI/Tests/UIViewElementTests.swift
+++ b/BlueprintUI/Tests/UIViewElementTests.swift
@@ -11,6 +11,14 @@ import XCTest
 
 
 class UIViewElementTests: XCTestCase {
+    
+    override func setUp() {
+        BlueprintView.enableCrossLayoutCaching = true
+    }
+    
+    override func tearDown() {
+        BlueprintView.enableCrossLayoutCaching = false
+    }
 
     func test_measuring() {
         // Due to the static caching of UIViewElementMeasurer, this struct is nested to give it a

--- a/BlueprintUI/Tests/ViewDiffingBehaviourTests.swift
+++ b/BlueprintUI/Tests/ViewDiffingBehaviourTests.swift
@@ -11,11 +11,11 @@ import XCTest
 @testable import BlueprintUI
 
 class ViewDiffingBehaviourTests: XCTestCase {
-    
+
     override func setUp() {
         BlueprintView.enableCrossLayoutCaching = true
     }
-    
+
     override func tearDown() {
         BlueprintView.enableCrossLayoutCaching = false
     }

--- a/BlueprintUI/Tests/ViewDiffingBehaviourTests.swift
+++ b/BlueprintUI/Tests/ViewDiffingBehaviourTests.swift
@@ -11,6 +11,15 @@ import XCTest
 @testable import BlueprintUI
 
 class ViewDiffingBehaviourTests: XCTestCase {
+    
+    override func setUp() {
+        BlueprintView.enableCrossLayoutCaching = true
+    }
+    
+    override func tearDown() {
+        BlueprintView.enableCrossLayoutCaching = false
+    }
+
     func test_view_instances_do_not_change() {
         // Set up initial view and contents.
 

--- a/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
@@ -4,11 +4,11 @@ import XCTest
 
 
 class AttributedLabelTests: XCTestCase {
-    
+
     override func setUp() {
         BlueprintView.enableCrossLayoutCaching = true
     }
-    
+
     override func tearDown() {
         BlueprintView.enableCrossLayoutCaching = false
     }

--- a/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
@@ -4,6 +4,14 @@ import XCTest
 
 
 class AttributedLabelTests: XCTestCase {
+    
+    override func setUp() {
+        BlueprintView.enableCrossLayoutCaching = true
+    }
+    
+    override func tearDown() {
+        BlueprintView.enableCrossLayoutCaching = false
+    }
 
     func test_accessibilityTraits() {
 

--- a/BlueprintUICommonControls/Tests/Sources/PerformancePlayground.swift
+++ b/BlueprintUICommonControls/Tests/Sources/PerformancePlayground.swift
@@ -26,11 +26,11 @@ class PerformancePlayground: XCTestCase {
         // Uncomment this line to run performance metrics, eg in Instruments.app.
         super.invokeTest()
     }
-    
+
     override func setUp() {
         BlueprintView.enableCrossLayoutCaching = true
     }
-    
+
     override func tearDown() {
         BlueprintView.enableCrossLayoutCaching = false
     }
@@ -309,7 +309,7 @@ class PerformancePlayground: XCTestCase {
 
         print("Iterations: \(iterations), Average Time: \(average)")
     }
-    
+
     func test_increment_state_changes() {
         let gridSize = 30
 

--- a/BlueprintUICommonControls/Tests/Sources/PerformancePlayground.swift
+++ b/BlueprintUICommonControls/Tests/Sources/PerformancePlayground.swift
@@ -26,6 +26,14 @@ class PerformancePlayground: XCTestCase {
         // Uncomment this line to run performance metrics, eg in Instruments.app.
         super.invokeTest()
     }
+    
+    override func setUp() {
+        BlueprintView.useCrossLayoutCaching = true
+    }
+    
+    override func tearDown() {
+        BlueprintView.useCrossLayoutCaching = false
+    }
 
     func test_deep_and_wide_grid() {
 

--- a/BlueprintUICommonControls/Tests/Sources/PixelBoundarySnapshotTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/PixelBoundarySnapshotTests.swift
@@ -3,6 +3,15 @@ import BlueprintUICommonControls
 import XCTest
 
 final class PixelBoundarySnapshotTests: XCTestCase {
+    
+    override func setUp() {
+        BlueprintView.enableCrossLayoutCaching = true
+    }
+    
+    override func tearDown() {
+        BlueprintView.enableCrossLayoutCaching = false
+    }
+
     func test_nestedBoxes() {
         compareSnapshot(
             of: NestedBoxes(addIntermediateViews: false),

--- a/BlueprintUICommonControls/Tests/Sources/PixelBoundarySnapshotTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/PixelBoundarySnapshotTests.swift
@@ -3,11 +3,11 @@ import BlueprintUICommonControls
 import XCTest
 
 final class PixelBoundarySnapshotTests: XCTestCase {
-    
+
     override func setUp() {
         BlueprintView.enableCrossLayoutCaching = true
     }
-    
+
     override func tearDown() {
         BlueprintView.enableCrossLayoutCaching = false
     }

--- a/BlueprintUICommonControls/Tests/Sources/TextFieldTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/TextFieldTests.swift
@@ -4,11 +4,11 @@ import XCTest
 
 
 class TextFieldTests: XCTestCase {
-    
+
     override func setUp() {
         BlueprintView.enableCrossLayoutCaching = true
     }
-    
+
     override func tearDown() {
         BlueprintView.enableCrossLayoutCaching = false
     }

--- a/BlueprintUICommonControls/Tests/Sources/TextFieldTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/TextFieldTests.swift
@@ -4,6 +4,14 @@ import XCTest
 
 
 class TextFieldTests: XCTestCase {
+    
+    override func setUp() {
+        BlueprintView.enableCrossLayoutCaching = true
+    }
+    
+    override func tearDown() {
+        BlueprintView.enableCrossLayoutCaching = false
+    }
 
     func test_snapshots() {
 


### PR DESCRIPTION
Adds a flag to control cross-layout caching. The flag is a static member on BlueprintView. When turned on, all blueprint view instances will use the flag.

When the flag is off:
* We reset measurement caches and measurement caching behaves the same as it did with `CacheTree`.
* We do not cache layout nodes.

The feature flag is off by default. Because of this we turn it on for all tests that use `BlueprintView`.

Below is a comparison of performance tests between `main` and this branch with the flag turned off. Performance is not exact but close.


Test | Feature flag off w/ caching (seconds) | Main (seconds)
-- | -- | --
test_deep_and_wide_grid | 1.446 avg | 1.657 avg
test_repeated_layouts | 0.146 avg | 0.141 avg
test_row_with_one_flexible_element | 0.080 avg | 0.077 avg
test_deep_element_hierarchy | 0.254 avg | 0.245 avg
test_deep_stacks | 7.646 total | 8.136 total
test_incremental_state_change | 0.046 avg | 0.055 avg

