### PR TITLE
Explicit maccatalyst versioning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,6 +7,7 @@ let package = Package(
     name: "BlueprintUI",
     platforms: [
         .iOS(.v14),
+        .macCatalyst(.v14),
     ],
     products: [
         .library(


### PR DESCRIPTION
For whatever reason, this is now failing in CI with XC 14.1 _sigh_

```
12:44:04 [x] error: The package product 'BlueprintUI' requires minimum platform version 14.0 for the Mac Catalyst platform, but this target supports 13.1 (in target 'BlueprintUILists' from project 'Listable')
```