### PR TITLE
[SPL] Associated cache

### DIFF
--- a/BlueprintUI/Sources/Element/ElementContent+SPL.swift
+++ b/BlueprintUI/Sources/Element/ElementContent+SPL.swift
@@ -39,11 +39,11 @@ extension ElementContent.Builder {
         
         let subviews = subviews(from: context.cache, environment: context.environment)
         
-        var phaseCache = context.cache.phaseCache(create: { layout.makeCache(subviews: subviews) })
+        var associatedCache = context.cache.associatedCache(create: { layout.makeCache(subviews: subviews) })
         
-        let size = layout.sizeThatFits(proposal: proposal, subviews: subviews, cache: &phaseCache)
+        let size = layout.sizeThatFits(proposal: proposal, subviews: subviews, cache: &associatedCache)
         
-        context.cache.set(phaseCache: phaseCache)
+        context.cache.set(associatedCache: associatedCache)
         
         return size
     }
@@ -56,16 +56,16 @@ extension ElementContent.Builder {
         let attributes = context.attributes
         let frame = context.attributes.frame
 
-        var phaseCache = context.cache.phaseCache(create: { layout.makeCache(subviews: subviews) })
+        var associatedCache = context.cache.associatedCache(create: { layout.makeCache(subviews: subviews) })
 
         layout.placeSubviews(
             in: frame,
             proposal: proposal,
             subviews: subviews,
-            cache: &phaseCache
+            cache: &associatedCache
         )
 
-        context.cache.set(phaseCache: phaseCache)
+        context.cache.set(associatedCache: associatedCache)
 
         let identifiedNodes: [IdentifiedNode] = children.indexedMap { index, child in
             let subview = subviews[index]

--- a/BlueprintUI/Sources/Element/ElementContent+SPL.swift
+++ b/BlueprintUI/Sources/Element/ElementContent+SPL.swift
@@ -12,6 +12,7 @@ extension ElementContent: Sizable {
 extension ElementContent.Builder {
     
     private func subviews(from cache: SPCacheNode, environment: Environment) -> LayoutSubviews {
+
         cache.layoutSubviews {
             var identifierFactory = ElementIdentifier.Factory(elementCount: children.count)
             return children.map { child in
@@ -37,7 +38,14 @@ extension ElementContent.Builder {
     func sizeThatFits(proposal: SizeConstraint, context: MeasureContext) -> CGSize {
         
         let subviews = subviews(from: context.cache, environment: context.environment)
-        return layout.sizeThatFits(proposal: proposal, subviews: subviews)
+        
+        var phaseCache = context.cache.phaseCache(create: { layout.makeCache(subviews: subviews) })
+        
+        let size = layout.sizeThatFits(proposal: proposal, subviews: subviews, cache: &phaseCache)
+        
+        context.cache.set(phaseCache: phaseCache)
+        
+        return size
     }
 
     func performSinglePassLayout(proposal: SizeConstraint, context: SPLayoutContext) -> [IdentifiedNode] {
@@ -48,11 +56,16 @@ extension ElementContent.Builder {
         let attributes = context.attributes
         let frame = context.attributes.frame
 
+        var phaseCache = context.cache.phaseCache(create: { layout.makeCache(subviews: subviews) })
+
         layout.placeSubviews(
             in: frame,
             proposal: proposal,
-            subviews: subviews
+            subviews: subviews,
+            cache: &phaseCache
         )
+
+        context.cache.set(phaseCache: phaseCache)
 
         let identifiedNodes: [IdentifiedNode] = children.indexedMap { index, child in
             let subview = subviews[index]

--- a/BlueprintUI/Sources/Element/ElementContent+StrictSPL.swift
+++ b/BlueprintUI/Sources/Element/ElementContent+StrictSPL.swift
@@ -266,11 +266,11 @@ class StrictLayoutNode: StrictLayoutable {
 //            fatalError("\(type(of: element)) layout called \(layoutCount) times")
         }
 
-//        var environment = environment
-//        if let debugElementPath = environment.debugElementPath, path.matches(expression: debugElementPath) {
-//            print("Debugging triggered for path \(path)")
-//            environment.debugElementPath = nil
-//        }
+        var environment = environment
+        if let debugElementPath = environment.debugElementPath, fullPath.matches(expression: debugElementPath) {
+            print("Debugging triggered for path \(fullPath)")
+            environment.debugElementPath = nil
+        }
 
         Logger.logMeasureStart(object: self, description: "\(fullPath)", constraint: proposedSize)
 
@@ -449,5 +449,11 @@ extension Environment {
     public var debugElementPath: String? {
         get { self[DebugElementPathKey.self] }
         set { self[DebugElementPathKey.self] = newValue }
+    }
+}
+
+extension Element {
+    public func debugPath(_ path: String) -> Element {
+        adaptedEnvironment(keyPath: \.debugElementPath, value: path)
     }
 }

--- a/BlueprintUI/Sources/Element/ElementContent+StrictSPL.swift
+++ b/BlueprintUI/Sources/Element/ElementContent+StrictSPL.swift
@@ -48,26 +48,29 @@ typealias LayoutResultChildren = [(identifier: ElementIdentifier, node: LayoutRe
 
 struct StrictSubtreeResult {
     var intermediate: StrictLayoutAttributes
-    var children: [StrictLayoutNode]
+    var children: [StrictProposalCaptureNode]
 
     func resolve() -> LayoutResultChildren {
         zip(intermediate.childPositions, children).map { position, node in
-            let subtreeResult = node.ensuredResult
+
+            let proposal = node.lastProposal!
+
+            let layoutNode = node.layoutNode
+            let subtreeResult = layoutNode.results[proposal]!
             let childSize = subtreeResult.intermediate.size
             let childFrame = CGRect(
                 origin: position,
                 size: childSize
             )
             let nodeAttributes = LayoutAttributes(frame: childFrame)
-
             let result = LayoutResultNode(
-                element: node.element,
+                element: layoutNode.element,
                 layoutAttributes: nodeAttributes,
-                environment: node.environment,
+                environment: layoutNode.environment,
                 children: subtreeResult.resolve()
             )
 
-            return (node.id, result)
+            return (layoutNode.id, result)
         }
     }
 
@@ -89,16 +92,22 @@ struct StrictSubtreeResult {
         }
 
         for (child, childPosition) in zip(children, intermediate.childPositions) {
-            child.ensuredResult.dump(
+            let proposal = child.lastProposal!
+            let result = child.layoutNode.results[proposal]!
+            result.dump(
                 depth: depth + 1,
-                id: "\(child.id)",
+                id: "\(child.layoutNode.id)",
                 position: childPosition,
-                context: child.context,
-                correction: child.correction
+                context: StrictLayoutContext(
+                    path: context.path.appending(identifier:  child.layoutNode.id),
+                    cache: child.layoutNode.cache,
+                    proposedSize: proposal.proposedSize,
+                    mode: proposal.proposedMode
+                ),
+                correction: child.layoutNode.correction
             )
         }
     }
-
 }
 
 public enum StrictPressureMode: Equatable, CustomStringConvertible {
@@ -114,7 +123,7 @@ public enum StrictPressureMode: Equatable, CustomStringConvertible {
 }
 
 /// SPL version of `LayoutAttributes`.
-public struct StrictLayoutAttributes {
+public struct StrictLayoutAttributes: Equatable {
     public var size: CGSize
     public var childPositions: [CGPoint]
 
@@ -126,6 +135,12 @@ public struct StrictLayoutAttributes {
     public init(size: CGSize, childPositions: [CGPoint] = []) {
         self.size = size
         self.childPositions = childPositions
+    }
+}
+
+extension CATransform3D: Equatable {
+    public static func == (lhs: CATransform3D, rhs: CATransform3D) -> Bool {
+        CATransform3DEqualToTransform(lhs, rhs)
     }
 }
 
@@ -176,13 +191,44 @@ public struct StrictNeutralLayout: SingleChildLayout {
 }
 
 
-class StrictLayoutNode: StrictLayoutable {
+class StrictProposalCaptureNode: StrictLayoutable {
+    let contextMode: AxisVarying<StrictPressureMode>
+    let layoutNode: StrictLayoutNode
+    
+    var lastProposal: StrictLayoutResultKey?
+    
+    init(
+        mode: AxisVarying<StrictPressureMode>,
+        layoutNode: StrictLayoutNode
+    ) {
+        self.contextMode = mode
+        self.layoutNode = layoutNode
+    }
+    
+    func layout(in proposedSize: SizeConstraint, options: StrictLayoutOptions) -> CGSize {
+        
+        let layoutMode = AxisVarying(
+            horizontal: options.mode.horizontal ?? contextMode.horizontal,
+            vertical: options.mode.vertical ?? contextMode.vertical
+        )
+
+        let proposal = StrictLayoutResultKey(
+            proposedSize: proposedSize,
+            proposedMode: layoutMode
+        )
+
+        lastProposal = proposal
+
+        return layoutNode.layout(in: proposedSize, mode: layoutMode)
+    }
+}
+
+class StrictLayoutNode {
     init(
         path: ElementPath,
         id: ElementIdentifier,
         element: Element,
         content: ElementContent,
-        mode: AxisVarying<StrictPressureMode>,
         environment: Environment,
         cache: StrictCacheNode
     ) {
@@ -190,7 +236,6 @@ class StrictLayoutNode: StrictLayoutable {
         self.id = id
         self.element = element
         self.content = content
-        self.mode = mode
         self.environment = environment
         self.cache = cache
 
@@ -201,54 +246,28 @@ class StrictLayoutNode: StrictLayoutable {
     var id: ElementIdentifier
     var element: Element
     var content: ElementContent
-    var mode: AxisVarying<StrictPressureMode>
     var environment: Environment
     var cache: StrictCacheNode
 
     var fullPath: ElementPath
 
-    // These values are initially unset, and captured when the child is laid out:
-    var layoutResult: StrictSubtreeResult?
-    var proposedSize: SizeConstraint?
-    var proposedMode: AxisVarying<StrictPressureMode>?
     var correction: CGSize = .zero
 
     var results: [LayoutResultKey: StrictSubtreeResult] = [:]
 
     private var layoutCount = 0
-
-    var ensuredResult: StrictSubtreeResult {
-        guard let layoutResult = layoutResult else {
-            fatalError("child was not laid out")
-        }
-        return layoutResult
+    
+    func result(in proposedSize: SizeConstraint, mode: AxisVarying<StrictPressureMode>) -> StrictSubtreeResult {
+        results[LayoutResultKey(proposedSize: proposedSize, proposedMode: mode)]!
     }
 
-    // saved proposed size, for debugging
-    var ensuredProposedSize: SizeConstraint {
-        guard let proposedSize = proposedSize else {
-            fatalError("child was not laid out")
-        }
-        return proposedSize
-    }
+    func layout(in proposedSize: SizeConstraint, mode: AxisVarying<StrictPressureMode>) -> CGSize {
 
-    // effective context, for debugging
-    var context: StrictLayoutContext {
-        StrictLayoutContext(path: path, cache: cache, proposedSize: ensuredProposedSize, mode: proposedMode!)
-    }
-
-    func layout(in proposedSize: SizeConstraint, options: StrictLayoutOptions) -> CGSize {
-
-        let layoutMode = AxisVarying(
-            horizontal: options.mode.horizontal ?? mode.horizontal,
-            vertical: options.mode.vertical ?? mode.vertical
-        )
+        let layoutMode = mode
 
         let resultKey = LayoutResultKey(proposedSize: proposedSize, proposedMode: layoutMode)
+
         if let layoutResult = results[resultKey] {
-            self.proposedSize = proposedSize
-            proposedMode = layoutMode
-            self.layoutResult = layoutResult
 
             Logger.logCacheHit(object: self, description: "\(fullPath)", constraint: proposedSize)
 
@@ -261,10 +280,10 @@ class StrictLayoutNode: StrictLayoutable {
         // multiple stacks will get hit (2 * stack depth) times. We can disable it entirely, or
         // try to track this some other way.
         layoutCount += 1
-        if layoutCount > options.maxAllowedLayoutCount {
+//        if layoutCount > options.maxAllowedLayoutCount {
 //            print("warning: \(path) layout called \(layoutCount) times")
 //            fatalError("\(type(of: element)) layout called \(layoutCount) times")
-        }
+//        }
 
         var environment = environment
         if let debugElementPath = environment.debugElementPath, fullPath.matches(expression: debugElementPath) {
@@ -304,10 +323,6 @@ class StrictLayoutNode: StrictLayoutable {
 
         Logger.logMeasureEnd(object: self)
 
-        self.proposedSize = proposedSize
-        proposedMode = layoutMode
-        self.layoutResult = layoutResult
-
         assert(
             layoutResult.intermediate.size.isFinite,
             "\(type(of: element)) layout size must be finite"
@@ -317,21 +332,35 @@ class StrictLayoutNode: StrictLayoutable {
             layoutResult.intermediate.childPositions.allSatisfy { $0.isFinite },
             "\(type(of: element)) child positions must be finite"
         )
+        
+        
 
         results[resultKey] = layoutResult
 
         return layoutResult.intermediate.size
     }
 
+    typealias LayoutResultKey = StrictLayoutResultKey
 
-    struct LayoutResultKey: Hashable {
-        var proposedSize: SizeConstraint
-        var proposedMode: AxisVarying<StrictPressureMode>
+    func dump(depth: Int = 0) {
+        let indent = String(repeating: "  ", count: depth)
+        
+        print("\(indent)- \(id)")
+//        print("\(indent)    \(context)")
+
+        for (resultKey, resultValue) in results {
+            print("\(indent)    * (\(resultKey.proposedMode), \(resultKey.proposedSize)): \(resultValue.intermediate.size)")
+            for child in resultValue.children {
+                child.layoutNode.dump(depth: depth + 1)
+            }
+        }
     }
-
 }
 
-
+struct StrictLayoutResultKey: Hashable {
+    var proposedSize: SizeConstraint
+    var proposedMode: AxisVarying<StrictPressureMode>
+}
 
 enum Unit: Hashable {
     case value
@@ -424,6 +453,12 @@ public struct AxisVarying<T> {
 }
 
 extension AxisVarying: Hashable, Equatable where T: Hashable {}
+
+extension AxisVarying: CustomStringConvertible {
+    public var description: String {
+        "\(horizontal)-\(vertical)"
+    }
+}
 
 extension CGFloat {
     var finiteValue: CGFloat? {

--- a/BlueprintUI/Sources/Element/ElementContent+StrictSPL.swift
+++ b/BlueprintUI/Sources/Element/ElementContent+StrictSPL.swift
@@ -48,26 +48,30 @@ typealias LayoutResultChildren = [(identifier: ElementIdentifier, node: LayoutRe
 
 struct StrictSubtreeResult {
     var intermediate: StrictLayoutAttributes
-    var children: [StrictLayoutNode]
+    var children: [StrictProposalCaptureNode]
 
+//    func resolve(in proposedSize: SizeConstraint, mode: AxisVarying<StrictPressureMode>) -> LayoutResultChildren {
     func resolve() -> LayoutResultChildren {
         zip(intermediate.childPositions, children).map { position, node in
-            let subtreeResult = node.ensuredResult
+
+            let proposal = node.proposals.last!
+
+            let layoutNode = node.layoutNode
+            let subtreeResult = layoutNode.results[proposal]!
             let childSize = subtreeResult.intermediate.size
             let childFrame = CGRect(
                 origin: position,
                 size: childSize
             )
             let nodeAttributes = LayoutAttributes(frame: childFrame)
-
             let result = LayoutResultNode(
-                element: node.element,
+                element: layoutNode.element,
                 layoutAttributes: nodeAttributes,
-                environment: node.environment,
-                children: subtreeResult.resolve()
+                environment: layoutNode.environment,
+                children: subtreeResult.resolve() //in: proposal.proposedSize, mode: proposal.proposedMode)
             )
 
-            return (node.id, result)
+            return (layoutNode.id, result)
         }
     }
 
@@ -89,16 +93,46 @@ struct StrictSubtreeResult {
         }
 
         for (child, childPosition) in zip(children, intermediate.childPositions) {
-            child.ensuredResult.dump(
-                depth: depth + 1,
-                id: "\(child.id)",
-                position: childPosition,
-                context: child.context,
-                correction: child.correction
-            )
+            // TODO: fix
+//            child.ensuredResult.dump(
+//                depth: depth + 1,
+//                id: "\(child.id)",
+//                position: childPosition,
+//                context: child.context,
+//                correction: child.correction
+//            )
         }
     }
-
+    
+//    func compare(to other: StrictSubtreeResult) -> Bool {
+//        guard intermediate == other.intermediate else {
+//            return false
+//        }
+//
+//        guard children.count == other.children.count else {
+//            return false
+//        }
+//
+//        for (child, otherChild) in zip(children, other.children) {
+//            guard
+//                (child.path == otherChild.path),
+//                (child.id == otherChild.id),
+//                ("\(child.element)" == "\(otherChild.element)"),
+//                ("\(child.content)" == "\(otherChild.content)"),
+//                (child.mode == otherChild.mode)
+//            else {
+//                return false
+//            }
+//
+//            let childResult = child.ensuredResult
+//            let otherResult = otherChild.ensuredResult
+//            if !childResult.compare(to: otherResult) {
+//                return false
+//            }
+//        }
+//
+//        return true
+//    }
 }
 
 public enum StrictPressureMode: Equatable, CustomStringConvertible {
@@ -114,7 +148,7 @@ public enum StrictPressureMode: Equatable, CustomStringConvertible {
 }
 
 /// SPL version of `LayoutAttributes`.
-public struct StrictLayoutAttributes {
+public struct StrictLayoutAttributes: Equatable {
     public var size: CGSize
     public var childPositions: [CGPoint]
 
@@ -126,6 +160,12 @@ public struct StrictLayoutAttributes {
     public init(size: CGSize, childPositions: [CGPoint] = []) {
         self.size = size
         self.childPositions = childPositions
+    }
+}
+
+extension CATransform3D: Equatable {
+    public static func == (lhs: CATransform3D, rhs: CATransform3D) -> Bool {
+        CATransform3DEqualToTransform(lhs, rhs)
     }
 }
 
@@ -176,13 +216,55 @@ public struct StrictNeutralLayout: SingleChildLayout {
 }
 
 
-class StrictLayoutNode: StrictLayoutable {
+class StrictProposalCaptureNode: StrictLayoutable {
+//    let contextSize: SizeConstraint
+    let contextMode: AxisVarying<StrictPressureMode>
+
+    let layoutNode: StrictLayoutNode
+    
+    // temp debugging tool
+    let description: String
+    
+    var proposals: [StrictLayoutResultKey] = []
+    
+    init(
+//        proposedSize: SizeConstraint,
+        mode: AxisVarying<StrictPressureMode>,
+        layoutNode: StrictLayoutNode,
+        description: String = ""
+    ) {
+//        self.contextSize = proposedSize
+        self.contextMode = mode
+        self.layoutNode = layoutNode
+        self.description = description
+    }
+    
+    func layout(in proposedSize: SizeConstraint, options: StrictLayoutOptions) -> CGSize {
+        
+        let layoutMode = AxisVarying(
+            horizontal: options.mode.horizontal ?? contextMode.horizontal,
+            vertical: options.mode.vertical ?? contextMode.vertical
+        )
+
+        let proposal = StrictLayoutResultKey(
+            proposedSize: proposedSize,
+            proposedMode: layoutMode
+        )
+
+//        print("\(description) captured \(proposal)")
+
+        self.proposals.append(proposal)
+
+        return layoutNode.layout(in: proposedSize, mode: layoutMode)
+    }
+}
+
+class StrictLayoutNode {
     init(
         path: ElementPath,
         id: ElementIdentifier,
         element: Element,
         content: ElementContent,
-        mode: AxisVarying<StrictPressureMode>,
         environment: Environment,
         cache: StrictCacheNode
     ) {
@@ -190,7 +272,6 @@ class StrictLayoutNode: StrictLayoutable {
         self.id = id
         self.element = element
         self.content = content
-        self.mode = mode
         self.environment = environment
         self.cache = cache
 
@@ -201,54 +282,57 @@ class StrictLayoutNode: StrictLayoutable {
     var id: ElementIdentifier
     var element: Element
     var content: ElementContent
-    var mode: AxisVarying<StrictPressureMode>
     var environment: Environment
     var cache: StrictCacheNode
 
     var fullPath: ElementPath
 
-    // These values are initially unset, and captured when the child is laid out:
-    var layoutResult: StrictSubtreeResult?
-    var proposedSize: SizeConstraint?
-    var proposedMode: AxisVarying<StrictPressureMode>?
     var correction: CGSize = .zero
 
     var results: [LayoutResultKey: StrictSubtreeResult] = [:]
 
     private var layoutCount = 0
 
-    var ensuredResult: StrictSubtreeResult {
-        guard let layoutResult = layoutResult else {
-            fatalError("child was not laid out")
-        }
-        return layoutResult
-    }
+//    var ensuredResult: StrictSubtreeResult {
+//        guard let resultKey, let layoutResult = results[resultKey] else {
+//            fatalError("child was not laid out")
+//        }
+//        return layoutResult
+//    }
 
     // saved proposed size, for debugging
-    var ensuredProposedSize: SizeConstraint {
-        guard let proposedSize = proposedSize else {
-            fatalError("child was not laid out")
-        }
-        return proposedSize
-    }
+//    var ensuredProposedSize: SizeConstraint {
+//        guard let proposedSize = resultKey?.proposedSize else {
+//            fatalError("child was not laid out")
+//        }
+//        return proposedSize
+//    }
+//
+//    var ensuredProposedMode: AxisVarying<StrictPressureMode> {
+//        resultKey!.proposedMode
+//    }
 
     // effective context, for debugging
-    var context: StrictLayoutContext {
-        StrictLayoutContext(path: path, cache: cache, proposedSize: ensuredProposedSize, mode: proposedMode!)
+//    var context: StrictLayoutContext {
+//        StrictLayoutContext(
+//            path: path,
+//            cache: cache,
+//            proposedSize: ensuredProposedSize,
+//            mode: ensuredProposedMode
+//        )
+//    }
+    
+    func result(in proposedSize: SizeConstraint, mode: AxisVarying<StrictPressureMode>) -> StrictSubtreeResult {
+        results[LayoutResultKey(proposedSize: proposedSize, proposedMode: mode)]!
     }
 
-    func layout(in proposedSize: SizeConstraint, options: StrictLayoutOptions) -> CGSize {
+    func layout(in proposedSize: SizeConstraint, mode: AxisVarying<StrictPressureMode>) -> CGSize {
 
-        let layoutMode = AxisVarying(
-            horizontal: options.mode.horizontal ?? mode.horizontal,
-            vertical: options.mode.vertical ?? mode.vertical
-        )
+        let layoutMode = mode
 
         let resultKey = LayoutResultKey(proposedSize: proposedSize, proposedMode: layoutMode)
+
         if let layoutResult = results[resultKey] {
-            self.proposedSize = proposedSize
-            proposedMode = layoutMode
-            self.layoutResult = layoutResult
 
             Logger.logCacheHit(object: self, description: "\(fullPath)", constraint: proposedSize)
 
@@ -261,10 +345,10 @@ class StrictLayoutNode: StrictLayoutable {
         // multiple stacks will get hit (2 * stack depth) times. We can disable it entirely, or
         // try to track this some other way.
         layoutCount += 1
-        if layoutCount > options.maxAllowedLayoutCount {
+//        if layoutCount > options.maxAllowedLayoutCount {
 //            print("warning: \(path) layout called \(layoutCount) times")
 //            fatalError("\(type(of: element)) layout called \(layoutCount) times")
-        }
+//        }
 
         var environment = environment
         if let debugElementPath = environment.debugElementPath, fullPath.matches(expression: debugElementPath) {
@@ -304,9 +388,11 @@ class StrictLayoutNode: StrictLayoutable {
 
         Logger.logMeasureEnd(object: self)
 
-        self.proposedSize = proposedSize
-        proposedMode = layoutMode
-        self.layoutResult = layoutResult
+//        if let cachedResult = results[resultKey] {
+//            assert(cachedResult.compare(to: layoutResult))
+//
+//            return cachedResult.intermediate.size
+//        }
 
         assert(
             layoutResult.intermediate.size.isFinite,
@@ -317,21 +403,35 @@ class StrictLayoutNode: StrictLayoutable {
             layoutResult.intermediate.childPositions.allSatisfy { $0.isFinite },
             "\(type(of: element)) child positions must be finite"
         )
+        
+        
 
         results[resultKey] = layoutResult
 
         return layoutResult.intermediate.size
     }
 
+    typealias LayoutResultKey = StrictLayoutResultKey
 
-    struct LayoutResultKey: Hashable {
-        var proposedSize: SizeConstraint
-        var proposedMode: AxisVarying<StrictPressureMode>
+    func dump(depth: Int = 0) {
+        let indent = String(repeating: "  ", count: depth)
+        
+        print("\(indent)- \(id)")
+//        print("\(indent)    \(context)")
+
+        for (resultKey, resultValue) in results {
+            print("\(indent)    * (\(resultKey.proposedMode), \(resultKey.proposedSize)): \(resultValue.intermediate.size)")
+            for child in resultValue.children {
+                child.layoutNode.dump(depth: depth + 1)
+            }
+        }
     }
-
 }
 
-
+struct StrictLayoutResultKey: Hashable {
+    var proposedSize: SizeConstraint
+    var proposedMode: AxisVarying<StrictPressureMode>
+}
 
 enum Unit: Hashable {
     case value
@@ -424,6 +524,12 @@ public struct AxisVarying<T> {
 }
 
 extension AxisVarying: Hashable, Equatable where T: Hashable {}
+
+extension AxisVarying: CustomStringConvertible {
+    public var description: String {
+        "\(horizontal)-\(vertical)"
+    }
+}
 
 extension CGFloat {
     var finiteValue: CGFloat? {

--- a/BlueprintUI/Sources/Element/ElementContent+StrictSPL.swift
+++ b/BlueprintUI/Sources/Element/ElementContent+StrictSPL.swift
@@ -176,11 +176,11 @@ public struct StrictNeutralLayout: SingleChildLayout {
         LayoutAttributes(size: size)
     }
 
-    public func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview) -> CGSize {
+    public func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview, cache: inout Void) -> CGSize {
         subview.sizeThatFits(proposal)
     }
 
-    public func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview) {}
+    public func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview, cache: inout Void) {}
 
     public func layout(in context: StrictLayoutContext, child: StrictLayoutable) -> StrictLayoutAttributes {
         StrictLayoutAttributes(

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -630,7 +630,7 @@ private struct MeasurableStorage: ContentStorage {
 extension ElementContent.Builder {
 
     enum NodesEntry: StrictCacheTreeEntry {
-        typealias Value = ([StrictLayoutNode], [(traits: LayoutType.Traits, layoutable: StrictLayoutable)])
+        typealias Value = [StrictLayoutNode]
     }
 
     func strictLayout(
@@ -638,14 +638,11 @@ extension ElementContent.Builder {
         environment: Environment
     ) -> StrictSubtreeResult {
 
-        // TODO: fix caching
-        let (nodes, layoutChildren) = { // } context.cache.get(entryType: NodesEntry.self) {
+        func makeNodes() -> [StrictLayoutNode] {
             var identifierFactory = ElementIdentifier.Factory(elementCount: childCount)
             var nodes: [StrictLayoutNode] = []
             nodes.reserveCapacity(children.count)
 
-            var layoutChildren: [(traits: LayoutType.Traits, layoutable: StrictLayoutable)] = []
-            layoutChildren.reserveCapacity(children.count)
 
             for index in 0..<children.count {
                 let child = children[index]
@@ -657,22 +654,46 @@ extension ElementContent.Builder {
                     id: id,
                     element: childElement,
                     content: childElement.content,
-                    mode: context.mode,
                     environment: environment,
                     cache: context.cache.subcache(key: index)
                 )
 
                 nodes.append(node)
-                layoutChildren.append((traits: child.traits, layoutable: node))
             }
 
-            return (nodes, layoutChildren)
-        }()
+            return nodes
+        }
+        
+        let layoutNodes = context.cache.get(entryType: NodesEntry.self, or: makeNodes)
+        
+        func makeProposalCaptureNodes() -> [StrictProposalCaptureNode] {
+            var nodes: [StrictProposalCaptureNode] = []
+            nodes.reserveCapacity(children.count)
 
-        // Update mode on cached node
-//        for node in nodes {
-//            node.mode = context.mode
-//        }
+            for index in 0..<children.count {
+                let layoutNode = layoutNodes[index]
+                let node = StrictProposalCaptureNode(
+                    mode: context.mode,
+                    layoutNode: layoutNode
+                )
+                nodes.append(node)
+            }
+            
+            return nodes
+        }
+        
+        let nodes = makeProposalCaptureNodes()
+        
+        var layoutChildren: [(traits: LayoutType.Traits, layoutable: StrictLayoutable)] = []
+        layoutChildren.reserveCapacity(children.count)
+
+        for index in (0..<childCount) {
+            let node = nodes[index]
+
+            let traits = children[index].traits
+            let layoutable = node
+            layoutChildren.append((traits, layoutable))
+        }
 
         let intermediateResult = layout.layout(
             in: context,
@@ -696,15 +717,15 @@ extension EnvironmentAdaptingStorage {
         let identifier = ElementIdentifier(elementType: type(of: child), key: nil, count: 1)
         let cache = context.cache.subcache(key: 0)
 
-        let node = StrictLayoutNode(
+        let layoutNode = StrictLayoutNode(
             path: context.path,
             id: identifier,
             element: child,
             content: child.content,
-            mode: context.mode,
             environment: environment,
             cache: cache
         )
+        let node = StrictProposalCaptureNode(mode: context.mode, layoutNode: layoutNode)
 
         return StrictSubtreeResult(
             intermediate: NeutralLayout().layout(in: context, child: node),
@@ -726,15 +747,15 @@ extension LazyStorage {
         let identifier = ElementIdentifier(elementType: type(of: child), key: nil, count: 1)
         let cache = context.cache.subcache(key: 0)
 
-        let node = StrictLayoutNode(
+        let layoutNode = StrictLayoutNode(
             path: context.path,
             id: identifier,
             element: child,
             content: child.content,
-            mode: context.mode,
             environment: environment,
             cache: cache
         )
+        let node = StrictProposalCaptureNode(mode: context.mode, layoutNode: layoutNode)
 
         return StrictSubtreeResult(
             intermediate: NeutralLayout().layout(in: context, child: node),

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -154,10 +154,10 @@ extension ElementContent {
     /// - parameter element: The single child element.
     /// - parameter key: The key to use to unique the element during updates.
     /// - parameter layout: The layout that will be used.
-    public init(
+    public init<LayoutType: SingleChildLayout>(
         child: Element,
         key: AnyHashable? = nil,
-        layout: SingleChildLayout
+        layout: LayoutType
     ) {
         self = ElementContent(layout: SingleChildLayoutHost(wrapping: layout)) {
             $0.add(key: key, element: child)
@@ -782,11 +782,13 @@ extension MeasurableStorage {
 
 // All layout is ultimately performed by the `Layout` protocol – this implementations delegates to a wrapped
 // `SingleChildLayout` implementation for use in elements with a single child.
-fileprivate struct SingleChildLayoutHost: Layout, StrictLayout {
+fileprivate struct SingleChildLayoutHost<LayoutType: SingleChildLayout>: Layout, StrictLayout {
 
-    private var wrapped: SingleChildLayout
+    typealias Cache = LayoutType.Cache
 
-    init(wrapping layout: SingleChildLayout) {
+    private var wrapped: LayoutType
+
+    init(wrapping layout: LayoutType) {
         wrapped = layout
     }
 
@@ -802,14 +804,19 @@ fileprivate struct SingleChildLayoutHost: Layout, StrictLayout {
         ]
     }
 
-    func sizeThatFits(proposal: SizeConstraint, subviews: Subviews) -> CGSize {
+    func sizeThatFits(proposal: SizeConstraint, subviews: Subviews, cache: inout Cache) -> CGSize {
         precondition(subviews.count == 1)
-        return wrapped.sizeThatFits(proposal: proposal, subview: subviews[0])
+
+        return wrapped.sizeThatFits(proposal: proposal, subview: subviews[0], cache: &cache)
     }
 
-    func placeSubviews(in bounds: CGRect, proposal: SizeConstraint, subviews: Subviews) {
+    func placeSubviews(in bounds: CGRect, proposal: SizeConstraint, subviews: Subviews, cache: inout Cache) {
         precondition(subviews.count == 1)
-        return wrapped.placeSubview(in: bounds, proposal: proposal, subview: subviews[0])
+        return wrapped.placeSubview(in: bounds, proposal: proposal, subview: subviews[0], cache: &cache)
+    }
+
+    func makeCache(subviews: Subviews) -> LayoutType.Cache {
+        wrapped.makeCache(subview: subviews[0])
     }
 
     func layout(in context: StrictLayoutContext, children: [StrictLayoutChild]) -> StrictLayoutAttributes {

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -638,7 +638,8 @@ extension ElementContent.Builder {
         environment: Environment
     ) -> StrictSubtreeResult {
 
-        let (nodes, layoutChildren) = context.cache.get(entryType: NodesEntry.self) {
+        // TODO: fix caching
+        let (nodes, layoutChildren) = { // } context.cache.get(entryType: NodesEntry.self) {
             var identifierFactory = ElementIdentifier.Factory(elementCount: childCount)
             var nodes: [StrictLayoutNode] = []
             nodes.reserveCapacity(children.count)
@@ -666,7 +667,12 @@ extension ElementContent.Builder {
             }
 
             return (nodes, layoutChildren)
-        }
+        }()
+
+        // Update mode on cached node
+//        for node in nodes {
+//            node.mode = context.mode
+//        }
 
         let intermediateResult = layout.layout(
             in: context,

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -630,7 +630,7 @@ private struct MeasurableStorage: ContentStorage {
 extension ElementContent.Builder {
 
     enum NodesEntry: StrictCacheTreeEntry {
-        typealias Value = [StrictLayoutNode]
+        typealias Value = ([StrictLayoutNode], [(traits: LayoutType.Traits, layoutable: StrictLayoutable)])
     }
 
     func strictLayout(
@@ -638,11 +638,14 @@ extension ElementContent.Builder {
         environment: Environment
     ) -> StrictSubtreeResult {
 
-        func makeNodes() -> [StrictLayoutNode] {
+        // TODO: fix caching
+        let (nodes, layoutChildren) = { // } context.cache.get(entryType: NodesEntry.self) {
             var identifierFactory = ElementIdentifier.Factory(elementCount: childCount)
             var nodes: [StrictLayoutNode] = []
             nodes.reserveCapacity(children.count)
 
+            var layoutChildren: [(traits: LayoutType.Traits, layoutable: StrictLayoutable)] = []
+            layoutChildren.reserveCapacity(children.count)
 
             for index in 0..<children.count {
                 let child = children[index]
@@ -654,45 +657,21 @@ extension ElementContent.Builder {
                     id: id,
                     element: childElement,
                     content: childElement.content,
-//                    mode: context.mode,
+                    mode: context.mode,
                     environment: environment,
                     cache: context.cache.subcache(key: index)
                 )
 
                 nodes.append(node)
+                layoutChildren.append((traits: child.traits, layoutable: node))
             }
 
-            return nodes
-        }
-        
-//        let layoutNodes = context.cache.get(entryType: NodesEntry.self, or: makeNodes)
-        let layoutNodes = makeNodes()
-        
-        var layoutChildren: [(traits: LayoutType.Traits, layoutable: StrictLayoutable)] = []
-        layoutChildren.reserveCapacity(children.count)
-        
-        var nodes: [StrictProposalCaptureNode] = []
-        nodes.reserveCapacity(children.count)
+            return (nodes, layoutChildren)
+        }()
 
-        for index in 0..<children.count {
-            let traits = children[index].traits
-            let layoutNode = layoutNodes[index]
-            let node = StrictProposalCaptureNode(
-                mode: context.mode,
-                layoutNode: layoutNode,
-                description: "\(layoutNode.id)"
-            )
-
-            layoutChildren.append((traits, node))
-            nodes.append(node)
-        }
-
-//        for (cachedNode, newNode) in zip(cachedNodes, newNodes) {
-//            assert(cachedNode.path == newNode.path)
-//            assert(cachedNode.id == newNode.id)
-//            assert("\(cachedNode.element)" == "\(newNode.element)")
-//            assert("\(cachedNode.content)" == "\(newNode.content)")
-////            assert(cachedNode.mode == newNode.mode)
+        // Update mode on cached node
+//        for node in nodes {
+//            node.mode = context.mode
 //        }
 
         let intermediateResult = layout.layout(
@@ -717,16 +696,15 @@ extension EnvironmentAdaptingStorage {
         let identifier = ElementIdentifier(elementType: type(of: child), key: nil, count: 1)
         let cache = context.cache.subcache(key: 0)
 
-        let layoutNode = StrictLayoutNode(
+        let node = StrictLayoutNode(
             path: context.path,
             id: identifier,
             element: child,
             content: child.content,
-//            mode: context.mode,
+            mode: context.mode,
             environment: environment,
             cache: cache
         )
-        let node = StrictProposalCaptureNode(mode: context.mode, layoutNode: layoutNode)
 
         return StrictSubtreeResult(
             intermediate: NeutralLayout().layout(in: context, child: node),
@@ -748,16 +726,15 @@ extension LazyStorage {
         let identifier = ElementIdentifier(elementType: type(of: child), key: nil, count: 1)
         let cache = context.cache.subcache(key: 0)
 
-        let layoutNode = StrictLayoutNode(
+        let node = StrictLayoutNode(
             path: context.path,
             id: identifier,
             element: child,
             content: child.content,
-//            mode: context.mode,
+            mode: context.mode,
             environment: environment,
             cache: cache
         )
-        let node = StrictProposalCaptureNode(mode: context.mode, layoutNode: layoutNode)
 
         return StrictSubtreeResult(
             intermediate: NeutralLayout().layout(in: context, child: node),

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -65,10 +65,14 @@ extension Element {
             environment: environment
         )
 
-        subtree.dump(id: "\(type(of: self))", position: .zero, context: context, correction: .zero)
+//        subtree.dump(id: "\(type(of: self))", position: .zero, context: context, correction: .zero)
 
-        let children = subtree
-            .resolve()
+//        print("StrictLayoutNode dump")
+//        for child in subtree.children {
+//            child.dump()
+//        }
+
+        let children = subtree.resolve() //in: context.proposedSize, mode: context.mode)
 
         let root = LayoutResultNode(
             element: self,

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -65,7 +65,7 @@ extension Element {
             environment: environment
         )
 
-//        subtree.dump(id: "\(type(of: self))", position: .zero, context: context, correction: .zero)
+        subtree.dump(id: "\(type(of: self))", position: .zero, context: context, correction: .zero)
 
         let children = subtree
             .resolve()

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -65,7 +65,7 @@ extension Element {
             environment: environment
         )
 
-        subtree.dump(id: "\(type(of: self))", position: .zero, context: context, correction: .zero)
+//        subtree.dump(id: "\(type(of: self))", position: .zero, context: context, correction: .zero)
 
         let children = subtree
             .resolve()

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -67,8 +67,7 @@ extension Element {
 
 //        subtree.dump(id: "\(type(of: self))", position: .zero, context: context, correction: .zero)
 
-        let children = subtree
-            .resolve()
+        let children = subtree.resolve()
 
         let root = LayoutResultNode(
             element: self,

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -65,14 +65,10 @@ extension Element {
             environment: environment
         )
 
-//        subtree.dump(id: "\(type(of: self))", position: .zero, context: context, correction: .zero)
+        subtree.dump(id: "\(type(of: self))", position: .zero, context: context, correction: .zero)
 
-//        print("StrictLayoutNode dump")
-//        for child in subtree.children {
-//            child.dump()
-//        }
-
-        let children = subtree.resolve() //in: context.proposedSize, mode: context.mode)
+        let children = subtree
+            .resolve()
 
         let root = LayoutResultNode(
             element: self,

--- a/BlueprintUI/Sources/Internal/PassthroughLayout.swift
+++ b/BlueprintUI/Sources/Internal/PassthroughLayout.swift
@@ -11,11 +11,11 @@ struct PassthroughLayout: SingleChildLayout {
         LayoutAttributes(size: size)
     }
 
-    func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview) -> CGSize {
+    func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview, cache: inout Cache) -> CGSize {
         subview.sizeThatFits(proposal)
     }
 
-    func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview) {
+    func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview, cache: inout ()) {
         subview.place(at: bounds)
     }
     

--- a/BlueprintUI/Sources/Internal/SPL/SPCacheTree.swift
+++ b/BlueprintUI/Sources/Internal/SPL/SPCacheTree.swift
@@ -3,19 +3,23 @@ import Foundation
 
 
 final class SPCacheTree<Key, Value, SubcacheKey> where Key: Hashable, SubcacheKey: Hashable {
-
+    
     typealias Subcache = SPCacheTree<Key, Value, SubcacheKey>
-
+    
     var valueCache: SPValueCache<Key, Value>
     private var subcaches: [SubcacheKey: Subcache] = [:]
-
+    
     var path: String
-
+    
+    private var layoutSubviews: [LayoutSubview]?
+    
+    private var _phaseCache: Any?
+    
     init(path: String) {
         self.path = path
         valueCache = .init(path: path)
     }
-
+    
     func subcache(key: SubcacheKey) -> Subcache {
         if let subcache = subcaches[key] {
             return subcache
@@ -25,9 +29,6 @@ final class SPCacheTree<Key, Value, SubcacheKey> where Key: Hashable, SubcacheKe
         return subcache
     }
     
-    var layoutSubviews: [LayoutSubview]?
-    
-    // TODO: generalize hanging anything off this cache
     func layoutSubviews(create: () -> [LayoutSubview]) -> [LayoutSubview] {
         if let layoutSubviews = layoutSubviews {
             return layoutSubviews
@@ -36,6 +37,22 @@ final class SPCacheTree<Key, Value, SubcacheKey> where Key: Hashable, SubcacheKe
         self.layoutSubviews = layoutSubviews
         return layoutSubviews
     }
+    
+    // TODO: Generalize using a EnvironmentKey system for better type safety?
+    func phaseCache<PhaseCache>(create: () -> PhaseCache) -> PhaseCache {
+        if let phaseCache = _phaseCache as? PhaseCache {
+            return phaseCache
+        }
+        
+        let phaseCache = create()
+        _phaseCache = phaseCache
+        return phaseCache
+    }
+
+    func `set`<PhaseCache>(phaseCache: PhaseCache) {
+        _phaseCache = phaseCache
+    }
+
 }
 
 extension SPCacheTree where Key == SizeConstraint {

--- a/BlueprintUI/Sources/Internal/SPL/SPCacheTree.swift
+++ b/BlueprintUI/Sources/Internal/SPL/SPCacheTree.swift
@@ -13,7 +13,7 @@ final class SPCacheTree<Key, Value, SubcacheKey> where Key: Hashable, SubcacheKe
     
     private var layoutSubviews: [LayoutSubview]?
     
-    private var _phaseCache: Any?
+    private var _associatedCache: Any?
     
     init(path: String) {
         self.path = path
@@ -39,18 +39,18 @@ final class SPCacheTree<Key, Value, SubcacheKey> where Key: Hashable, SubcacheKe
     }
     
     // TODO: Generalize using a EnvironmentKey system for better type safety?
-    func phaseCache<PhaseCache>(create: () -> PhaseCache) -> PhaseCache {
-        if let phaseCache = _phaseCache as? PhaseCache {
-            return phaseCache
+    func associatedCache<AssociatedCache>(create: () -> AssociatedCache) -> AssociatedCache {
+        if let associatedCache = _associatedCache as? AssociatedCache {
+            return associatedCache
         }
         
-        let phaseCache = create()
-        _phaseCache = phaseCache
-        return phaseCache
+        let associatedCache = create()
+        _associatedCache = associatedCache
+        return associatedCache
     }
 
-    func `set`<PhaseCache>(phaseCache: PhaseCache) {
-        _phaseCache = phaseCache
+    func `set`<AssociatedCache>(associatedCache: AssociatedCache) {
+        _associatedCache = associatedCache
     }
 
 }

--- a/BlueprintUI/Sources/Layout/Aligned.swift
+++ b/BlueprintUI/Sources/Layout/Aligned.swift
@@ -132,11 +132,11 @@ public struct Aligned: Element {
             return attributes
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview) -> CGSize {
+        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview, cache: inout Cache) -> CGSize {
             subview.sizeThatFits(proposal)
         }
 
-        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview) {
+        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview, cache: inout ()) {
             let x: CGFloat
             let y: CGFloat
 

--- a/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
@@ -159,7 +159,7 @@ public struct ConstrainedAspectRatio: Element {
             LayoutAttributes(size: size)
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview) -> CGSize {
+        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview, cache: inout Cache) -> CGSize {
             let contentSize = subview.sizeThatFits(proposal)
             return contentMode.constrain(
                 contentSize: contentSize,
@@ -168,7 +168,7 @@ public struct ConstrainedAspectRatio: Element {
             )
         }
 
-        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview) {
+        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview, cache: inout ()) {
             subview.place(at: bounds)
         }
         

--- a/BlueprintUI/Sources/Layout/ConstrainedSize.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedSize.swift
@@ -188,7 +188,7 @@ extension ConstrainedSize {
             LayoutAttributes(size: size)
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview) -> CGSize {
+        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview, cache: inout Cache) -> CGSize {
             if case let .absolute(width) = width, case let .absolute(height) = height {
                 return CGSize(width: width, height: height)
             }
@@ -206,7 +206,7 @@ extension ConstrainedSize {
             )
         }
 
-        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview) {
+        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview, cache: inout ()) {
             subview.place(at: bounds)
         }
 

--- a/BlueprintUI/Sources/Layout/EqualStack.swift
+++ b/BlueprintUI/Sources/Layout/EqualStack.swift
@@ -153,7 +153,7 @@ extension EqualStack {
             return result
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subviews: Subviews) -> CGSize {
+        func sizeThatFits(proposal: SizeConstraint, subviews: Subviews, cache: inout Cache) -> CGSize {
             guard subviews.count > 0 else { return .zero }
 
             let totalSpacing = (spacing * CGFloat(subviews.count - 1))
@@ -192,7 +192,7 @@ extension EqualStack {
             return totalSize
         }
 
-        func placeSubviews(in bounds: CGRect, proposal: SizeConstraint, subviews: Subviews) {
+        func placeSubviews(in bounds: CGRect, proposal: SizeConstraint, subviews: Subviews, cache: inout ()) {
             guard subviews.count > 0 else { return }
             let size = bounds.size
 

--- a/BlueprintUI/Sources/Layout/EqualStack.swift
+++ b/BlueprintUI/Sources/Layout/EqualStack.swift
@@ -223,53 +223,42 @@ extension EqualStack {
                 subview.place(at: origin, size: itemSize)
             }
         }
-        
+
         func layout(in context: StrictLayoutContext, children: [StrictLayoutChild]) -> StrictLayoutAttributes {
             guard !children.isEmpty else { return .init(size: .zero) }
-            
-            let totalSpacing = (spacing * CGFloat(children.count - 1))
-            
-            let itemProposal: SizeConstraint
 
-            if context.mode.horizontal == .fill {
-                print("fill")
-            }
+            let totalSpacing = (spacing * CGFloat(children.count - 1))
+
+            let itemProposal: SizeConstraint
 
             switch direction {
             case .horizontal:
                 let width: SizeConstraint.Axis
-                if
-//                    context.mode.horizontal == .fill,
-                    let proposedWidth = context.proposedSize.width.constrainedValue
-                {
+                if let proposedWidth = context.proposedSize.width.constrainedValue {
                     width = .atMost((proposedWidth - totalSpacing) / CGFloat(children.count))
                 } else {
                     width = .unconstrained
                 }
-                
 
                 itemProposal = SizeConstraint(
                     width: width,
                     height: context.proposedSize.height
                 )
-                
+
             case .vertical:
                 let height: SizeConstraint.Axis
-                if
-//                    context.mode.vertical == .fill,
-                    let proposedHeight = context.proposedSize.height.constrainedValue
-                {
+                if let proposedHeight = context.proposedSize.height.constrainedValue {
                     height = .atMost((proposedHeight - totalSpacing) / CGFloat(children.count))
                 } else {
                     height = .unconstrained
                 }
-                
+
                 itemProposal = SizeConstraint(
                     width: context.proposedSize.width,
                     height: height
                 )
             }
-            
+
             let options: StrictLayoutOptions
             switch direction {
             case .horizontal:
@@ -287,27 +276,26 @@ extension EqualStack {
                     )
                 )
             }
-            
+
             let childSizes = children.map { (traits: Void, layoutable: StrictLayoutable) in
                 layoutable.layout(
                     in: itemProposal,
                     options: options
                 )
             }
-            
+
             let childWidth = (context.mode.horizontal == .fill ? itemProposal.width.constrainedValue : nil)
-//            let childWidth = itemProposal.width.constrainedValue
                 ?? childSizes.map(\.width).max()
                 ?? 0
-            let childHeight = (context.mode.vertical == .fill ?  itemProposal.height.constrainedValue : nil)
+            let childHeight = (context.mode.vertical == .fill ? itemProposal.height.constrainedValue : nil)
                 ?? childSizes.map(\.height).max()
                 ?? 0
-            
+
             let itemSize = CGSize(
                 width: childWidth,
                 height: childHeight
             )
-            
+
             for child in children {
                 _ = child.layoutable.layout(
                     in: SizeConstraint(itemSize),
@@ -331,7 +319,7 @@ extension EqualStack {
                     height: itemSize.height * CGFloat(children.count) + totalSpacing
                 )
             }
-            
+
             let childPositions = (0..<children.count).map { index in
                 switch direction {
                 case .horizontal:

--- a/BlueprintUI/Sources/Layout/EqualStack.swift
+++ b/BlueprintUI/Sources/Layout/EqualStack.swift
@@ -307,6 +307,16 @@ extension EqualStack {
                 width: childWidth,
                 height: childHeight
             )
+            
+            for child in children {
+                _ = child.layoutable.layout(
+                    in: SizeConstraint(itemSize),
+                    options: StrictLayoutOptions(
+                        maxAllowedLayoutCount: 2,
+                        mode: .init(horizontal: .fill, vertical: .fill)
+                    )
+                )
+            }
 
             let totalSize: CGSize
             switch direction {

--- a/BlueprintUI/Sources/Layout/GridRow.swift
+++ b/BlueprintUI/Sources/Layout/GridRow.swift
@@ -130,7 +130,7 @@ extension GridRow {
             }
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subviews: Subviews) -> CGSize {
+        func sizeThatFits(proposal: SizeConstraint, subviews: Subviews, cache: inout Cache) -> CGSize {
             guard subviews.count > 0 else {
                 return .zero
             }
@@ -147,7 +147,7 @@ extension GridRow {
             return size
         }
 
-        func placeSubviews(in bounds: CGRect, proposal: SizeConstraint, subviews: Subviews) {
+        func placeSubviews(in bounds: CGRect, proposal: SizeConstraint, subviews: Subviews, cache: inout ()) {
             guard subviews.count > 0 else {
                 return
             }

--- a/BlueprintUI/Sources/Layout/Hidden.swift
+++ b/BlueprintUI/Sources/Layout/Hidden.swift
@@ -34,11 +34,11 @@ public struct Hidden: Element {
             return attributes
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview) -> CGSize {
+        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview, cache: inout Cache) -> CGSize {
             subview.sizeThatFits(proposal)
         }
 
-        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview) {
+        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview, cache: inout ()) {
             subview.attributes.isHidden = isHidden
         }
 

--- a/BlueprintUI/Sources/Layout/Inset.swift
+++ b/BlueprintUI/Sources/Layout/Inset.swift
@@ -159,13 +159,13 @@ extension Inset {
             return LayoutAttributes(frame: frame)
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview) -> CGSize {
+        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview, cache: inout ()) -> CGSize {
             let insetProposal = proposal.inset(by: edgeInsets)
             let childSize = subview.sizeThatFits(insetProposal)
             return childSize + CGSize(width: left + right, height: top + bottom)
         }
 
-        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview) {
+        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview, cache: inout ()) {
             let insetSize = bounds.size.inset(by: edgeInsets)
 
             subview.place(

--- a/BlueprintUI/Sources/Layout/Keyed.swift
+++ b/BlueprintUI/Sources/Layout/Keyed.swift
@@ -70,11 +70,11 @@ public struct Keyed: Element {
             LayoutAttributes(size: size)
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview) -> CGSize {
+        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview, cache: inout Cache) -> CGSize {
             subview.sizeThatFits(proposal)
         }
 
-        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview) {
+        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview, cache: inout ()) {
             subview.place(at: bounds)
         }
         

--- a/BlueprintUI/Sources/Layout/LayoutWriter.swift
+++ b/BlueprintUI/Sources/Layout/LayoutWriter.swift
@@ -273,11 +273,11 @@ extension LayoutWriter {
                 }
             }
 
-            func sizeThatFits(proposal: SizeConstraint, subviews: Subviews) -> CGSize {
+            func sizeThatFits(proposal: SizeConstraint, subviews: Subviews, cache: inout Cache) -> CGSize {
                 builder.sizing.measure(with: builder)
             }
 
-            func placeSubviews(in bounds: CGRect, proposal: SizeConstraint, subviews: Subviews) {
+            func placeSubviews(in bounds: CGRect, proposal: SizeConstraint, subviews: Subviews, cache: inout ()) {
                 for (child, subview) in zip(builder.children, subviews) {
                     subview.place(
                         at: bounds.origin + child.frame.origin,

--- a/BlueprintUI/Sources/Layout/Opacity.swift
+++ b/BlueprintUI/Sources/Layout/Opacity.swift
@@ -43,11 +43,11 @@ public struct Opacity: Element {
             return attributes
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview) -> CGSize {
+        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview, cache: inout ()) -> CGSize {
             subview.sizeThatFits(proposal)
         }
 
-        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview) {
+        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview, cache: inout ()) {
             subview.attributes.alpha = opacity
         }
         

--- a/BlueprintUI/Sources/Layout/Overlay.swift
+++ b/BlueprintUI/Sources/Layout/Overlay.swift
@@ -78,7 +78,7 @@ fileprivate struct OverlayLayout: Layout, StrictLayout {
         )
     }
 
-    func sizeThatFits(proposal: SizeConstraint, subviews: Subviews) -> CGSize {
+    func sizeThatFits(proposal: SizeConstraint, subviews: Subviews, cache: inout Cache) -> CGSize {
         subviews.reduce(into: CGSize.zero) { result, subview in
             let measuredSize = subview.sizeThatFits(proposal)
             result.width = max(result.width, measuredSize.width)
@@ -86,7 +86,7 @@ fileprivate struct OverlayLayout: Layout, StrictLayout {
         }
     }
 
-    func placeSubviews(in bounds: CGRect, proposal: SizeConstraint, subviews: Subviews) {
+    func placeSubviews(in bounds: CGRect, proposal: SizeConstraint, subviews: Subviews, cache: inout ()) {
         for subview in subviews {
             subview.place(at: bounds)
         }

--- a/BlueprintUI/Sources/Layout/SPL/SPLayout.swift
+++ b/BlueprintUI/Sources/Layout/SPL/SPLayout.swift
@@ -6,14 +6,26 @@ public protocol SPLayout {
 
     typealias Subviews = LayoutSubviews
 
+    associatedtype Cache = Void
+
     func sizeThatFits(
         proposal: SizeConstraint,
-        subviews: Subviews
+        subviews: Subviews,
+        cache: inout Self.Cache
     ) -> CGSize
 
     func placeSubviews(
         in bounds: CGRect,
         proposal: SizeConstraint,
-        subviews: Subviews
+        subviews: Subviews,
+        cache: inout Self.Cache
     )
+
+    func makeCache(subviews: Subviews) -> Cache
+}
+
+
+extension SPLayout where Cache == Void {
+
+    public func makeCache(subviews: Subviews) { () }
 }

--- a/BlueprintUI/Sources/Layout/SPL/SPSingleChildLayout.swift
+++ b/BlueprintUI/Sources/Layout/SPL/SPSingleChildLayout.swift
@@ -4,7 +4,17 @@ import Foundation
 
 public protocol SPSingleChildLayout {
 
-    func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview) -> CGSize
+    associatedtype Cache = Void
 
-    func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview)
+    func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview, cache: inout Cache) -> CGSize
+
+    func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview, cache: inout Cache)
+
+    func makeCache(subview: LayoutSubview) -> Cache
+}
+
+
+extension SPSingleChildLayout where Cache == Void {
+
+    public func makeCache(subview: LayoutSubview) { () }
 }

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -1016,6 +1016,31 @@ extension StackLayout {
         let crossItems = items(axisPressure: nil)
 
         let frames = _frames(axisItems: axisItems, crossItems: crossItems, in: vectorConstraint)
+        
+        let crossPressure: StrictPressureMode = {
+            switch axis {
+            case .horizontal:
+                return context.mode.vertical
+            case .vertical:
+                return context.mode.horizontal
+            }
+        }()
+        
+        switch (alignment, crossPressure) {
+        case (.fill, .natural):
+            for (child, frame) in zip(children, frames) {
+                let sizeConstraint = SizeConstraint(frame.size.size(axis: axis))
+                _ = child.layoutable.layout(
+                    in: sizeConstraint,
+                    options: .init(
+                        mode: .init(horizontal: .fill, vertical: .fill)
+                    )
+                )
+            }
+            
+        default: break
+        }
+        
 
         let vector = frames.reduce(Vector.zero) { vector, frame -> Vector in
             Vector(

--- a/BlueprintUI/Sources/Layout/Transformed.swift
+++ b/BlueprintUI/Sources/Layout/Transformed.swift
@@ -57,11 +57,11 @@ public struct Transformed: Element {
             return attributes
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview) -> CGSize {
+        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview, cache: inout Cache) -> CGSize {
             subview.sizeThatFits(proposal)
         }
 
-        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview) {
+        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview, cache: inout ()) {
             subview.attributes.transform = transform
         }
         

--- a/BlueprintUI/Sources/Layout/UserInteractionEnabled.swift
+++ b/BlueprintUI/Sources/Layout/UserInteractionEnabled.swift
@@ -33,11 +33,11 @@ public struct UserInteractionEnabled: Element {
             return attributes
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview) -> CGSize {
+        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview, cache: inout Cache) -> CGSize {
             subview.sizeThatFits(proposal)
         }
 
-        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview) {
+        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview, cache: inout ()) {
             subview.attributes.isUserInteractionEnabled = isEnabled
         }
 

--- a/BlueprintUI/Sources/Measuring/SizeConstraint.swift
+++ b/BlueprintUI/Sources/Measuring/SizeConstraint.swift
@@ -4,7 +4,7 @@ import UIKit
 ///
 /// Currently this constraint type can only handles layout where
 /// the primary (breaking) axis is horizontal (row in CSS-speak).
-public struct SizeConstraint: Hashable, CustomDebugStringConvertible {
+public struct SizeConstraint: Hashable, CustomStringConvertible {
 
     /// The width constraint.
     @UnconstrainedInfiniteAxis public var width: Axis
@@ -19,8 +19,8 @@ public struct SizeConstraint: Hashable, CustomDebugStringConvertible {
 
     // MARK: CustomDebugStringConvertible
 
-    public var debugDescription: String {
-        "<SizeConstraint: \(width.debugDescription) x \(height.debugDescription)>"
+    public var description: String {
+        "\(width) × \(height)"
     }
 }
 
@@ -69,7 +69,7 @@ extension SizeConstraint {
 extension SizeConstraint {
 
     /// Represents a size constraint for a single axis.
-    public enum Axis: Hashable, CustomDebugStringConvertible {
+    public enum Axis: Hashable, CustomStringConvertible {
 
         /// The measurement should treat the associated value as the largest
         /// possible size in the given dimension.
@@ -199,7 +199,7 @@ extension SizeConstraint {
 
         // MARK: CustomDebugStringConvertible
 
-        public var debugDescription: String {
+        public var description: String {
             switch self {
             case .atMost(let max):
                 return "atMost(\(max))"

--- a/BlueprintUI/Sources/Measuring/SizeConstraint.swift
+++ b/BlueprintUI/Sources/Measuring/SizeConstraint.swift
@@ -4,7 +4,7 @@ import UIKit
 ///
 /// Currently this constraint type can only handles layout where
 /// the primary (breaking) axis is horizontal (row in CSS-speak).
-public struct SizeConstraint: Hashable, CustomStringConvertible {
+public struct SizeConstraint: Hashable, CustomDebugStringConvertible {
 
     /// The width constraint.
     @UnconstrainedInfiniteAxis public var width: Axis
@@ -19,8 +19,8 @@ public struct SizeConstraint: Hashable, CustomStringConvertible {
 
     // MARK: CustomDebugStringConvertible
 
-    public var description: String {
-        "\(width) × \(height)"
+    public var debugDescription: String {
+        "<SizeConstraint: \(width.debugDescription) x \(height.debugDescription)>"
     }
 }
 
@@ -69,7 +69,7 @@ extension SizeConstraint {
 extension SizeConstraint {
 
     /// Represents a size constraint for a single axis.
-    public enum Axis: Hashable, CustomStringConvertible {
+    public enum Axis: Hashable, CustomDebugStringConvertible {
 
         /// The measurement should treat the associated value as the largest
         /// possible size in the given dimension.
@@ -199,7 +199,7 @@ extension SizeConstraint {
 
         // MARK: CustomDebugStringConvertible
 
-        public var description: String {
+        public var debugDescription: String {
             switch self {
             case .atMost(let max):
                 return "atMost(\(max))"

--- a/BlueprintUICommonControls/Sources/ScrollView.swift
+++ b/BlueprintUICommonControls/Sources/ScrollView.swift
@@ -190,7 +190,7 @@ extension ScrollView {
             }
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview) -> CGSize {
+        func sizeThatFits(proposal: SizeConstraint, subview: LayoutSubview, cache: inout Cache) -> CGSize {
             let adjustedProposal = proposal.inset(by: contentInset)
 
             var result = fittedSize(in: adjustedProposal, subview: subview)
@@ -204,7 +204,7 @@ extension ScrollView {
             return result
         }
 
-        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview) {
+        func placeSubview(in bounds: CGRect, proposal: SizeConstraint, subview: LayoutSubview, cache: inout ()) {
             let size = bounds.size
             var insetSize = size
             insetSize.width -= contentInset.left + contentInset.right

--- a/SampleApp/Sources/RootViewController.swift
+++ b/SampleApp/Sources/RootViewController.swift
@@ -49,20 +49,23 @@ final class RootViewController: UIViewController {
         ]
     }
 
+    let leftBlueprintView = BlueprintView()
+    let rightBlueprintView = BlueprintView()
+
     override func loadView() {
-        let leftBlueprintView = BlueprintView(element: contents)
         leftBlueprintView.backgroundColor = .clear
         leftBlueprintView.layer.borderColor = UIColor.black.cgColor
         leftBlueprintView.layer.borderWidth = 1
 
         leftBlueprintView.layoutMode = .strictSinglePass
+        leftBlueprintView.element = contents
 
-        let rightBlueprintView = BlueprintView(element: contents)
         rightBlueprintView.backgroundColor = .clear
         rightBlueprintView.layer.borderColor = UIColor.black.cgColor
         rightBlueprintView.layer.borderWidth = 1
 
         rightBlueprintView.layoutMode = .standard
+        rightBlueprintView.element = contents
 
         let stackView = UIStackView(arrangedSubviews: [
             leftBlueprintView,
@@ -74,12 +77,23 @@ final class RootViewController: UIViewController {
         view = stackView
 
         view.backgroundColor = .init(white: 0.9, alpha: 1.0)
+
+        let tapRecognizer = UITapGestureRecognizer()
+        tapRecognizer.addTarget(self, action: #selector(viewTapped))
+        stackView.addGestureRecognizer(tapRecognizer)
+    }
+
+    @objc
+    func viewTapped() {
+        // trigger a layout
+        leftBlueprintView.element = leftBlueprintView.element
+        rightBlueprintView.element = rightBlueprintView.element
     }
 
     var contents: Element {
         demoScreenWrapper
     }
-    
+
     var demoScreenWrapper: Element {
         Column(alignment: .leading, underflow: .justifyToCenter) {
             Label(text: "Date Picker") { label in
@@ -90,13 +104,13 @@ final class RootViewController: UIViewController {
                 .box(borders: .solid(color: .blue, width: 1))
         }
     }
-    
+
     var datePicker: Element {
         var daySegment: Element {
             Spacer(5)
                 .box(background: .red, borders: .solid(color: .black, width: 1))
         }
-        
+
         var weekdaySymbols: Element {
             EqualStack(direction: .horizontal) {
                 for weekday in ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"] {
@@ -108,7 +122,7 @@ final class RootViewController: UIViewController {
             }
             .constrainedTo(height: .atLeast(40))
         }
-        
+
         var header: Element {
             Row(
                 alignment: .center,
@@ -131,7 +145,7 @@ final class RootViewController: UIViewController {
 
 
         var monthGrid: Element {
-            return Column(alignment: .fill, minimumSpacing: 8) {
+            Column(alignment: .fill, minimumSpacing: 8) {
 
                 weekdaySymbols
                     .box(borders: .solid(color: .brown, width: 1))
@@ -159,6 +173,7 @@ final class RootViewController: UIViewController {
         }
         .box(borders: .solid(color: .yellow, width: 1))
         .constrainedTo(width: .atLeast(280))
+//        .debugPath("ConstrainedSize")
     }
 
     var contents2: Element {

--- a/SampleApp/Sources/RootViewController.swift
+++ b/SampleApp/Sources/RootViewController.swift
@@ -59,7 +59,7 @@ final class RootViewController: UIViewController {
         leftBlueprintView.layer.borderColor = UIColor.black.cgColor
         leftBlueprintView.layer.borderWidth = 1
 
-        leftBlueprintView.layoutMode = .singlePass
+        leftBlueprintView.layoutMode = .strictSinglePass
         leftBlueprintView.element = contents
 
         rightBlueprintView.backgroundColor = .clear

--- a/SampleApp/Sources/RootViewController.swift
+++ b/SampleApp/Sources/RootViewController.swift
@@ -91,17 +91,7 @@ final class RootViewController: UIViewController {
     }
 
     var contents: Element {
-        test
-    }
-    
-    var test: Element {
-        Column(alignment: .fill) {
-            Spacer(10).box(background: .blue)
-            Spacer(100).box(background: .red)
-        }
-        .constrainedTo(width: .atLeast(100))
-        .aligned(vertically: .center, horizontally: .leading)
-        .debugPath("Column")
+        demoScreenWrapper
     }
 
     var demoScreenWrapper: Element {
@@ -155,35 +145,21 @@ final class RootViewController: UIViewController {
 
 
         var monthGrid: Element {
-//            Column(alignment: .fill, minimumSpacing: 8) {
+            Column(alignment: .fill, minimumSpacing: 8) {
 
-//                weekdaySymbols
-//                    .box(borders: .solid(color: .brown, width: 1))
+                weekdaySymbols
+                    .box(borders: .solid(color: .brown, width: 1))
 
-//                for _ in 0..<3 {
-//                    EqualStack(direction: .horizontal) {
-//                        for _ in 0..<7 {
-//                            daySegment
-//                        }
-//                    }
-//                    .constrainedTo(height: .atLeast(40))
-//                    .box(borders: .solid(color: .brown, width: 1))
-//                }
-                
-//                EqualStack(direction: .horizontal) {
-////                    for _ in 0..<3 {
-////                        daySegment
-////                    }
-//                    for _ in 0..<7 {
-//                        Spacer(40)
-//                            .box(background: .red, borders: .solid(color: .black, width: 1))
-//
-//                    }
-//                }
-//                .constrainedTo(height: .atLeast(40))
-            Spacer(width: 281, height: 25)
-                .box(borders: .solid(color: .brown, width: 1))
-//            }
+                for _ in 0..<4 {
+                    EqualStack(direction: .horizontal) {
+                        for _ in 0..<7 {
+                            daySegment
+                        }
+                    }
+                    .constrainedTo(height: .atLeast(40))
+                    .box(borders: .solid(color: .brown, width: 1))
+                }
+            }
 
         }
 
@@ -195,7 +171,6 @@ final class RootViewController: UIViewController {
             header.stackLayoutChild(priority: .fixed)
             monthGrid.stackLayoutChild(priority: .flexible)
         }
-        .debugPath("Column")
         .box(borders: .solid(color: .yellow, width: 1))
         .constrainedTo(width: .atLeast(280))
 //        .debugPath("ConstrainedSize")

--- a/SampleApp/Sources/RootViewController.swift
+++ b/SampleApp/Sources/RootViewController.swift
@@ -55,7 +55,7 @@ final class RootViewController: UIViewController {
         leftBlueprintView.layer.borderColor = UIColor.black.cgColor
         leftBlueprintView.layer.borderWidth = 1
 
-        leftBlueprintView.layoutMode = .singlePass
+        leftBlueprintView.layoutMode = .strictSinglePass
 
         let rightBlueprintView = BlueprintView(element: contents)
         rightBlueprintView.backgroundColor = .clear
@@ -77,16 +77,88 @@ final class RootViewController: UIViewController {
     }
 
     var contents: Element {
-        Column(
-            alignment: .center,
-            underflow: .growUniformly
-        ) {
-            Label(text: "Test")
+        demoScreenWrapper
+    }
+    
+    var demoScreenWrapper: Element {
+        Column(alignment: .leading, underflow: .justifyToCenter) {
+            Label(text: "Date Picker") { label in
+                label.font = .preferredFont(forTextStyle: .caption1)
+            }
 
-            Label(text: "Test2")
+            datePicker
+                .box(borders: .solid(color: .blue, width: 1))
         }
-        .opacity(0.5)
-        .inset(uniform: 10)
+    }
+    
+    var datePicker: Element {
+        var daySegment: Element {
+            Spacer(5)
+                .box(background: .red, borders: .solid(color: .black, width: 1))
+        }
+        
+        var weekdaySymbols: Element {
+            EqualStack(direction: .horizontal) {
+                for weekday in ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"] {
+                    Label(text: weekday) { label in
+                        label.font = .preferredFont(forTextStyle: .body)
+                    }
+                    .box(borders: .solid(color: .green, width: 1))
+                }
+            }
+            .constrainedTo(height: .atLeast(40))
+        }
+        
+        var header: Element {
+            Row(
+                alignment: .center,
+                underflow: .growProportionally,
+                minimumSpacing: 8
+            ) {
+                Label(text: "Jan 2023") { label in
+                    label.font = .preferredFont(forTextStyle: .title2)
+                }
+
+                Spacer(40)
+                    .box(background: .lightGray, corners: .rounded(radius: 6))
+                    .stackLayoutChild(priority: .fixed)
+
+                Spacer(40)
+                    .box(background: .lightGray, corners: .rounded(radius: 6))
+                    .stackLayoutChild(priority: .fixed)
+            }
+        }
+
+
+        var monthGrid: Element {
+            return Column(alignment: .fill, minimumSpacing: 8) {
+
+                weekdaySymbols
+                    .box(borders: .solid(color: .brown, width: 1))
+
+                for _ in 0..<4 {
+                    EqualStack(direction: .horizontal) {
+                        for _ in 0..<7 {
+                            daySegment
+                        }
+                    }
+                    .constrainedTo(height: .atLeast(40))
+                    .box(borders: .solid(color: .brown, width: 1))
+                }
+            }
+
+        }
+
+        return Column(
+            alignment: .fill,
+            underflow: .justifyToStart,
+            minimumSpacing: 8
+        ) {
+            header.stackLayoutChild(priority: .fixed)
+            monthGrid.stackLayoutChild(priority: .flexible)
+        }
+        .box(borders: .solid(color: .yellow, width: 1))
+        .constrainedTo(width: .atLeast(280))
     }
 
     var contents2: Element {

--- a/SampleApp/Sources/RootViewController.swift
+++ b/SampleApp/Sources/RootViewController.swift
@@ -91,7 +91,17 @@ final class RootViewController: UIViewController {
     }
 
     var contents: Element {
-        demoScreenWrapper
+        test
+    }
+    
+    var test: Element {
+        Column(alignment: .fill) {
+            Spacer(10).box(background: .blue)
+            Spacer(100).box(background: .red)
+        }
+        .constrainedTo(width: .atLeast(100))
+        .aligned(vertically: .center, horizontally: .leading)
+        .debugPath("Column")
     }
 
     var demoScreenWrapper: Element {
@@ -145,21 +155,35 @@ final class RootViewController: UIViewController {
 
 
         var monthGrid: Element {
-            Column(alignment: .fill, minimumSpacing: 8) {
+//            Column(alignment: .fill, minimumSpacing: 8) {
 
-                weekdaySymbols
-                    .box(borders: .solid(color: .brown, width: 1))
+//                weekdaySymbols
+//                    .box(borders: .solid(color: .brown, width: 1))
 
-                for _ in 0..<4 {
-                    EqualStack(direction: .horizontal) {
-                        for _ in 0..<7 {
-                            daySegment
-                        }
-                    }
-                    .constrainedTo(height: .atLeast(40))
-                    .box(borders: .solid(color: .brown, width: 1))
-                }
-            }
+//                for _ in 0..<3 {
+//                    EqualStack(direction: .horizontal) {
+//                        for _ in 0..<7 {
+//                            daySegment
+//                        }
+//                    }
+//                    .constrainedTo(height: .atLeast(40))
+//                    .box(borders: .solid(color: .brown, width: 1))
+//                }
+                
+//                EqualStack(direction: .horizontal) {
+////                    for _ in 0..<3 {
+////                        daySegment
+////                    }
+//                    for _ in 0..<7 {
+//                        Spacer(40)
+//                            .box(background: .red, borders: .solid(color: .black, width: 1))
+//
+//                    }
+//                }
+//                .constrainedTo(height: .atLeast(40))
+            Spacer(width: 281, height: 25)
+                .box(borders: .solid(color: .brown, width: 1))
+//            }
 
         }
 
@@ -171,6 +195,7 @@ final class RootViewController: UIViewController {
             header.stackLayoutChild(priority: .fixed)
             monthGrid.stackLayoutChild(priority: .flexible)
         }
+        .debugPath("Column")
         .box(borders: .solid(color: .yellow, width: 1))
         .constrainedTo(width: .atLeast(280))
 //        .debugPath("ConstrainedSize")

--- a/SampleApp/Sources/RootViewController.swift
+++ b/SampleApp/Sources/RootViewController.swift
@@ -52,7 +52,9 @@ final class RootViewController: UIViewController {
     let leftBlueprintView = BlueprintView()
     let rightBlueprintView = BlueprintView()
 
-    override func loadView() {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
         leftBlueprintView.backgroundColor = .clear
         leftBlueprintView.layer.borderColor = UIColor.black.cgColor
         leftBlueprintView.layer.borderWidth = 1
@@ -67,20 +69,24 @@ final class RootViewController: UIViewController {
         rightBlueprintView.layoutMode = .standard
         rightBlueprintView.element = contents
 
-        let stackView = UIStackView(arrangedSubviews: [
-            leftBlueprintView,
-            rightBlueprintView,
-        ])
-        stackView.axis = .horizontal
-        stackView.distribution = .fillEqually
-        stackView.alignment = .fill
-        view = stackView
-
+        view.addSubview(leftBlueprintView)
+        view.addSubview(rightBlueprintView)
         view.backgroundColor = .init(white: 0.9, alpha: 1.0)
 
         let tapRecognizer = UITapGestureRecognizer()
         tapRecognizer.addTarget(self, action: #selector(viewTapped))
-        stackView.addGestureRecognizer(tapRecognizer)
+        view.addGestureRecognizer(tapRecognizer)
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        var frame = view.bounds
+        frame.size.width = frame.width / 2
+        leftBlueprintView.frame = frame
+
+        frame.origin.x = frame.width
+        rightBlueprintView.frame = frame
     }
 
     @objc
@@ -99,11 +105,37 @@ final class RootViewController: UIViewController {
             Spacer(10).box(background: .blue)
             Spacer(100).box(background: .red)
         }
-//        .constrainedTo(width: .atLeast(100))
+        .constrainedTo(width: .atLeast(100))
         .aligned(vertically: .center, horizontally: .leading)
         .debugPath("Column")
     }
+    
+    var test2: Element {
+        Column(alignment: .leading, underflow: .justifyToCenter) {
 
+            Column(
+                alignment: .fill,
+                underflow: .justifyToStart,
+                minimumSpacing: 8
+            ) {
+                EqualStack(direction: .horizontal) {
+//                    for _ in 0..<1 {
+                        Spacer(20)
+                            .box(background: .red)
+//                    }
+                }
+                .constrainedTo(height: .atLeast(40))
+                .box(borders: .solid(color: .brown, width: 2))
+//                .stackLayoutChild(priority: .flexible)
+            }
+//            .debugPath("Column")
+            .box(borders: .solid(color: .yellow, width: 2))
+            .constrainedTo(width: .atLeast(280))
+            .box(borders: .solid(color: .blue, width: 2))
+        }
+
+    }
+    
     var demoScreenWrapper: Element {
         Column(alignment: .leading, underflow: .justifyToCenter) {
             Label(text: "Date Picker") { label in
@@ -169,8 +201,8 @@ final class RootViewController: UIViewController {
                     .constrainedTo(height: .atLeast(40))
                     .box(borders: .solid(color: .brown, width: 1))
                 }
-            }
 
+            }
         }
 
         return Column(
@@ -181,6 +213,7 @@ final class RootViewController: UIViewController {
             header.stackLayoutChild(priority: .fixed)
             monthGrid.stackLayoutChild(priority: .flexible)
         }
+//        .debugPath("Column")
         .box(borders: .solid(color: .yellow, width: 1))
         .constrainedTo(width: .atLeast(280))
     }

--- a/SampleApp/Sources/RootViewController.swift
+++ b/SampleApp/Sources/RootViewController.swift
@@ -93,6 +93,16 @@ final class RootViewController: UIViewController {
     var contents: Element {
         demoScreenWrapper
     }
+    
+    var test: Element {
+        Column(alignment: .fill) {
+            Spacer(10).box(background: .blue)
+            Spacer(100).box(background: .red)
+        }
+//        .constrainedTo(width: .atLeast(100))
+        .aligned(vertically: .center, horizontally: .leading)
+        .debugPath("Column")
+    }
 
     var demoScreenWrapper: Element {
         Column(alignment: .leading, underflow: .justifyToCenter) {
@@ -173,7 +183,6 @@ final class RootViewController: UIViewController {
         }
         .box(borders: .solid(color: .yellow, width: 1))
         .constrainedTo(width: .atLeast(280))
-//        .debugPath("ConstrainedSize")
     }
 
     var contents2: Element {

--- a/SampleApp/Sources/RootViewController.swift
+++ b/SampleApp/Sources/RootViewController.swift
@@ -59,7 +59,7 @@ final class RootViewController: UIViewController {
         leftBlueprintView.layer.borderColor = UIColor.black.cgColor
         leftBlueprintView.layer.borderWidth = 1
 
-        leftBlueprintView.layoutMode = .strictSinglePass
+        leftBlueprintView.layoutMode = .singlePass
         leftBlueprintView.element = contents
 
         rightBlueprintView.backgroundColor = .clear


### PR DESCRIPTION
This is the cache you can add to any layout type, a.k.a. "phase cache", in the SwiftUI-mimicking API. By default, it is `Void` for all layouts.

This PR is stacked on #419 