### PR TITLE
[SPL] Regression testing options

### DIFF
--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -48,17 +48,14 @@ public struct ElementContent {
         switch layoutMode {
         case .standard:
             return storage.measure(in: constraint, environment: environment, cache: cache)
-        case .singlePass:
+        case .singlePass(let options):
             return storage.sizeThatFits(
                 proposal: constraint,
                 context: .init(
                     // TODO: Hoist upward?
                     cache: SPCacheNode(
                         path: "m",
-                        options: SPCacheOptions(
-                            hintRangeBoundaries: true,
-                            searchUnconstrainedKeys: false
-                        )
+                        options: options
                     ),
                     environment: environment
                 )

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -21,7 +21,7 @@ extension Element {
         switch layoutMode {
         case .standard:
             return layout(layoutAttributes: LayoutAttributes(frame: frame), environment: environment)
-        case .singlePass:
+        case .singlePass(let options):
             return singlePassLayout(
                 proposal: .init(frame.size),
                 context: SPLayoutContext(
@@ -30,10 +30,7 @@ extension Element {
                     // TODO: Hoist up?
                     cache: SPCacheNode(
                         path: "\(type(of: self))",
-                        options: SPCacheOptions(
-                            hintRangeBoundaries: true,
-                            searchUnconstrainedKeys: true
-                        )
+                        options: options
                     )
                 )
             )

--- a/BlueprintUI/Sources/Internal/SPL/SPCacheTree.swift
+++ b/BlueprintUI/Sources/Internal/SPL/SPCacheTree.swift
@@ -76,9 +76,20 @@ final class SPValueCache<Key: Hashable, Value> {
     }
 }
 
-struct SPCacheOptions {
-    var hintRangeBoundaries: Bool
-    var searchUnconstrainedKeys: Bool
+public struct SPCacheOptions: Equatable {
+    
+    public static let `default` = SPCacheOptions(
+        hintRangeBoundaries: true,
+        searchUnconstrainedKeys: true
+    )
+
+    public var hintRangeBoundaries: Bool
+    public var searchUnconstrainedKeys: Bool
+
+    public init(hintRangeBoundaries: Bool, searchUnconstrainedKeys: Bool) {
+        self.hintRangeBoundaries = hintRangeBoundaries
+        self.searchUnconstrainedKeys = searchUnconstrainedKeys
+    }
 }
 
 extension SPValueCache where Key == SizeConstraint, Value == CGSize {

--- a/BlueprintUI/Sources/Layout/LayoutMode.swift
+++ b/BlueprintUI/Sources/Layout/LayoutMode.swift
@@ -6,4 +6,6 @@ public enum LayoutMode: Equatable {
     case standard
     case singlePass(options: SPCacheOptions = .default)
     case strictSinglePass
+    
+    public static let singlePass: Self = .singlePass()
 }

--- a/BlueprintUI/Sources/Layout/LayoutMode.swift
+++ b/BlueprintUI/Sources/Layout/LayoutMode.swift
@@ -4,6 +4,6 @@ public enum LayoutMode: Equatable {
     public static let `default`: Self = .strictSinglePass
 
     case standard
-    case singlePass
+    case singlePass(options: SPCacheOptions = .default)
     case strictSinglePass
 }

--- a/BlueprintUI/Sources/Layout/SPL/LayoutSubview.swift
+++ b/BlueprintUI/Sources/Layout/SPL/LayoutSubview.swift
@@ -99,6 +99,10 @@ public struct LayoutSubview {
         ]
     }
 
+    // TODO:
+    // - make the positioning relative to bounds origin so that it's not necessary to manually
+    //   offset by bounds.origin
+    // - remove optional width/height, since nothing uses it and there is no advantage in our layout semantics
     public func place(
         at position: CGPoint,
         anchor: UnitPoint = .topLeading,

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -1012,22 +1012,17 @@ extension StackLayout {
 
         // First pass, use natural to get a measurement
         let axisItems = items(axisPressure: .natural)
-        // Second pass, inherit mode so that we fill properly
-        let crossItems = items(axisPressure: nil)
+        // Second pass, fill assigned space on axis
+        let crossItems = items(axisPressure: .fill)
 
         let frames = _frames(axisItems: axisItems, crossItems: crossItems, in: vectorConstraint)
         
-        let crossPressure: StrictPressureMode = {
-            switch axis {
-            case .horizontal:
-                return context.mode.vertical
-            case .vertical:
-                return context.mode.horizontal
-            }
-        }()
-        
-        switch (alignment, crossPressure) {
-        case (.fill, .natural):
+        // If we're in fill mode, we'll do an additional pass to ensure we fill the assigned space,
+        // in case:
+        // - cross pressure is natural, so we still need to fill the calculated size
+        // - we skipped a pass during cross segments, and didn't fill along axis yet
+        switch alignment {
+        case .fill:
             for (child, frame) in zip(children, frames) {
                 let sizeConstraint = SizeConstraint(frame.size.size(axis: axis))
                 _ = child.layoutable.layout(
@@ -1040,7 +1035,6 @@ extension StackLayout {
             
         default: break
         }
-        
 
         let vector = frames.reduce(Vector.zero) { vector, frame -> Vector in
             Vector(

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -921,29 +921,14 @@ extension StackLayout {
             let vectorFrame = frames[i]
             let subview = subviews[i]
 
-            var width: CGFloat?
-            var height: CGFloat?
-
-            let size = vectorFrame.size.size(axis: axis)
-
-            switch axis {
-            case .vertical:
-                width = vectorFrame.crossMeasured ? nil : size.width
-                height = vectorFrame.axisMeasured ? nil : size.height
-
-            case .horizontal:
-                width = vectorFrame.axisMeasured ? nil : size.width
-                height = vectorFrame.crossMeasured ? nil : size.height
-            }
-
             let frame = vectorFrame.rect(axis: axis)
 
             subview.place(
                 at: bounds.origin + frame.origin,
                 anchor: .topLeading,
                 proposal: vectorFrame.constraint,
-                width: size.width,
-                height: size.height
+                width: frame.width,
+                height: frame.height
             )
         }
     }

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -942,8 +942,8 @@ extension StackLayout {
                 at: bounds.origin + frame.origin,
                 anchor: .topLeading,
                 proposal: vectorFrame.constraint,
-                width: width,
-                height: height
+                width: size.width,
+                height: size.height
             )
         }
     }


### PR DESCRIPTION
- expose layout result for "snapshot" comparison
- hoist SwiftUI-SPL layout options up to the enum
- fix strict stack layout in some cases I found in regression tests