### PR TITLE
Fix Image aspectFit measurement

### DIFF
--- a/BlueprintUICommonControls/Sources/Image.swift
+++ b/BlueprintUICommonControls/Sources/Image.swift
@@ -141,15 +141,17 @@ extension Image {
                     mode = .fitHeight(height)
                 }
 
+            case (.aspectFill, .atMost(let width), _),
+                 (.aspectFit, .atMost(let width), _):
+                mode = .fitWidth(width)
+
+            case (.aspectFill, _, .atMost(let height)),
+                 (.aspectFit, _, .atMost(let height)):
+                mode = .fitHeight(height)
+
             case (.aspectFill, _, _),
                  (.aspectFit, _, _):
-                if case .atMost(let width) = constraint.width {
-                    mode = .fitWidth(width)
-                } else if case .atMost(let height) = constraint.height {
-                    mode = .fitHeight(height)
-                } else {
-                    mode = .useImageSize
-                }
+                mode = .useImageSize
             }
 
             switch mode {

--- a/BlueprintUICommonControls/Sources/Image.swift
+++ b/BlueprintUICommonControls/Sources/Image.swift
@@ -122,17 +122,28 @@ extension Image {
 
             let mode: Mode
 
-            switch contentMode {
-            case .center, .stretch:
+            switch (contentMode, constraint.width, constraint.height) {
+            case (.center, _, _),
+                 (.stretch, _, _):
                 mode = .useImageSize
-            case .aspectFit, .aspectFill:
-                if case .atMost(let width) = constraint.width, case .atMost(let height) = constraint.height {
-                    if CGSize(width: width, height: height).aspectRatio > imageSize.aspectRatio {
-                        mode = .fitWidth(width)
-                    } else {
-                        mode = .fitHeight(height)
-                    }
-                } else if case .atMost(let width) = constraint.width {
+
+            case (.aspectFill, .atMost(let width), .atMost(let height)):
+                if CGSize(width: width, height: height).aspectRatio > imageSize.aspectRatio {
+                    mode = .fitWidth(width)
+                } else {
+                    mode = .fitHeight(height)
+                }
+
+            case (.aspectFit, .atMost(let width), .atMost(let height)):
+                if CGSize(width: width, height: height).aspectRatio < imageSize.aspectRatio {
+                    mode = .fitWidth(width)
+                } else {
+                    mode = .fitHeight(height)
+                }
+
+            case (.aspectFill, _, _),
+                 (.aspectFit, _, _):
+                if case .atMost(let width) = constraint.width {
                     mode = .fitWidth(width)
                 } else if case .atMost(let height) = constraint.height {
                     mode = .fitHeight(height)

--- a/BlueprintUICommonControls/Tests/Sources/ImageTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/ImageTests.swift
@@ -13,15 +13,6 @@ class ImageTests: XCTestCase {
         XCTAssertNil(element.tintColor)
     }
 
-    func test_measuring() {
-        let element = Image(image: image)
-        XCTAssertEqual(
-            element.content.measure(in: SizeConstraint(width: .unconstrained, height: .unconstrained)),
-            image.size
-        )
-
-    }
-
     func test_aspectFill() {
         var element = Image(image: image)
         element.contentMode = .aspectFill
@@ -46,4 +37,355 @@ class ImageTests: XCTestCase {
         compareSnapshot(of: element, size: CGSize(width: 100, height: 100))
     }
 
+    func test_measure_aspectFill() {
+        func validate(
+            size: CGSize,
+            constraint: SizeConstraint,
+            expectedValue: CGSize,
+            line: UInt = #line
+        ) {
+            self.validate(
+                contentMode: .aspectFill,
+                imageSize: size,
+                constraint: constraint,
+                expectedValue: expectedValue,
+                line: line
+            )
+        }
+
+        // Wide aspect ratio image
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .unconstrained, height: .unconstrained),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(40), height: .unconstrained),
+            expectedValue: .init(width: 40, height: 20)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(10), height: .unconstrained),
+            expectedValue: .init(width: 10, height: 5)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(5), height: .atMost(5)),
+            expectedValue: .init(width: 10, height: 5)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(40), height: .atMost(40)),
+            expectedValue: .init(width: 80, height: 40)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .unconstrained, height: .atMost(100)),
+            expectedValue: .init(width: 200, height: 100)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .unconstrained, height: .atMost(1)),
+            expectedValue: .init(width: 2, height: 1)
+        )
+
+        // Tall aspect ratio image
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .unconstrained, height: .unconstrained),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(100), height: .unconstrained),
+            expectedValue: .init(width: 100, height: 200)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(5), height: .unconstrained),
+            expectedValue: .init(width: 5, height: 10)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(5), height: .atMost(5)),
+            expectedValue: .init(width: 5, height: 10)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(40), height: .atMost(40)),
+            expectedValue: .init(width: 40, height: 80)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .unconstrained, height: .atMost(100)),
+            expectedValue: .init(width: 50, height: 100)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .unconstrained, height: .atMost(4)),
+            expectedValue: .init(width: 2, height: 4)
+        )
+    }
+
+    func test_measure_aspectFit() {
+        func validate(
+            size: CGSize,
+            constraint: SizeConstraint,
+            expectedValue: CGSize,
+            line: UInt = #line
+        ) {
+            self.validate(
+                contentMode: .aspectFit,
+                imageSize: size,
+                constraint: constraint,
+                expectedValue: expectedValue,
+                line: line
+            )
+        }
+
+        // Wide aspect ratio image
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .unconstrained, height: .unconstrained),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(40), height: .unconstrained),
+            expectedValue: .init(width: 40, height: 20)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(10), height: .unconstrained),
+            expectedValue: .init(width: 10, height: 5)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(8), height: .atMost(8)),
+            expectedValue: .init(width: 8, height: 4)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(40), height: .atMost(40)),
+            expectedValue: .init(width: 40, height: 20)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .unconstrained, height: .atMost(100)),
+            expectedValue: .init(width: 200, height: 100)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .unconstrained, height: .atMost(1)),
+            expectedValue: .init(width: 2, height: 1)
+        )
+
+        // Tall aspect ratio image
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .unconstrained, height: .unconstrained),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(100), height: .unconstrained),
+            expectedValue: .init(width: 100, height: 200)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(5), height: .unconstrained),
+            expectedValue: .init(width: 5, height: 10)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(5), height: .atMost(8)),
+            expectedValue: .init(width: 4, height: 8)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(40), height: .atMost(40)),
+            expectedValue: .init(width: 20, height: 40)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .unconstrained, height: .atMost(100)),
+            expectedValue: .init(width: 50, height: 100)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .unconstrained, height: .atMost(4)),
+            expectedValue: .init(width: 2, height: 4)
+        )
+    }
+
+    func test_measure_center() {
+        func validate(
+            size: CGSize,
+            constraint: SizeConstraint,
+            expectedValue: CGSize,
+            line: UInt = #line
+        ) {
+            self.validate(
+                contentMode: .center,
+                imageSize: size,
+                constraint: constraint,
+                expectedValue: expectedValue,
+                line: line
+            )
+        }
+
+        // Wide aspect ratio image
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .unconstrained, height: .unconstrained),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(40), height: .unconstrained),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(10), height: .unconstrained),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(8), height: .atMost(8)),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(40), height: .atMost(40)),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .unconstrained, height: .atMost(100)),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .unconstrained, height: .atMost(1)),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        // Tall aspect ratio image
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .unconstrained, height: .unconstrained),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(100), height: .unconstrained),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(5), height: .unconstrained),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(5), height: .atMost(8)),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(40), height: .atMost(40)),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .unconstrained, height: .atMost(100)),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .unconstrained, height: .atMost(4)),
+            expectedValue: .init(width: 10, height: 20)
+        )
+    }
+
+    private func validate(
+        contentMode: Image.ContentMode,
+        imageSize: CGSize,
+        constraint: SizeConstraint,
+        expectedValue: CGSize,
+        line: UInt = #line
+    ) {
+        let image = UIImage.test(imageSize)
+        let element = Image(
+            image: image,
+            contentMode: contentMode
+        )
+
+        XCTAssertEqual(
+            element.content.measure(in: constraint),
+            expectedValue,
+            """
+            Image in content mode: \(contentMode),
+            of size (\(Int(imageSize.width))x\(Int(imageSize.height)))
+            expected to be measured as (\(Int(expectedValue.width))x\(Int(expectedValue.height)))
+            in constraint: (\(constraint))
+            """,
+            line: line
+        )
+    }
+}
+
+
+extension UIImage {
+
+    fileprivate static func test(_ size: CGSize) -> UIImage {
+        UIGraphicsImageRenderer(size: size).image { rendererContext in
+            UIColor.red.setFill()
+            rendererContext.fill(CGRect(origin: .zero, size: size))
+        }
+    }
 }

--- a/BlueprintUICommonControls/Tests/Sources/ImageTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/ImageTests.swift
@@ -87,6 +87,12 @@ class ImageTests: XCTestCase {
 
         validate(
             size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(40), height: .atMost(10)),
+            expectedValue: .init(width: 40, height: 20)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
             constraint: .init(width: .unconstrained, height: .atMost(100)),
             expectedValue: .init(width: 200, height: 100)
         )
@@ -127,6 +133,12 @@ class ImageTests: XCTestCase {
             size: .init(width: 10, height: 20),
             constraint: .init(width: .atMost(40), height: .atMost(40)),
             expectedValue: .init(width: 40, height: 80)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(10), height: .atMost(40)),
+            expectedValue: .init(width: 20, height: 40)
         )
 
         validate(
@@ -192,6 +204,12 @@ class ImageTests: XCTestCase {
 
         validate(
             size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(40), height: .atMost(10)),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
             constraint: .init(width: .unconstrained, height: .atMost(100)),
             expectedValue: .init(width: 200, height: 100)
         )
@@ -232,6 +250,12 @@ class ImageTests: XCTestCase {
             size: .init(width: 10, height: 20),
             constraint: .init(width: .atMost(40), height: .atMost(40)),
             expectedValue: .init(width: 20, height: 40)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(10), height: .atMost(40)),
+            expectedValue: .init(width: 10, height: 20)
         )
 
         validate(
@@ -297,6 +321,12 @@ class ImageTests: XCTestCase {
 
         validate(
             size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(40), height: .atMost(10)),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
             constraint: .init(width: .unconstrained, height: .atMost(100)),
             expectedValue: .init(width: 20, height: 10)
         )
@@ -336,6 +366,12 @@ class ImageTests: XCTestCase {
         validate(
             size: .init(width: 10, height: 20),
             constraint: .init(width: .atMost(40), height: .atMost(40)),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(40), height: .atMost(10)),
             expectedValue: .init(width: 10, height: 20)
         )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed unexpected measurement results that could occur from `Image`s using the `aspectFit` `contentMode`.
+
 ### Added
 
 ### Removed


### PR DESCRIPTION
## Overview

`Image`'s `aspectFit` `contentMode` currently reports measured sizes that correspond to the expected result of an `aspectFill` measurement. This leads to some weird bugs in layout.

For example, take this simple layout as an example:
```swift
        Column(
            alignment: .fill,
            minimumSpacing: 16
        ) {
            Image(
                image: {
                    let size = CGSize(width: 60, height: 30)
                    return UIGraphicsImageRenderer(size: size).image { rendererContext in
                        UIColor.red.withAlphaComponent(0.2).setFill()
                        rendererContext.fill(CGRect(origin: .zero, size: size))
                    }
                }(),
                contentMode: .aspectFit
            )
            .stackLayoutChild(priority: .fixed)

            Label(text: "Hello World")
        }
        .scrollable(.fittingHeight) { $0.centersUnderflow = true }
```

| Current | With Fix |
| - | - |
| <img width="647" alt="Current" src="https://user-images.githubusercontent.com/671271/217622748-2b304c06-0d09-4760-b1a4-7adbfd72d40e.png"> | <img width="646" alt="Fixed" src="https://user-images.githubusercontent.com/671271/217622715-b22d988c-f9e2-4c0b-a15f-eeba6aa5879a.png"> |

## Integration PRs

https://github.com/squareup/ios-register/pull/80822
https://github.com/squareup/market/pull/5562