### PR TITLE
Release 0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed unexpected measurement results that could occur from `Image`s using the `aspectFit` `contentMode`.
-
 ### Added
 
 ### Removed
@@ -26,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Misc
 
 # Past Releases
+
+## [0.49.0]
+
+### Fixed
+
+- Fixed unexpected measurement results that could occur from `Image`s using the `aspectFit` `contentMode`.
 
 ## [0.48.1]
 
@@ -929,7 +933,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/0.48.1...HEAD
+[main]: https://github.com/square/Blueprint/compare/0.49.0...HEAD
+[0.49.0]: https://github.com/square/Blueprint/compare/0.48.1...0.49.0
 [0.48.1]: https://github.com/square/Blueprint/compare/0.48.0...0.48.1
 [0.48.0]: https://github.com/square/Blueprint/compare/0.47.0...0.48.0
 [0.47.0]: https://github.com/square/Blueprint/compare/0.46.0...0.47.0

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (0.48.1)
-  - BlueprintUI/Tests (0.48.1)
-  - BlueprintUICommonControls (0.48.1):
-    - BlueprintUI (= 0.48.1)
+  - BlueprintUI (0.49.0)
+  - BlueprintUI/Tests (0.49.0)
+  - BlueprintUICommonControls (0.49.0):
+    - BlueprintUI (= 0.49.0)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 18c3ae5f3744831602423574e13fb1fa5e8c8a8d
-  BlueprintUICommonControls: 80db8cd1bd45e2d39d3c28d39ae9fcfe036d3aa4
+  BlueprintUI: 890f6a44bcad754a537532ca6cbe479bc93c0267
+  BlueprintUICommonControls: 2b9559ab9c5a68fc05ac62c30be6a5f5fde68e79
 
 PODFILE CHECKSUM: c795e247aa1c5eb825186ef8192821306c59c891
 

--- a/version.rb
+++ b/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '0.48.1'
+BLUEPRINT_VERSION ||= '0.49.0'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))


### PR DESCRIPTION
## [0.49.0](https://github.com/square/Blueprint/compare/0.48.1...d5afe3ad92cf2381e3c21591cd7bdfc72480db04)

### Fixed

- Fixed unexpected measurement results that could occur from `Image`s using the `aspectFit` `contentMode`.