### PR TITLE
Measure `Image` in `aspectFill` `contentMode` the same as `aspectFit`

### DIFF
--- a/BlueprintUICommonControls/Sources/Image.swift
+++ b/BlueprintUICommonControls/Sources/Image.swift
@@ -122,36 +122,23 @@ extension Image {
 
             let mode: Mode
 
-            switch (contentMode, constraint.width, constraint.height) {
-            case (.center, _, _),
-                 (.stretch, _, _):
+            switch contentMode {
+            case .center, .stretch:
                 mode = .useImageSize
-
-            case (.aspectFill, .atMost(let width), .atMost(let height)):
-                if CGSize(width: width, height: height).aspectRatio > imageSize.aspectRatio {
+            case .aspectFit, .aspectFill:
+                if case .atMost(let width) = constraint.width, case .atMost(let height) = constraint.height {
+                    if CGSize(width: width, height: height).aspectRatio < imageSize.aspectRatio {
+                        mode = .fitWidth(width)
+                    } else {
+                        mode = .fitHeight(height)
+                    }
+                } else if case .atMost(let width) = constraint.width {
                     mode = .fitWidth(width)
-                } else {
+                } else if case .atMost(let height) = constraint.height {
                     mode = .fitHeight(height)
-                }
-
-            case (.aspectFit, .atMost(let width), .atMost(let height)):
-                if CGSize(width: width, height: height).aspectRatio < imageSize.aspectRatio {
-                    mode = .fitWidth(width)
                 } else {
-                    mode = .fitHeight(height)
+                    mode = .useImageSize
                 }
-
-            case (.aspectFill, .atMost(let width), _),
-                 (.aspectFit, .atMost(let width), _):
-                mode = .fitWidth(width)
-
-            case (.aspectFill, _, .atMost(let height)),
-                 (.aspectFit, _, .atMost(let height)):
-                mode = .fitHeight(height)
-
-            case (.aspectFill, _, _),
-                 (.aspectFit, _, _):
-                mode = .useImageSize
             }
 
             switch mode {

--- a/BlueprintUICommonControls/Tests/Sources/ImageTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/ImageTests.swift
@@ -76,19 +76,19 @@ class ImageTests: XCTestCase {
         validate(
             size: .init(width: 20, height: 10),
             constraint: .init(width: .atMost(5), height: .atMost(5)),
-            expectedValue: .init(width: 10, height: 5)
+            expectedValue: .init(width: 5, height: 2.5)
         )
 
         validate(
             size: .init(width: 20, height: 10),
             constraint: .init(width: .atMost(40), height: .atMost(40)),
-            expectedValue: .init(width: 80, height: 40)
+            expectedValue: .init(width: 40, height: 20)
         )
 
         validate(
             size: .init(width: 20, height: 10),
             constraint: .init(width: .atMost(40), height: .atMost(10)),
-            expectedValue: .init(width: 40, height: 20)
+            expectedValue: .init(width: 20, height: 10)
         )
 
         validate(
@@ -126,19 +126,19 @@ class ImageTests: XCTestCase {
         validate(
             size: .init(width: 10, height: 20),
             constraint: .init(width: .atMost(5), height: .atMost(5)),
-            expectedValue: .init(width: 5, height: 10)
+            expectedValue: .init(width: 2.5, height: 5)
         )
 
         validate(
             size: .init(width: 10, height: 20),
             constraint: .init(width: .atMost(40), height: .atMost(40)),
-            expectedValue: .init(width: 40, height: 80)
+            expectedValue: .init(width: 20, height: 40)
         )
 
         validate(
             size: .init(width: 10, height: 20),
             constraint: .init(width: .atMost(10), height: .atMost(40)),
-            expectedValue: .init(width: 20, height: 40)
+            expectedValue: .init(width: 10, height: 20)
         )
 
         validate(
@@ -280,6 +280,123 @@ class ImageTests: XCTestCase {
         ) {
             self.validate(
                 contentMode: .center,
+                imageSize: size,
+                constraint: constraint,
+                expectedValue: expectedValue,
+                line: line
+            )
+        }
+
+        // Wide aspect ratio image
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .unconstrained, height: .unconstrained),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(40), height: .unconstrained),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(10), height: .unconstrained),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(8), height: .atMost(8)),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(40), height: .atMost(40)),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .atMost(40), height: .atMost(10)),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .unconstrained, height: .atMost(100)),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        validate(
+            size: .init(width: 20, height: 10),
+            constraint: .init(width: .unconstrained, height: .atMost(1)),
+            expectedValue: .init(width: 20, height: 10)
+        )
+
+        // Tall aspect ratio image
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .unconstrained, height: .unconstrained),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(100), height: .unconstrained),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(5), height: .unconstrained),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(5), height: .atMost(8)),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(40), height: .atMost(40)),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .atMost(40), height: .atMost(10)),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .unconstrained, height: .atMost(100)),
+            expectedValue: .init(width: 10, height: 20)
+        )
+
+        validate(
+            size: .init(width: 10, height: 20),
+            constraint: .init(width: .unconstrained, height: .atMost(4)),
+            expectedValue: .init(width: 10, height: 20)
+        )
+    }
+
+    func test_measure_stretch() {
+        func validate(
+            size: CGSize,
+            constraint: SizeConstraint,
+            expectedValue: CGSize,
+            line: UInt = #line
+        ) {
+            self.validate(
+                contentMode: .stretch,
                 imageSize: size,
                 constraint: constraint,
                 expectedValue: expectedValue,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Image`'s `aspectFill` `contentMode` now measures the same as `aspectFit` to avoid aggressively taking up space when not necessary.
+
 ### Added
 
 ### Removed


### PR DESCRIPTION
This prevents aggressively taking up space when using the `aspectFill` `contentMode`. Doing so will end up creating layouts that are more likely to show the entire image contents without cropping when it could fit the proposed space.

Additionally adds `stretch` measurement unit tests.