### PR TITLE
Release 0.49.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `Image`'s `aspectFill` `contentMode` now measures the same as `aspectFit` to avoid aggressively taking up space when not necessary.
-
 ### Added
 
 ### Removed
@@ -26,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Misc
 
 # Past Releases
+
+## [0.49.1]
+
+### Fixed
+
+- `Image`'s `aspectFill` `contentMode` now measures the same as `aspectFit` to avoid aggressively taking up space when not necessary.
 
 ## [0.49.0]
 
@@ -935,7 +939,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/0.49.0...HEAD
+[main]: https://github.com/square/Blueprint/compare/0.49.1...HEAD
+[0.49.1]: https://github.com/square/Blueprint/compare/0.49.0...0.49.1
 [0.49.0]: https://github.com/square/Blueprint/compare/0.48.1...0.49.0
 [0.48.1]: https://github.com/square/Blueprint/compare/0.48.0...0.48.1
 [0.48.0]: https://github.com/square/Blueprint/compare/0.47.0...0.48.0

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (0.49.0)
-  - BlueprintUI/Tests (0.49.0)
-  - BlueprintUICommonControls (0.49.0):
-    - BlueprintUI (= 0.49.0)
+  - BlueprintUI (0.49.1)
+  - BlueprintUI/Tests (0.49.1)
+  - BlueprintUICommonControls (0.49.1):
+    - BlueprintUI (= 0.49.1)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 890f6a44bcad754a537532ca6cbe479bc93c0267
-  BlueprintUICommonControls: 2b9559ab9c5a68fc05ac62c30be6a5f5fde68e79
+  BlueprintUI: 090293fb945bffd9f669a9b12778b50a8b8a06e6
+  BlueprintUICommonControls: d18ffe128add2a3d101a916c469d570735d19c04
 
 PODFILE CHECKSUM: c795e247aa1c5eb825186ef8192821306c59c891
 

--- a/version.rb
+++ b/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '0.49.0'
+BLUEPRINT_VERSION ||= '0.49.1'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))


### PR DESCRIPTION
## 0.49.1

### Fixed

- `Image`'s `aspectFill` `contentMode` now measures the same as `aspectFit` to avoid aggressively taking up space when not necessary.