### PR TITLE
`BlueprintViewMetricsDelegate` terminology and calculation improvements

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -327,7 +327,7 @@ public final class BlueprintView: UIView {
         needsViewHierarchyUpdate = false
         lastViewHierarchyUpdateBounds = bounds
 
-        let start = CACurrentMediaTime()
+        let startTime = CACurrentMediaTime()
         Logger.logLayoutStart(view: self)
 
         let environment = makeEnvironment()
@@ -384,8 +384,8 @@ public final class BlueprintView: UIView {
         metricsDelegate?.blueprintView(
             self,
             completedRenderWith: .init(
-                totalDuration: viewUpdateEndTime - start,
-                layoutDuration: measurementEndTime - start,
+                totalDuration: viewUpdateEndTime - startTime,
+                layoutDuration: measurementEndTime - startTime,
                 viewUpdateDuration: viewUpdateEndTime - measurementEndTime
             )
         )

--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -446,15 +446,15 @@ public final class BlueprintView: UIView {
 }
 
 
-/// Provides performance information for blueprint measurements and updates.
+/// Provides performance information for blueprint layouts and updates.
 public protocol BlueprintViewMetricsDelegate: AnyObject {
 
-    func blueprintView(_ view: BlueprintView, completedRenderWith metrics: BlueprintViewUpdateMetrics)
+    func blueprintView(_ view: BlueprintView, completedRenderWith metrics: BlueprintViewRenderMetrics)
 
 }
 
 
-public struct BlueprintViewUpdateMetrics {
+public struct BlueprintViewRenderMetrics {
 
     /// The total time it took to apply a new element.
     public var totalDuration: TimeInterval

--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -344,7 +344,7 @@ public final class BlueprintView: UIView {
             .layout(layoutAttributes: LayoutAttributes(frame: rootFrame), environment: environment)
             .resolve() ?? []
 
-        let measurementEndTime = CACurrentMediaTime()
+        let layoutEndTime = CACurrentMediaTime()
         Logger.logLayoutEnd(view: self)
 
         // The root controller is fixed, and its layout attributes are never applied.
@@ -385,8 +385,8 @@ public final class BlueprintView: UIView {
             self,
             completedRenderWith: .init(
                 totalDuration: viewUpdateEndTime - startTime,
-                layoutDuration: measurementEndTime - startTime,
-                viewUpdateDuration: viewUpdateEndTime - measurementEndTime
+                layoutDuration: layoutEndTime - startTime,
+                viewUpdateDuration: viewUpdateEndTime - layoutEndTime
             )
         )
     }

--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -327,7 +327,7 @@ public final class BlueprintView: UIView {
         needsViewHierarchyUpdate = false
         lastViewHierarchyUpdateBounds = bounds
 
-        let start = Date()
+        let start = CACurrentMediaTime()
         Logger.logLayoutStart(view: self)
 
         let environment = makeEnvironment()
@@ -344,7 +344,7 @@ public final class BlueprintView: UIView {
             .layout(layoutAttributes: LayoutAttributes(frame: rootFrame), environment: environment)
             .resolve() ?? []
 
-        let measurementEndDate = Date()
+        let measurementEndTime = CACurrentMediaTime()
         Logger.logLayoutEnd(view: self)
 
         // The root controller is fixed, and its layout attributes are never applied.
@@ -375,7 +375,7 @@ public final class BlueprintView: UIView {
         }
 
         Logger.logViewUpdateEnd(view: self)
-        let viewUpdateEndDate = Date()
+        let viewUpdateEndTime = CACurrentMediaTime()
 
         hasUpdatedViewHierarchy = true
 
@@ -383,10 +383,10 @@ public final class BlueprintView: UIView {
 
         metricsDelegate?.blueprintView(
             self,
-            completedUpdateWith: .init(
-                totalDuration: viewUpdateEndDate.timeIntervalSince(start),
-                measureDuration: measurementEndDate.timeIntervalSince(start),
-                viewUpdateDuration: viewUpdateEndDate.timeIntervalSince(measurementEndDate)
+            completedRenderWith: .init(
+                totalDuration: viewUpdateEndTime - start,
+                layoutDuration: measurementEndTime - start,
+                viewUpdateDuration: viewUpdateEndTime - measurementEndTime
             )
         )
     }
@@ -449,7 +449,7 @@ public final class BlueprintView: UIView {
 /// Provides performance information for blueprint measurements and updates.
 public protocol BlueprintViewMetricsDelegate: AnyObject {
 
-    func blueprintView(_ view: BlueprintView, completedUpdateWith metrics: BlueprintViewUpdateMetrics)
+    func blueprintView(_ view: BlueprintView, completedRenderWith metrics: BlueprintViewUpdateMetrics)
 
 }
 
@@ -459,7 +459,7 @@ public struct BlueprintViewUpdateMetrics {
     /// The total time it took to apply a new element.
     public var totalDuration: TimeInterval
     /// The time it took to lay out and measure the new element.
-    public var measureDuration: TimeInterval
+    public var layoutDuration: TimeInterval
     /// The time it took to update the on-screen views for the element.
     public var viewUpdateDuration: TimeInterval
 }

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -691,6 +691,26 @@ class BlueprintViewTests: XCTestCase {
         XCTAssertEqual(view.sizeThatFits(CGSize(width: 150, height: 200)), size)
         XCTAssertEqual(measureCount, 3)
     }
+
+    func test_metrics_delegate_completedRenderWith() {
+        let testMetricsDelegate = TestMetricsDelegate()
+
+        let view = BlueprintView()
+        view.metricsDelegate = testMetricsDelegate
+
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+
+        guard let metric = testMetricsDelegate.metrics.first else {
+            XCTFail("No metric generated")
+            return
+        }
+
+        XCTAssertTrue(metric.totalDuration > 0)
+        XCTAssertTrue(metric.layoutDuration > 0)
+        XCTAssertTrue(metric.viewUpdateDuration > 0)
+        XCTAssertEqual(metric.totalDuration, metric.layoutDuration + metric.viewUpdateDuration, accuracy: .ulpOfOne)
+    }
 }
 
 fileprivate struct MeasurableElement: Element {
@@ -830,3 +850,14 @@ private enum LifecycleTestEvent: Equatable, CustomStringConvertible {
     }
 }
 
+private class TestMetricsDelegate: BlueprintViewMetricsDelegate {
+
+    var metrics: [BlueprintUI.BlueprintViewUpdateMetrics] = []
+
+    func blueprintView(
+        _ view: BlueprintUI.BlueprintView,
+        completedRenderWith metrics: BlueprintUI.BlueprintViewUpdateMetrics
+    ) {
+        self.metrics.append(metrics)
+    }
+}

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -709,7 +709,13 @@ class BlueprintViewTests: XCTestCase {
         XCTAssertTrue(metric.totalDuration > 0)
         XCTAssertTrue(metric.layoutDuration > 0)
         XCTAssertTrue(metric.viewUpdateDuration > 0)
-        XCTAssertEqual(metric.totalDuration, metric.layoutDuration + metric.viewUpdateDuration, accuracy: .ulpOfOne)
+
+        // Sanity check that total duration is the sum of the two components.
+        // `accuracy` is generous to account for any accumated error during arithmetic.
+        XCTAssertEqual(
+            metric.totalDuration, metric.layoutDuration + metric.viewUpdateDuration,
+            accuracy: metric.totalDuration.ulp * 2
+        )
     }
 }
 

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -852,11 +852,11 @@ private enum LifecycleTestEvent: Equatable, CustomStringConvertible {
 
 private class TestMetricsDelegate: BlueprintViewMetricsDelegate {
 
-    var metrics: [BlueprintUI.BlueprintViewUpdateMetrics] = []
+    var metrics: [BlueprintUI.BlueprintViewRenderMetrics] = []
 
     func blueprintView(
         _ view: BlueprintUI.BlueprintView,
-        completedRenderWith metrics: BlueprintUI.BlueprintViewUpdateMetrics
+        completedRenderWith metrics: BlueprintUI.BlueprintViewRenderMetrics
     ) {
         self.metrics.append(metrics)
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed `BlueprintViewUpdateMetrics` to `BlueprintViewRenderMetrics`.
+- Renamed `BlueprintViewRenderMetrics.measureDuration` to `layoutDuration`.
+- Renamed `BlueprintViewMetricsDelegate.blueprintView(_:completedUpdateWith:)` to `blueprintView(_:completedRenderWith:)`.
+- `BlueprintViewRenderMetrics` values are now calculated using `CACurrentMediaTime` instead of `Date`.
+
 ### Deprecated
 
 ### Security


### PR DESCRIPTION
This renames a few items related to the `BlueprintViewMetricsDelegate` and improves the calculation of the metric values.

- Renamed `BlueprintViewUpdateMetrics` to `BlueprintViewRenderMetrics`.
- Renamed `BlueprintViewRenderMetrics.measureDuration` to `layoutDuration`.
- Renamed `BlueprintViewMetricsDelegate.blueprintView(_:completedUpdateWith:)` to `blueprintView(_:completedRenderWith:)`.
- `BlueprintViewRenderMetrics` values are now calculated using `CACurrentMediaTime` instead of `Date`.
- Tests for `BlueprintViewMetricsDelegate`.