### PR TITLE
Ensure nested BlueprintViews inherit their environment when inside a UIViewElement

### DIFF
--- a/BlueprintUI/Sources/Element/UIViewElement.swift
+++ b/BlueprintUI/Sources/Element/UIViewElement.swift
@@ -154,6 +154,13 @@ private final class UIViewElementMeasurer {
 
         let view = measurementView(for: element)
 
+        /// Ensure that during measurement / sizing, the inherited `Environment` is available
+        /// to any child `BlueprintView`s. We must manually wire this property up, as the
+        /// measurement views are not in the view hierarchy.
+
+        view.nativeViewNodeBlueprintEnvironment = environment
+        defer { view.nativeViewNodeBlueprintEnvironment = nil }
+
         element.updateUIView(view, with: .init(isMeasuring: true, environment: environment))
 
         return element.size(bounds.size, thatFits: view)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The `Environment` will now automatically inherit for `BlueprintView` instances nested inside `UIViewElement` during measurement.
+
 ### Added
 
 ### Removed


### PR DESCRIPTION
Because these aren't placed into a view hierarchy anywhere, we need to manually perform this wiring.