### PR TITLE
Implement init(byMeasuring:) on ElementContent for measuring nested blueprint view elements

### DIFF
--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -208,7 +208,6 @@ extension ElementContent {
             environment: Environment,
             cache: CacheTree
         ) -> CGSize {
-
             cache.get(constraint) { constraint -> CGSize in
                 child.content.measure(
                     in: constraint,

--- a/BlueprintUI/Tests/ElementContentTests.swift
+++ b/BlueprintUI/Tests/ElementContentTests.swift
@@ -187,9 +187,9 @@ class ElementContentTests: XCTestCase {
         XCTAssertEqual(callCount, 2)
     }
 
-    func test_byMeasuring() {
+    func test_measuring() {
 
-        struct TestElement: Element {
+        struct InnerTestElement: Element {
 
             var measure: (SizeConstraint) -> CGSize
 
@@ -202,26 +202,44 @@ class ElementContentTests: XCTestCase {
             }
         }
 
-        var calls: [SizeConstraint] = []
+        struct OuterTestElement: Element {
 
-        let element = Column {
-            TestElement { constraint in
-                calls.append(constraint)
-                return CGSize(width: 10, height: 10)
+            var element: InnerTestElement
+
+            var content: ElementContent {
+                ElementContent(measuring: element)
+            }
+
+            func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
+                nil
             }
         }
 
+        var calls: [SizeConstraint] = []
+
+        let element = OuterTestElement(
+            element: InnerTestElement { constraint in
+                calls.append(constraint)
+                return CGSize(width: 100, height: 10)
+            }
+        )
+
         let cache = RenderPassCache(name: "Test", signpostRef: NSObject())
 
-        /// Invoke measurement with the same cache twice to ensure repeated calls with the same constraints are cached.
+        /// Should output the size of the inner element.
 
-        _ = element.content.measure(in: .init(CGSize(width: 100, height: 100)), environment: .empty, cache: cache)
-        _ = element.content.measure(in: .init(CGSize(width: 100, height: 100)), environment: .empty, cache: cache)
+        XCTAssertEqual(
+            CGSize(width: 100, height: 10),
+            element.content.measure(in: .init(CGSize(width: 100, height: 100)), environment: .empty, cache: cache)
+        )
 
-        XCTAssertEqual(calls, [
-            SizeConstraint(CGSize(width: 100, height: 100)),
-            SizeConstraint(CGSize(width: 100, height: 10)),
-        ])
+        let layout = element.content.performLayout(
+            attributes: .init(size: CGSize(width: 100, height: 100)),
+            environment: .empty,
+            cache: cache
+        )
+
+        XCTAssertTrue(layout.isEmpty)
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Introduced `ElementContent.init(byMeasuring:)`, for use when your `Element` contains a nested `BlueprintView`, commonly used to implement stateful elements. This avoids detached measurements and improves performance. 
+
 ### Removed
 
 ### Changed
@@ -21,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `BlueprintViewRenderMetrics.measureDuration` to `layoutDuration`.
 - Renamed `BlueprintViewMetricsDelegate.blueprintView(_:completedUpdateWith:)` to `blueprintView(_:completedRenderWith:)`.
 - `BlueprintViewRenderMetrics` values are now calculated using `CACurrentMediaTime` instead of `Date`.
+- `ElementContent.init(child:)` now utilizes a unique `ContentStorage` type, which improves layout performance.
 
 ### Deprecated
 


### PR DESCRIPTION
This ports a fix / improvement from the caching branch, which introduces a new `ElementContent.init(byMeasuring:)`, which allows using the standard cache tree for caching OOB / detached measurements that we do in Market a lot, eg when nesting `BlueprintView`s inside elements. You can see an example of it in use here: https://github.com/squareup/market/compare/main...kve/adopt-bymeasuring. I've also ported an unique `ContentStorage` type, which provides some performance improvements when measuring a single child element.