### PR TITLE
Fix documentation generation by setting explicit ruby version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Switch to Xcode ${{ env.xcode_version }}
         run: sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.ruby_version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
       - name: Generate Docs
         run: |
           bundle

--- a/.github/workflows/env.properties
+++ b/.github/workflows/env.properties
@@ -1,1 +1,2 @@
 xcode_version=14.2
+ruby_version=2.6

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -77,10 +77,6 @@ jobs:
         ruby-version: ${{ env.ruby_version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-    - name: Bundle Install
-      run: |
-        bundle check || bundle install --path .bundle
-
     - name: Pod Install
       run: |
         bundle exec pod install --project-directory=SampleApp/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,7 +74,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: ${{ env.ruby_version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
     - name: Bundle Install


### PR DESCRIPTION
Our documentation generation step [started failing](https://github.com/square/Blueprint/actions/runs/4256655333/jobs/7405802101) after the update to Xcode 14 / macos-12. This PR configures the docs workflow to use an explicit Ruby version (the same as the tests workflow was configured to use).