### PR TITLE
1) Introduce mode control and debugging types

### DIFF
--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -34,11 +34,22 @@ public struct ElementContent {
         measure(
             in: constraint,
             environment: environment,
-            cache: CacheFactory.makeCache(name: "ElementContent")
+            cache: CacheFactory.makeCache(name: "ElementContent"),
+            layoutMode: RenderContext.current?.layoutMode ?? environment.layoutMode
         )
     }
 
-    func measure(in constraint: SizeConstraint, environment: Environment, cache: CacheTree) -> CGSize {
+    func measure(
+        in constraint: SizeConstraint,
+        environment: Environment,
+        cache: CacheTree,
+        layoutMode: LayoutMode
+    ) -> CGSize {
+        // TODO: switch on layoutMode
+        storage.measure(in: constraint, environment: environment, cache: cache)
+    }
+
+    fileprivate func measure(in constraint: SizeConstraint, environment: Environment, cache: CacheTree) -> CGSize {
         storage.measure(in: constraint, environment: environment, cache: cache)
     }
 

--- a/BlueprintUI/Sources/Internal/ElementIdentifier.swift
+++ b/BlueprintUI/Sources/Internal/ElementIdentifier.swift
@@ -41,24 +41,24 @@
 
  You will note that the identifiers remain stable, which ultimately ensures that views are reused.
  */
-struct ElementIdentifier: Hashable, CustomDebugStringConvertible {
+struct ElementIdentifier: Hashable, CustomStringConvertible {
 
-    let elementType: ObjectIdentifier
+    let elementType: Metatype
     let key: AnyHashable?
 
     let count: Int
 
     init(elementType: Element.Type, key: AnyHashable?, count: Int) {
 
-        self.elementType = ObjectIdentifier(elementType)
+        self.elementType = Metatype(elementType)
         self.key = key
 
         self.count = count
     }
 
-    var debugDescription: String {
+    var description: String {
         if let key = key {
-            return "\(elementType).\(String(describing: key)).\(count)"
+            return "\(elementType).\(key).\(count)"
         } else {
             return "\(elementType).\(count)"
         }

--- a/BlueprintUI/Sources/Internal/ElementPath.swift
+++ b/BlueprintUI/Sources/Internal/ElementPath.swift
@@ -1,6 +1,6 @@
 /// Represents a path into an element hierarchy.
 /// Used for disambiguation during diff operations.
-struct ElementPath: Hashable, CustomDebugStringConvertible {
+struct ElementPath: Hashable, CustomStringConvertible {
 
     private var identifiersHash: Int? = nil
 
@@ -44,11 +44,9 @@ struct ElementPath: Hashable, CustomDebugStringConvertible {
         hasher.combine(identifiersHash)
     }
 
-    // MARK: CustomDebugStringConvertible
+    // MARK: CustomStringConvertible
 
-    var debugDescription: String {
-        identifiers.map { $0.debugDescription }.joined()
+    var description: String {
+        identifiers.map(\.description).joined(separator: "/")
     }
 }
-
-

--- a/BlueprintUI/Sources/Internal/LayoutModeKey.swift
+++ b/BlueprintUI/Sources/Internal/LayoutModeKey.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum LayoutModeKey: EnvironmentKey {
+    static let defaultValue: LayoutMode = .default
+}
+
+extension Environment {
+    /// This mode will be inherited by descendant BlueprintViews that do not have an explicit
+    /// mode set.
+    var layoutMode: LayoutMode {
+        get { self[LayoutModeKey.self] }
+        set { self[LayoutModeKey.self] = newValue }
+    }
+}

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -17,6 +17,10 @@ extension Element {
         )
     }
 
+    func layout(frame: CGRect, environment: Environment, layoutMode: LayoutMode) -> LayoutResultNode {
+        // TODO: switch on layoutMode
+        layout(layoutAttributes: LayoutAttributes(frame: frame), environment: environment)
+    }
 }
 
 /// Represents a tree of elements with complete layout attributes
@@ -124,6 +128,26 @@ extension LayoutResultNode {
             }
         }
 
+    }
+
+    /// Recursively dump layout tree, for debugging. By default, prints to stdout.
+    @_spi(BlueprintDebugging)
+    public func dump(
+        depth: Int = 0,
+        visit: ((_ depth: Int, _ identifier: String, _ frame: CGRect) -> Void) = { depth, identifier, frame in
+            let origin = "x \(frame.origin.x), y \(frame.origin.y)"
+            let size = "\(frame.size.width) × \(frame.size.height)"
+            let indent = String(repeating: "  ", count: depth)
+            print("\(indent)\(identifier) \(origin), \(size)")
+        }
+    ) {
+        for child in children {
+            let attributes = child.node.layoutAttributes
+
+            visit(depth, "\(child.identifier)", attributes.frame)
+
+            child.node.dump(depth: depth + 1, visit: visit)
+        }
     }
 
 }

--- a/BlueprintUI/Sources/Internal/Metatype.swift
+++ b/BlueprintUI/Sources/Internal/Metatype.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// A wrapper to make metatypes easier to work with, providing Equatable, Hashable, and
+/// CustomStringConvertible.
+struct Metatype: Hashable, CustomStringConvertible {
+    var type: Any.Type
+
+    init(_ type: Any.Type) {
+        self.type = type
+    }
+
+    var description: String {
+        "\(type)"
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(type))
+    }
+
+    static func == (lhs: Metatype, rhs: Metatype) -> Bool {
+        lhs.type == rhs.type
+    }
+}

--- a/BlueprintUI/Sources/Internal/RenderContext.swift
+++ b/BlueprintUI/Sources/Internal/RenderContext.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Stores info about the currently running render pass, if there is one.
+///
+/// The render context is available statically, which allows "out of band" operations like
+/// calls to ``ElementContent/measure(in:environment:)`` to get some context without having it
+/// passed in explicitly. This depends entirely on the render pass running exclusively on the main
+/// thread.
+struct RenderContext {
+    /// The current render context, if there is one.
+    private(set) static var current: Self?
+
+    var layoutMode: LayoutMode
+
+    /// Perform the given block with this as the current render context, restoring the previous
+    /// context before returning.
+    func perform<Result>(block: () throws -> Result) rethrows -> Result {
+        let previous = Self.current
+        defer { Self.current = previous }
+
+        Self.current = self
+
+        return try block()
+    }
+}

--- a/BlueprintUI/Sources/Layout/Alignment.swift
+++ b/BlueprintUI/Sources/Layout/Alignment.swift
@@ -51,7 +51,7 @@ public protocol AlignmentID {
 }
 
 /// An alignment position along the horizontal axis.
-public struct HorizontalAlignment: Equatable {
+public struct HorizontalAlignment: Equatable, CustomStringConvertible {
 
     var id: AlignmentID.Type
 
@@ -65,10 +65,14 @@ public struct HorizontalAlignment: Equatable {
     public static func == (lhs: HorizontalAlignment, rhs: HorizontalAlignment) -> Bool {
         lhs.id == rhs.id
     }
+
+    public var description: String {
+        "\(id)"
+    }
 }
 
 /// An alignment position along the vertical axis.
-public struct VerticalAlignment: Equatable {
+public struct VerticalAlignment: Equatable, CustomStringConvertible {
 
     var id: AlignmentID.Type
 
@@ -81,6 +85,10 @@ public struct VerticalAlignment: Equatable {
 
     public static func == (lhs: VerticalAlignment, rhs: VerticalAlignment) -> Bool {
         lhs.id == rhs.id
+    }
+
+    public var description: String {
+        "\(id)"
     }
 }
 

--- a/BlueprintUI/Sources/Layout/LayoutMode.swift
+++ b/BlueprintUI/Sources/Layout/LayoutMode.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Controls the layout system that Blueprint uses to lay out elements.
+///
+/// Blueprint supports multiple layout systems. Each is expected to produce the same result, but
+/// some may have different performance profiles or special requirements.
+///
+/// You can change the layout system used by setting the ``BlueprintView/layoutMode`` property, but
+/// generally you should use the ``default`` option.
+///
+public enum LayoutMode: Equatable {
+    public static let `default`: Self = .legacy
+
+    /// The "standard" layout system.
+    case legacy
+
+    /// A newer layout system with some optimizations made possible by ensuring elements adhere
+    /// certain contract for behavior.
+    case caffeinated
+}

--- a/BlueprintUI/Sources/Measuring/SizeConstraint.swift
+++ b/BlueprintUI/Sources/Measuring/SizeConstraint.swift
@@ -4,7 +4,7 @@ import UIKit
 ///
 /// Currently this constraint type can only handles layout where
 /// the primary (breaking) axis is horizontal (row in CSS-speak).
-public struct SizeConstraint: Hashable, CustomDebugStringConvertible {
+public struct SizeConstraint: Hashable, CustomStringConvertible {
 
     /// The width constraint.
     @UnconstrainedInfiniteAxis public var width: Axis
@@ -19,8 +19,8 @@ public struct SizeConstraint: Hashable, CustomDebugStringConvertible {
 
     // MARK: CustomDebugStringConvertible
 
-    public var debugDescription: String {
-        "<SizeConstraint: \(width.debugDescription) x \(height.debugDescription)>"
+    public var description: String {
+        "\(width) × \(height)"
     }
 }
 
@@ -62,7 +62,7 @@ extension SizeConstraint {
 extension SizeConstraint {
 
     /// Represents a size constraint for a single axis.
-    public enum Axis: Hashable, CustomDebugStringConvertible {
+    public enum Axis: Hashable, CustomStringConvertible {
 
         /// The measurement should treat the associated value as the largest
         /// possible size in the given dimension.
@@ -192,7 +192,7 @@ extension SizeConstraint {
 
         // MARK: CustomDebugStringConvertible
 
-        public var debugDescription: String {
+        public var description: String {
             switch self {
             case .atMost(let max):
                 return "atMost(\(max))"

--- a/BlueprintUI/Tests/ElementContentTests.swift
+++ b/BlueprintUI/Tests/ElementContentTests.swift
@@ -106,7 +106,8 @@ class ElementContentTests: XCTestCase {
             _ = container.measure(
                 in: SizeConstraint(containerSize),
                 environment: .empty,
-                cache: cache
+                cache: cache,
+                layoutMode: .legacy
             )
 
             return (cache, counts)

--- a/BlueprintUI/Tests/RenderContextTests.swift
+++ b/BlueprintUI/Tests/RenderContextTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import XCTest
+@testable import BlueprintUI
+
+final class RenderContextTests: XCTestCase {
+    func test_mode() {
+        let view = BlueprintView()
+        XCTAssertNil(view.layoutMode)
+
+        let defaultMode: LayoutMode = .default
+        let overrideMode: LayoutMode = defaultMode == .legacy
+            ? .caffeinated
+            : .legacy
+
+        var contextualMode: LayoutMode?
+
+        view.element = EnvironmentReader { _ in
+
+            // this element measurement is "out-of-band", meaning the enclosing render doesn't
+            // know about it and can't explicitly pass it any info
+            _ = EnvironmentReader { _ in
+                contextualMode = RenderContext.current?.layoutMode
+                return Empty()
+            }
+            .content
+            .measure(in: .unconstrained, environment: .empty)
+
+            return Empty()
+        }
+
+        view.ensureLayoutPass()
+        XCTAssertEqual(contextualMode, defaultMode)
+
+        view.layoutMode = overrideMode
+        view.ensureLayoutPass()
+        XCTAssertEqual(contextualMode, overrideMode)
+    }
+}


### PR DESCRIPTION
This is PR 1 in a stack targeting `feature/caffeinated-layout`. You can see how it fits into the larger picture by looking at the staging branch in #434 .

It introduces the `LayoutMode` enum and `RenderContext` type, along with some setting up some related debugging changes. Largely the same as it was in #374, targeting the SPL branch.