### PR TITLE
3) Caffeinated layout path

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -231,7 +231,7 @@ public final class BlueprintView: UIView {
             element.content.measure(
                 in: constraint,
                 environment: environment,
-                cache: CacheFactory.makeCache(name: cacheName),
+                cacheName: cacheName,
                 layoutMode: layoutMode
             )
         }

--- a/BlueprintUI/Sources/Element/ContentStorage.swift
+++ b/BlueprintUI/Sources/Element/ContentStorage.swift
@@ -1,18 +1,50 @@
 import CoreGraphics
 
 /// The implementation of an `ElementContent`.
-protocol ContentStorage {
+protocol ContentStorage: LegacyContentStorage, CaffeinatedContentStorage {
     var childCount: Int { get }
+}
 
+protocol LegacyContentStorage {
     func measure(
         in constraint: SizeConstraint,
         environment: Environment,
         cache: CacheTree
     ) -> CGSize
 
-    func performLayout(
+    func performLegacyLayout(
         attributes: LayoutAttributes,
         environment: Environment,
         cache: CacheTree
-    ) -> [(identifier: ElementIdentifier, node: LayoutResultNode)]
+    ) -> [ElementContent.IdentifiedNode]
+}
+
+protocol CaffeinatedContentStorage {
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        context: MeasureContext
+    ) -> CGSize
+
+    func performCaffeinatedLayout(
+        frame: CGRect,
+        context: LayoutContext
+    ) -> [ElementContent.IdentifiedNode]
+}
+
+// TODO: temporary conformance
+
+extension CaffeinatedContentStorage {
+    public func sizeThatFits(
+        proposal: SizeConstraint,
+        context: MeasureContext
+    ) -> CGSize {
+        fatalError("not implemented")
+    }
+
+    public func performCaffeinatedLayout(
+        frame: CGRect,
+        context: LayoutContext
+    ) -> [ElementContent.IdentifiedNode] {
+        fatalError("not implemented")
+    }
 }

--- a/BlueprintUI/Sources/Element/EnvironmentAdaptingStorage.swift
+++ b/BlueprintUI/Sources/Element/EnvironmentAdaptingStorage.swift
@@ -11,7 +11,7 @@ struct EnvironmentAdaptingStorage: ContentStorage {
 
     var child: Element
 
-    func performLayout(
+    func performLegacyLayout(
         attributes: LayoutAttributes,
         environment: Environment,
         cache: CacheTree
@@ -26,7 +26,7 @@ struct EnvironmentAdaptingStorage: ContentStorage {
             element: child,
             layoutAttributes: childAttributes,
             environment: environment,
-            children: child.content.performLayout(
+            children: child.content.performLegacyLayout(
                 attributes: childAttributes,
                 environment: environment,
                 cache: cache.subcache(element: child)

--- a/BlueprintUI/Sources/Element/LayoutStorage.swift
+++ b/BlueprintUI/Sources/Element/LayoutStorage.swift
@@ -35,7 +35,7 @@ struct LayoutStorage<LayoutType: Layout>: ContentStorage {
         }
     }
 
-    func performLayout(
+    func performLegacyLayout(
         attributes: LayoutAttributes,
         environment: Environment,
         cache: CacheTree
@@ -65,7 +65,7 @@ struct LayoutStorage<LayoutType: Layout>: ContentStorage {
                 element: currentChild.element,
                 layoutAttributes: currentChildLayoutAttributes,
                 environment: environment,
-                children: currentChild.content.performLayout(
+                children: currentChild.content.performLegacyLayout(
                     attributes: currentChildLayoutAttributes,
                     environment: environment,
                     cache: currentChildCache

--- a/BlueprintUI/Sources/Element/LazyStorage.swift
+++ b/BlueprintUI/Sources/Element/LazyStorage.swift
@@ -6,7 +6,7 @@ struct LazyStorage: ContentStorage {
 
     var builder: (ElementContent.LayoutPhase, SizeConstraint, Environment) -> Element
 
-    func performLayout(
+    func performLegacyLayout(
         attributes: LayoutAttributes,
         environment: Environment,
         cache: CacheTree
@@ -21,7 +21,7 @@ struct LazyStorage: ContentStorage {
             element: child,
             layoutAttributes: childAttributes,
             environment: environment,
-            children: child.content.performLayout(
+            children: child.content.performLegacyLayout(
                 attributes: childAttributes,
                 environment: environment,
                 cache: cache.subcache(element: child)

--- a/BlueprintUI/Sources/Element/MeasurableStorage.swift
+++ b/BlueprintUI/Sources/Element/MeasurableStorage.swift
@@ -7,7 +7,7 @@ struct MeasurableStorage: ContentStorage {
 
     let measurer: (SizeConstraint, Environment) -> CGSize
 
-    func performLayout(
+    func performLegacyLayout(
         attributes: LayoutAttributes,
         environment: Environment,
         cache: CacheTree

--- a/BlueprintUI/Sources/Element/MeasureElementStorage.swift
+++ b/BlueprintUI/Sources/Element/MeasureElementStorage.swift
@@ -2,6 +2,8 @@ import Foundation
 
 struct MeasureElementStorage: ContentStorage {
 
+    typealias IdentifiedNode = ElementContent.IdentifiedNode
+
     let child: Element
 
     let childCount: Int = 0
@@ -29,11 +31,11 @@ struct MeasureElementStorage: ContentStorage {
         }
     }
 
-    func performLayout(
+    func performLegacyLayout(
         attributes: LayoutAttributes,
         environment: Environment,
         cache: CacheTree
-    ) -> [(identifier: ElementIdentifier, node: LayoutResultNode)] {
+    ) -> [IdentifiedNode] {
         []
     }
 }

--- a/BlueprintUI/Sources/Element/PassthroughStorage.swift
+++ b/BlueprintUI/Sources/Element/PassthroughStorage.swift
@@ -4,6 +4,8 @@ import Foundation
 /// another child, without any modification.
 struct PassthroughStorage: ContentStorage {
 
+    typealias IdentifiedNode = ElementContent.IdentifiedNode
+
     let childCount: Int = 1
 
     var child: Element
@@ -32,11 +34,11 @@ struct PassthroughStorage: ContentStorage {
         }
     }
 
-    func performLayout(
+    func performLegacyLayout(
         attributes: LayoutAttributes,
         environment: Environment,
         cache: CacheTree
-    ) -> [(identifier: ElementIdentifier, node: LayoutResultNode)] {
+    ) -> [IdentifiedNode] {
 
         let childAttributes = LayoutAttributes(size: attributes.bounds.size)
 
@@ -46,7 +48,7 @@ struct PassthroughStorage: ContentStorage {
             element: child,
             layoutAttributes: childAttributes,
             environment: environment,
-            children: child.content.performLayout(
+            children: child.content.performLegacyLayout(
                 attributes: childAttributes,
                 environment: environment,
                 cache: cache.subcache(element: child)

--- a/BlueprintUI/Sources/Internal/LayoutContext.swift
+++ b/BlueprintUI/Sources/Internal/LayoutContext.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct LayoutContext {
+    var environment: Environment
+
+    // TODO:
+    // var node: LayoutTreeNode
+}

--- a/BlueprintUI/Sources/Internal/MeasureContext.swift
+++ b/BlueprintUI/Sources/Internal/MeasureContext.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct MeasureContext {
+    var environment: Environment
+    // TODO:
+    // var node: LayoutTreeNode
+}

--- a/BlueprintUI/Sources/Layout/Layout.swift
+++ b/BlueprintUI/Sources/Layout/Layout.swift
@@ -1,29 +1,125 @@
-import UIKit
+import CoreGraphics
 
-/// Conforming types can calculate layout attributes for an array of children.
-public protocol Layout {
+/// A type that defines the geometry of a collection of elements.
+///
+/// You traditionally arrange views in your app's user interface using built-in layout containers
+/// like ``Row`` and ``Column``. If  you need more complex layout behavior, you can define a custom
+/// layout container by creating a type that conforms to the ``Layout`` protocol and implementing
+/// its required methods:
+///
+/// - ``CaffeinatedLayout/sizeThatFits(proposal:subelements:cache:)`` reports the sizes of the
+///   composite layout.
+/// - ``CaffeinatedLayout/placeSubelements(in:subelements:cache:)`` assigns positions to the
+///   container's subelements.
+///
+/// You can define a basic layout type with only these two methods (see note below):
+///
+/// ```swift
+/// struct BasicLayout: Layout {
+///     func sizeThatFits(
+///         proposal: SizeConstraint,
+///         subelements: Subelements,
+///         cache: inout ()
+///     ) -> CGSize {
+///         // Calculate and return the size of the layout container.
+///     }
+///
+///     func placeSubelements(
+///         in size: CGSize,
+///         subelements: Subelements,
+///         cache: inout ()
+///     ) {
+///         // Tell each subelement where to appear.
+///     }
+/// }
+/// ```
+///
+/// Add your layout to an element by passing it to the `ElementContent` initializer
+/// ``ElementContent/init(layout:configure:)``. If your layout has parameters that come from the
+/// element, pass them at initialization time. Use the `configure` block to add your element's
+/// children to the content.
+///
+/// ```swift
+/// struct BasicContainer: Element {
+///     var alignment: Alignment = .center
+///     var children: [Element]
+///
+///     var content: ElementContent {
+///         ElementContent(layout: BasicLayout(alignment: alignment)) { builder in
+///             for child in children {
+///                 builder.add(element: child)
+///             }
+///         }
+///     }
+///
+///     func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
+///         nil
+///     }
+/// }
+/// ```
+///
+/// If your layout is specialized for laying out a single subelement, you can use the
+/// ``SingleChildLayout`` protocol instead. It has similar methods, but is strongly typed for a
+/// single subelement instead of a collection.
+///
+/// - Note: During the transition from Blueprint's legacy layout system to Caffeinated Layout, the
+///   ``Layout`` protocol is composed of two sets of layout methods: ``LegacyLayout`` and
+///   ``CaffeinatedLayout``. While this documentation focuses on the newer layout API, you must
+///   currently implement both. Fortunately, the methods are similar, and you may be able to reuse
+///   logic.
+///
+/// ## Interact with subelements through their proxies
+///
+/// To perform layout, you need information about all of your container's subelements, which are the
+/// child elements that your container arranges. While your layout can’t interact directly with its
+/// subelements, it can access a set of subelement proxies through the
+/// ``CaffeinatedLayout/Subelements`` collection that each protocol method receives as an input
+/// parameter. That type is an alias for the ``LayoutSubelements`` collection type, which in turn
+/// contains ``LayoutSubelement`` instances that are the subelement proxies.
+///
+/// You can get information about each subelement from its proxy, like its dimensions and traits.
+/// This enables you to measure subelements before you commit to placing them. You also assign a
+/// position to each subelement by calling its proxy’s ``LayoutSubelement/place(at:anchor:size:)``
+/// method. Call the method on each subelement from within your implementation of the layout’s
+/// ``CaffeinatedLayout/placeSubelements(in:subelements:cache:)`` method.
+///
+/// ## Access layout traits
+///
+/// Subelements may have _traits_ that are specific to their container's layout. The traits are of
+/// the ``Layout`` protocol's associated type ``LegacyLayout/Traits``, and each subelement can have
+/// a distinct `Traits` value assigned. You can set this in the `configure` block of
+/// ``ElementContent/init(layout:configure:)``, when you call
+/// ``ElementContent/Builder/add(traits:key:element:)``. If you do not specify a `Traits` type for
+/// your layout, it defaults to the void type, `()`.
+///
+/// Containers can choose to condition their behavior according to the traits of their subelements.
+/// For example, the ``Row`` and ``Column`` types allocate space to their subelements based in part
+/// on the grow and shrink priorities that you set on each child. Your layout container accesses the
+/// traits for a subelement by calling ``LayoutSubelement/traits(forLayoutType:)`` on the
+/// ``LayoutSubelement`` proxy.
+///
+public protocol Layout: LegacyLayout, CaffeinatedLayout {}
 
+public protocol LegacyLayout {
     /// Per-item metadata that is used during the measuring and layout pass.
     associatedtype Traits = ()
 
-    /// Computes the size that this layout requires in a layout, given an array
-    /// of chidren and accompanying layout traits.
+    /// Computes the size that this layout requires in a layout, given an array of children and
+    /// accompanying layout traits.
     ///
-    /// - parameter constraint: The size constraint in which measuring should
-    ///   occur.
-    /// - parameter items: An array of 'items', pairs consisting of a traits
-    ///   object and a `Measurable` value.
+    /// - parameter constraint: The size constraint in which measuring should occur.
+    /// - parameter items: An array of 'items', pairs consisting of a traits object and a
+    ///   `Measurable` value.
     ///
     /// - returns: The measured size for the given array of items.
     func measure(in constraint: SizeConstraint, items: [(traits: Self.Traits, content: Measurable)]) -> CGSize
 
     /// Generates layout attributes for the given items.
     ///
-    /// - parameter size: The size that layout attributes should be generated
-    ///   within.
+    /// - parameter size: The size that layout attributes should be generated within.
     ///
-    /// - parameter items: An array of 'items', pairs consisting of a traits
-    ///   object and a `Measurable` value.
+    /// - parameter items: An array of 'items', pairs consisting of a traits object and a
+    ///   `Measurable` value.
     ///
     /// - returns: Layout attributes for the given array of items.
     func layout(size: CGSize, items: [(traits: Self.Traits, content: Measurable)]) -> [LayoutAttributes]
@@ -33,10 +129,172 @@ public protocol Layout {
 
 }
 
-extension Layout where Traits == () {
+extension LegacyLayout where Traits == () {
 
     public static var defaultTraits: () {
         return ()
     }
 
+}
+
+public protocol CaffeinatedLayout {
+
+    typealias Subelements = LayoutSubelements
+
+    /// Cached values associated with the layout instance.
+    ///
+    /// If you create a cache for your custom layout, you can use a type alias to define this type
+    /// as your data storage type. Alternatively, you can refer to the data storage type directly in
+    /// all the places where you work with the cache.
+    ///
+    /// See ``makeCache(subelements:)-4kmy2`` for more information.
+    associatedtype Cache = Void
+
+    /// Returns the size of the composite element, given a proposed size constraint and the
+    /// container's subelements.
+    ///
+    /// Implement this method to tell your custom layout container’s parent how much space the
+    /// container needs for a set of subelements, given a size constraint. The parent might call
+    /// this method more than once during a layout pass with different proposed sizes to test the
+    /// flexibility of the container.
+    ///
+    /// In Blueprint, parents ultimately choose the size of their children, so the actual size that
+    /// this container is laid out in may not be a size that was returned from this method.
+    ///
+    /// ## Sizing Rules
+    ///
+    /// For performance reasons, the layout engine may deduce the measurement of your container for
+    /// some constraint values without explicitly calling
+    /// ``sizeThatFits(proposal:subelements:cache:)``. To ensure that the deduced value is correct,
+    /// your layout must follow some ground rules:
+    ///
+    /// 1. **Given one fixed constraint axis, the element's growth along the other axis should be
+    ///    _monotonic_.** That is, an element can grow when given a larger constraint, or shrink
+    ///    when given a smaller constraint, but it should never shrink when given a larger
+    ///    constraint. When growing on one axis, it is OK to shrink along the other axis, such as a
+    ///    block of text that re-flows as the width changes.
+    /// 2. If your element has no intrinsic size along an axis, you can represent that in a couple
+    ///     ways:
+    ///     - You can return a fixed value representing the minimum size for your element. In this
+    ///       approach, a containing element is usually responsible for stretching your element to
+    ///       fill desired space.
+    ///     - You can return a size that entirely fills the constraint proposed. In this approach,
+    ///       you **must** return `.infinity` when the constraint is
+    ///       ``SizeConstraint/Axis/unconstrained``. Otherwise, your behavior would be in violation
+    ///       of rule #1.
+    ///
+    /// - Parameters:
+    ///   - proposal: A size constraint for the container. The container's parent element that calls
+    ///     this method might call the method more than once with different constraints to learn
+    ///     more about the container’s flexibility before choosing a size for placement.
+    ///   - subelements: A collection of proxies that represent the elements that the container
+    ///     arranges. You can use the proxies in the collection to get information about the
+    ///     subelements as you determine how much space the container needs to display them.
+    ///   - cache: Optional storage for calculated data that you can share among the methods of your
+    ///     custom layout container. See ``makeCache(subelements:)-4kmy2`` for details.
+    /// - Returns: A size that indicates how much space the container needs to arrange its
+    ///   subelements.
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        subelements: Subelements,
+        cache: inout Cache
+    ) -> CGSize
+
+    /// Assigns positions to each of the layout’s subelements.
+    ///
+    /// Blueprint calls your implementation of this method to tell your custom layout container to
+    /// place its subelements. From this method, call the
+    /// ``LayoutSubelement/place(at:anchor:size:)`` method on each item in `subelements` to tell the
+    /// subelements where to appear in the user interface.
+    ///
+    /// You can also update the ``LayoutSubelement/attributes-swift.property`` property of each
+    /// subelement to set properties like opacity and transforms on each subelement.
+    ///
+    /// Be sure that you use computations during placement that are consistent with those in your
+    /// implementation of other protocol methods for a given set of inputs. For example, if you add
+    /// spacing during placement, make sure your implementation of
+    /// ``sizeThatFits(proposal:subelements:cache:)`` accounts for the extra space.
+    ///
+    /// - Parameters:
+    ///   - size: The region that the container's parent allocates to the container. Place all the
+    ///     container's subelements within the region. The size of this region may not match any
+    ///     size that was returned from a call to ``sizeThatFits(proposal:subelements:cache:)``.
+    ///   - subelements: A collection of proxies that represent the elements that the container
+    ///     arranges. Use the proxies in the collection to get information about the subelements and
+    ///     to tell the subelements where to appear.
+    ///   - cache: Optional storage for calculated data that you can share among the methods of your
+    ///     custom layout container. See ``makeCache(subelements:)-4kmy2`` for details.
+    func placeSubelements(
+        in size: CGSize,
+        subelements: Subelements,
+        cache: inout Cache
+    )
+
+    /// Creates and initializes a cache for a layout instance.
+    ///
+    /// You can optionally use a cache to preserve calculated values across calls to a layout
+    /// container’s methods. Many layout types don’t need a cache, because Blueprint automatically
+    /// caches the results of calls into layout methods, such as
+    /// ``LayoutSubelement/sizeThatFits(_:)``. Rely on the protocol’s default implementation of this
+    /// method if you don’t need a cache.
+    ///
+    /// However you might find a cache useful when the layout container repeats complex intermediate
+    /// calculations across calls to ``sizeThatFits(proposal:subelements:cache:)`` and
+    /// ``placeSubelements(in:subelements:cache:)``. You might be able to improve performance by
+    /// calculating values once and storing them in a cache.
+    ///
+    /// - Note: A cache's lifetime is limited to a single render pass, so you cannot use it to store
+    ///   values across multiple calls to ``placeSubelements(in:subelements:cache:)``. A render pass
+    ///   includes zero, one, or many calls to ``sizeThatFits(proposal:subelements:cache:)``,
+    ///   followed by a single call to ``placeSubelements(in:subelements:cache:)``.
+    ///
+    /// Only implement a cache if profiling shows that it improves performance.
+    ///
+    /// ## Initializing a cache
+    ///
+    /// Implement the `makeCache(subelements:)` method to create a cache. You can add computed
+    /// values to the cache right away, using information from the subelements input parameter, or
+    /// you can do that later. The methods of the ``Layout`` protocol that can access the cache take
+    /// the cache as an in-out parameter, which enables you to modify the cache anywhere that you
+    /// can read it.
+    ///
+    /// You can use any storage type that makes sense for your layout algorithm, but be sure that
+    /// you only store data that you derive from the layout and its subelements (lazily, if
+    /// possible). For this to work correctly, Blueprint needs to be able to call this method to
+    /// recreate the cache without changing the layout result.
+    ///
+    /// When you return a cache from this method, you implicitly define a type for your cache. Be
+    /// sure to either make the type of the cache parameters on your other ``Layout`` protocol
+    /// methods match, or use a type alias to define the ``Cache`` associated type.
+    ///
+    /// - Parameter subelements: A collection of proxy instances that represent the subelements that
+    ///   the container arranges. You can use the proxies in the collection to get information about
+    ///   the subelements as you calculate values to store in the cache.
+    /// - Returns: Storage for calculated data that you share among the methods of your custom
+    ///   layout container.
+    func makeCache(subelements: Subelements) -> Cache
+}
+
+extension CaffeinatedLayout where Cache == () {
+    public func makeCache(subelements: Subelements) { () }
+}
+
+// TODO: Temporary conformance fulfillment
+
+extension CaffeinatedLayout {
+    public func sizeThatFits(
+        proposal: SizeConstraint,
+        subelements: Subelements,
+        cache: inout Cache
+    ) -> CGSize {
+        fatalError("not implemented")
+    }
+
+    public func placeSubelements(
+        in size: CGSize,
+        subelements: Subelements,
+        cache: inout Cache
+    ) {
+        fatalError("not implemented")
+    }
 }

--- a/BlueprintUI/Sources/Layout/LayoutSubelement.swift
+++ b/BlueprintUI/Sources/Layout/LayoutSubelement.swift
@@ -1,0 +1,8 @@
+import CoreGraphics
+
+
+public typealias LayoutSubelements = [LayoutSubelement]
+
+public struct LayoutSubelement {
+    // TODO:
+}

--- a/BlueprintUI/Sources/Layout/SingleChildLayout.swift
+++ b/BlueprintUI/Sources/Layout/SingleChildLayout.swift
@@ -1,7 +1,15 @@
 import UIKit
 
-/// Conforming types can calculate layout attributes for an array of children.
-public protocol SingleChildLayout {
+/// A type that defines the geometry of a single element.
+///
+/// For convenience, you can implement this protocol instead of ``Layout`` when building a container
+/// that always has a single child element.
+///
+/// For more information about writing custom layouts, see ``Layout``.
+///
+public protocol SingleChildLayout: LegacySingleChildLayout, CaffeinatedSingleChildLayout {}
+
+public protocol LegacySingleChildLayout {
 
     /// Computes the size that this layout requires
     ///
@@ -20,4 +28,165 @@ public protocol SingleChildLayout {
     /// - returns: Layout attributes for the child of this layout.
     func layout(size: CGSize, child: Measurable) -> LayoutAttributes
 
+}
+
+public protocol CaffeinatedSingleChildLayout {
+
+    typealias Subelement = LayoutSubelement
+
+    /// Cached values associated with the layout instance.
+    ///
+    /// If you create a cache for your custom layout, you can use a type alias to define this type
+    /// as your data storage type. Alternatively, you can refer to the data storage type directly in
+    /// all the places where you work with the cache.
+    ///
+    /// See ``makeCache(subelement:)-33y4l`` for more information.
+    associatedtype Cache = Void
+
+    /// Returns the size of the element, given a proposed size constraint and the container's
+    /// subelement.
+    ///
+    /// Implement this method to tell your custom layout container’s parent how much space the
+    /// container needs for a subelement, given a size constraint. The parent might call this method
+    /// more than once during a layout pass with different proposed sizes to test the flexibility of
+    /// the container.
+    ///
+    /// In Blueprint, parents ultimately choose the size of their children, so the actual size that
+    /// this container is laid out in may not be a size that was returned from this method.
+    ///
+    /// ## Sizing Rules
+    ///
+    /// For performance reasons, the layout engine may deduce the measurement of your container for
+    /// some constraint values without explicitly calling
+    /// ``sizeThatFits(proposal:subelement:cache:)``. To ensure that the deduced value is correct,
+    /// your layout must follow some ground rules:
+    ///
+    /// 1. **Given one fixed constraint axis, the element's growth along the other axis should be
+    ///    _monotonic_.** That is, an element can grow when given a larger constraint, or shrink
+    ///    when given a smaller constraint, but it should never shrink when given a larger
+    ///    constraint. When growing on one axis, it is OK to shrink along the other axis, such as a
+    ///    block of text that re-flows as the width changes.
+    /// 2. If your element has no intrinsic size along an axis, you can represent that in a couple
+    ///     ways:
+    ///     - You can return a fixed value representing the minimum size for your element. In this
+    ///       approach, a containing element is usually responsible for stretching your element to
+    ///       fill desired space.
+    ///     - You can return a size that entirely fills the constraint proposed. In this approach,
+    ///       you **must** return `.infinity` when the constraint is
+    ///       ``SizeConstraint/Axis/unconstrained``. Otherwise, your behavior would be in violation
+    ///       of rule #1.
+    ///
+    /// - Parameters:
+    ///   - proposal: A size constraint for the container. The container's parent element that calls
+    ///     this method might call the method more than once with different constraints to learn
+    ///     more about the container’s flexibility before choosing a size for placement.
+    ///   - subelement: A proxy that represents the element that the container arranges. You can use
+    ///     the proxy to get information about the subelement as you determine how much space the
+    ///     container needs to display it.
+    ///   - cache: Optional storage for calculated data that you can share among the methods of your
+    ///     custom layout container. See ``makeCache(subelement:)-33y4l`` for details.
+    /// - Returns: A size that indicates how much space the container needs to arrange its
+    ///   subelement.
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        subelement: Subelement,
+        cache: inout Cache
+    ) -> CGSize
+
+    /// Assigns a position to the layout’s subelement.
+    ///
+    /// Blueprint calls your implementation of this method to tell your custom layout container to
+    /// place its subelement. From this method, call the ``LayoutSubelement/place(at:anchor:size:)``
+    /// method on `subelement` to tell the subelement where to appear in the user interface.
+    ///
+    /// You can also update the ``LayoutSubelement/attributes-swift.property`` property to set
+    /// properties like opacity and transforms on the subelement.
+    ///
+    /// Be sure that you use computations during placement that are consistent with those in your
+    /// implementation of other protocol methods for a given set of inputs. For example, if you add
+    /// spacing during placement, make sure your implementation of
+    /// ``sizeThatFits(proposal:subelement:cache:)`` accounts for the extra space.
+    ///
+    /// - Parameters:
+    ///   - size: The region that the container's parent allocates to the container. Place the
+    ///     container's subelement within the region. The size of this region may not match any size
+    ///     that was returned from a call to ``sizeThatFits(proposal:subelement:cache:)``.
+    ///   - subelement: A proxy that represents the element that the container arranges. Use the
+    ///     proxy to get information about the subelement and to tell the subelement where to
+    ///     appear.
+    ///   - cache: Optional storage for calculated data that you can share among the methods of your
+    ///     custom layout container. See ``makeCache(subelement:)-33y4l`` for details.
+    func placeSubelement(
+        in size: CGSize,
+        subelement: Subelement,
+        cache: inout Cache
+    )
+
+    /// Creates and initializes a cache for a layout instance.
+    ///
+    /// You can optionally use a cache to preserve calculated values across calls to a layout
+    /// container’s methods. Many layout types don’t need a cache, because Blueprint automatically
+    /// caches the results of calls into layout methods, such as
+    /// ``LayoutSubelement/sizeThatFits(_:)``. Rely on the protocol’s default implementation of this
+    /// method if you don’t need a cache.
+    ///
+    /// However you might find a cache useful when the layout container repeats complex intermediate
+    /// calculations across calls to ``sizeThatFits(proposal:subelement:cache:)`` and
+    /// ``placeSubelement(in:subelement:cache:)``. You might be able to improve performance by
+    /// calculating values once and storing them in a cache.
+    ///
+    /// - Note: A cache's lifetime is limited to a single render pass, so you cannot use it to store
+    ///   values across multiple calls to ``placeSubelement(in:subelement:cache:)``. A render pass
+    ///   includes zero, one, or many calls to ``sizeThatFits(proposal:subelement:cache:)``,
+    ///   followed by a single call to ``placeSubelement(in:subelement:cache:)``.
+    ///
+    /// Only implement a cache if profiling shows that it improves performance.
+    ///
+    /// ## Initializing a cache
+    ///
+    /// Implement the `makeCache(subelement:)` method to create a cache. You can add computed values
+    /// to the cache right away, using information from the subelement input parameter, or you can
+    /// do that later. The methods of the ``SingleChildLayout`` protocol that can access the cache
+    /// take the cache as an in-out parameter, which enables you to modify the cache anywhere that
+    /// you can read it.
+    ///
+    /// You can use any storage type that makes sense for your layout algorithm, but be sure that
+    /// you only store data that you derive from the layout and its subelement (lazily, if
+    /// possible). For this to work correctly, Blueprint needs to be able to call this method to
+    /// recreate the cache without changing the layout result.
+    ///
+    /// When you return a cache from this method, you implicitly define a type for your cache. Be
+    /// sure to either make the type of the cache parameters on your other ``SingleChildLayout``
+    /// protocol methods match, or use a type alias to define the ``Cache`` associated type.
+    ///
+    /// - Parameter subelement: A proxy that represent the subelement that the container arranges.
+    ///   You can use the proxy to get information about the subelement as you calculate values to
+    ///   store in the cache.
+    /// - Returns: Storage for calculated data that you share among the methods of your custom
+    ///   layout container.
+    func makeCache(subelement: Subelement) -> Cache
+}
+
+extension CaffeinatedSingleChildLayout where Cache == () {
+    public func makeCache(subelement: Subelement) { () }
+}
+
+// TODO: temporary conformance
+
+extension CaffeinatedSingleChildLayout {
+    public func sizeThatFits(
+        proposal: SizeConstraint,
+        subelement: Subelement,
+        cache: inout Cache
+    ) -> CGSize {
+        fatalError("not implemented")
+    }
+
+    public func placeSubelement(
+        in size: CGSize,
+        subelement: Subelement,
+        cache: inout Cache
+    ) {
+        fatalError("not implemented")
+    }
 }

--- a/BlueprintUI/Tests/Element+Testing.swift
+++ b/BlueprintUI/Tests/Element+Testing.swift
@@ -9,7 +9,11 @@ extension Element {
     ///
     /// - Returns: A layout result
     func layout(frame: CGRect, environment: Environment = .empty) -> LayoutResultNode {
-        layout(layoutAttributes: LayoutAttributes(frame: frame), environment: environment)
+        layout(
+            frame: frame,
+            environment: environment,
+            layoutMode: RenderContext.current?.layoutMode ?? .default
+        )
     }
 }
 
@@ -26,10 +30,19 @@ extension ElementContent {
     /// A convenience wrapper to perform layout during testing, using a default `Environment` and
     /// a new cache.
     func testLayout(attributes: LayoutAttributes) -> [(identifier: ElementIdentifier, node: LayoutResultNode)] {
-        performLayout(
-            attributes: attributes,
-            environment: .empty,
-            cache: CacheFactory.makeCache(name: "test")
-        )
+        let layoutMode = RenderContext.current?.layoutMode ?? .default
+        switch layoutMode {
+        case .legacy:
+            return performLegacyLayout(
+                attributes: attributes,
+                environment: .empty,
+                cache: CacheFactory.makeCache(name: "test")
+            )
+        case .caffeinated:
+            return performCaffeinatedLayout(
+                frame: attributes.frame,
+                context: LayoutContext(environment: .empty)
+            )
+        }
     }
 }

--- a/BlueprintUI/Tests/ElementContentTests.swift
+++ b/BlueprintUI/Tests/ElementContentTests.swift
@@ -96,7 +96,7 @@ class ElementContentTests: XCTestCase {
             let cache = TestCache(name: "test")
 
             _ = container
-                .performLayout(
+                .performLegacyLayout(
                     attributes: LayoutAttributes(size: containerSize),
                     environment: .empty,
                     cache: cache
@@ -106,8 +106,7 @@ class ElementContentTests: XCTestCase {
             _ = container.measure(
                 in: SizeConstraint(containerSize),
                 environment: .empty,
-                cache: cache,
-                layoutMode: .legacy
+                cache: cache
             )
 
             return (cache, counts)
@@ -179,7 +178,7 @@ class ElementContentTests: XCTestCase {
 
         let size = measure.measure(in: .unconstrained)
 
-        _ = layout.performLayout(
+        _ = layout.performLegacyLayout(
             attributes: .init(size: size),
             environment: .empty,
             cache: TestCache(name: "test")
@@ -234,13 +233,9 @@ class ElementContentTests: XCTestCase {
             element.content.measure(in: .init(CGSize(width: 100, height: 100)), environment: .empty, cache: cache)
         )
 
-        let layout = element.content.performLayout(
-            attributes: .init(size: CGSize(width: 100, height: 100)),
-            environment: .empty,
-            cache: cache
-        )
+        let layoutResult = element.layout(frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)))
 
-        XCTAssertTrue(layout.isEmpty)
+        XCTAssertTrue(layoutResult.children.isEmpty)
     }
 }
 


### PR DESCRIPTION
This is PR 3 in a stack targeting `feature/caffeinated-layout`. You can see how it fits into the larger picture by looking at the staging branch in #434.

It creates the new parallel layout API:
- `ContentStorage` gets new methods
- `Layout` is turned into a composition of `LegacyLayout` and `CaffeinatedLayout`
- `SingleChildLayout` is also turned into a composition of `LegacySingleChildLayout` and `CaffeinatedSingleChildLayout`
- some new types like `LayoutSubelement` are stubbed out
- all new API methods have a default implementation that calls `fatalError`