### PR TITLE
4) ContentStorage implementations

### DIFF
--- a/BlueprintUI/Sources/Element/ContentStorage.swift
+++ b/BlueprintUI/Sources/Element/ContentStorage.swift
@@ -30,21 +30,3 @@ protocol CaffeinatedContentStorage {
         context: LayoutContext
     ) -> [ElementContent.IdentifiedNode]
 }
-
-// TODO: temporary conformance
-
-extension CaffeinatedContentStorage {
-    public func sizeThatFits(
-        proposal: SizeConstraint,
-        context: MeasureContext
-    ) -> CGSize {
-        fatalError("not implemented")
-    }
-
-    public func performCaffeinatedLayout(
-        frame: CGRect,
-        context: LayoutContext
-    ) -> [ElementContent.IdentifiedNode] {
-        fatalError("not implemented")
-    }
-}

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -34,10 +34,15 @@ public struct ElementContent {
                 environment: environment,
                 cache: CacheFactory.makeCache(name: cacheName)
             )
-        case .caffeinated:
+        case .caffeinated(let options):
+            let node = LayoutTreeNode(
+                path: cacheName,
+                signpostRef: SignpostToken(),
+                options: options
+            )
             return sizeThatFits(
                 proposal: constraint,
-                context: MeasureContext(environment: environment)
+                context: MeasureContext(environment: environment, node: node)
             )
         }
     }

--- a/BlueprintUI/Sources/Element/MeasurableStorage.swift
+++ b/BlueprintUI/Sources/Element/MeasurableStorage.swift
@@ -3,6 +3,8 @@ import CoreGraphics
 /// Content storage for leaf nodes.
 struct MeasurableStorage: ContentStorage {
 
+    typealias IdentifiedNode = ElementContent.IdentifiedNode
+
     let childCount = 0
 
     let measurer: (SizeConstraint, Environment) -> CGSize
@@ -11,7 +13,7 @@ struct MeasurableStorage: ContentStorage {
         attributes: LayoutAttributes,
         environment: Environment,
         cache: CacheTree
-    ) -> [(identifier: ElementIdentifier, node: LayoutResultNode)] {
+    ) -> [IdentifiedNode] {
         []
     }
 
@@ -27,5 +29,16 @@ struct MeasurableStorage: ContentStorage {
 
             return measurer(constraint, environment)
         }
+    }
+
+    func sizeThatFits(proposal: SizeConstraint, context: MeasureContext) -> CGSize {
+        measurer(proposal, context.environment)
+    }
+
+    func performCaffeinatedLayout(
+        frame: CGRect,
+        context: LayoutContext
+    ) -> [IdentifiedNode] {
+        []
     }
 }

--- a/BlueprintUI/Sources/Element/MeasureElementStorage.swift
+++ b/BlueprintUI/Sources/Element/MeasureElementStorage.swift
@@ -4,9 +4,17 @@ struct MeasureElementStorage: ContentStorage {
 
     typealias IdentifiedNode = ElementContent.IdentifiedNode
 
-    let child: Element
+    let childCount = 0
 
-    let childCount: Int = 0
+    var child: Element
+    var content: ElementContent
+    var identifier: ElementIdentifier
+
+    init(child: Element) {
+        self.child = child
+        content = child.content
+        identifier = ElementIdentifier(elementType: type(of: child), key: nil, count: 1)
+    }
 
     func measure(
         in constraint: SizeConstraint,
@@ -23,7 +31,7 @@ struct MeasureElementStorage: ContentStorage {
 
             defer { Logger.logMeasureEnd(object: cache.signpostRef) }
 
-            return child.content.measure(
+            return content.measure(
                 in: constraint,
                 environment: environment,
                 cache: cache.subcache(element: child)
@@ -36,6 +44,20 @@ struct MeasureElementStorage: ContentStorage {
         environment: Environment,
         cache: CacheTree
     ) -> [IdentifiedNode] {
+        []
+    }
+
+    func sizeThatFits(proposal: SizeConstraint, context: MeasureContext) -> CGSize {
+        content.sizeThatFits(
+            proposal: proposal,
+            context: MeasureContext(
+                environment: context.environment,
+                node: context.node.subnode(key: identifier)
+            )
+        )
+    }
+
+    func performCaffeinatedLayout(frame: CGRect, context: LayoutContext) -> [IdentifiedNode] {
         []
     }
 }

--- a/BlueprintUI/Sources/Internal/CacheFactory.swift
+++ b/BlueprintUI/Sources/Internal/CacheFactory.swift
@@ -10,4 +10,4 @@ enum CacheFactory {
 }
 
 /// A token reference type that can be used to group associated signpost logs using `OSSignpostID`.
-private final class SignpostToken {}
+final class SignpostToken {}

--- a/BlueprintUI/Sources/Internal/Extensions/CGRect.swift
+++ b/BlueprintUI/Sources/Internal/Extensions/CGRect.swift
@@ -41,4 +41,8 @@ extension CGRect {
     func offset(by point: CGPoint) -> CGRect {
         offsetBy(dx: point.x, dy: point.y)
     }
+
+    var center: CGPoint {
+        CGPoint(x: midX, y: midY)
+    }
 }

--- a/BlueprintUI/Sources/Internal/HintingSizeCache.swift
+++ b/BlueprintUI/Sources/Internal/HintingSizeCache.swift
@@ -1,0 +1,43 @@
+import CoreGraphics
+
+/// A measurement cache that automatically "hints" values that can be deduced from the Caffeinated
+/// Layout contract.
+final class HintingSizeCache {
+
+    typealias Options = LayoutOptions
+    typealias Key = SizeConstraint
+    typealias Value = CGSize
+
+    private var values: [Key: Value] = [:]
+
+    let path: String
+    let signpostRef: AnyObject
+    let options: Options
+
+    init(path: String, signpostRef: AnyObject, options: Options) {
+        self.path = path
+        self.signpostRef = signpostRef
+        self.options = options
+    }
+
+    func get(key: Key, or create: (Key) -> Value) -> Value {
+        if let size = values[key] {
+            Logger.logCacheHit(object: signpostRef, description: path, constraint: key)
+            return size
+        }
+
+        // TODO: implement hinting
+
+        // This particular log has a small, but non-negligible impact on a certain class of test
+        // cases, such as deeply nested stacks. Enable it manually if you want this statistic.
+        // Logger.logCacheMiss(object: signpostRef, description: path, constraint: key)
+
+        Logger.logMeasureStart(object: signpostRef, description: path, constraint: key)
+        let size = create(key)
+        Logger.logMeasureEnd(object: signpostRef)
+
+        values[key] = size
+
+        return size
+    }
+}

--- a/BlueprintUI/Sources/Internal/LayoutContext.swift
+++ b/BlueprintUI/Sources/Internal/LayoutContext.swift
@@ -1,8 +1,7 @@
 import Foundation
 
+/// Information passed to content storage implementations during layout.
 struct LayoutContext {
     var environment: Environment
-
-    // TODO:
-    // var node: LayoutTreeNode
+    var node: LayoutTreeNode
 }

--- a/BlueprintUI/Sources/Internal/LayoutOptions.swift
+++ b/BlueprintUI/Sources/Internal/LayoutOptions.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Configuration options for ``LayoutMode/caffeinated``.
+///
+/// Generally these are only useful for experimenting with the performance profile of different
+/// element compositions, and you should stick with ``default``.
+public struct LayoutOptions: Equatable {
+
+    /// The default configuration.
+    public static let `default` = LayoutOptions(
+        hintRangeBoundaries: true,
+        searchUnconstrainedKeys: true
+    )
+
+    /// Enables aggressive cache hinting along the boundaries of the range between constraints and
+    /// measured sizes. Requires elements to conform to the Caffeinated Layout contract for correct
+    /// behavior.
+    public var hintRangeBoundaries: Bool
+
+    /// Allows cache misses on finite constraints to deduce a range-based match by searching for a
+    /// hit on the unconstrained value for each axis. Requires elements to adhere to the Caffeinated
+    /// Layout contract for correct behavior.
+    public var searchUnconstrainedKeys: Bool
+
+    public init(hintRangeBoundaries: Bool, searchUnconstrainedKeys: Bool) {
+        self.hintRangeBoundaries = hintRangeBoundaries
+        self.searchUnconstrainedKeys = searchUnconstrainedKeys
+    }
+}

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -19,11 +19,16 @@ extension Element {
                 environment: environment
             )
 
-        case .caffeinated:
+        case .caffeinated(let options):
             return caffeinatedLayout(
                 frame: frame,
                 context: LayoutContext(
-                    environment: environment
+                    environment: environment,
+                    node: LayoutTreeNode(
+                        path: "\(type(of: self))",
+                        signpostRef: SignpostToken(),
+                        options: options
+                    )
                 )
             )
         }

--- a/BlueprintUI/Sources/Internal/LayoutTreeNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutTreeNode.swift
@@ -1,0 +1,72 @@
+import CoreGraphics
+import Foundation
+
+/// A node in the layout tree.
+///
+/// This tree is created during layout and measurement, and is used to hold information that may be
+/// reused if a node is visited multiple times, such as measurement caches.
+///
+/// In the layout tree, each edge is keyed by an `ElementIdentifier`, and each node corresponds to
+/// an `ElementContent`. An `ElementPath` can uniquely identify a node from the root. Elements that
+/// lazily generate subelements, such as `GeometryReader`, may create subelements with distinct
+/// identifiers across visits during a single render, which will result in spurious nodes being
+/// created that do not correspond to `LayoutResultNode` in the final layout. However, the
+/// `LayoutResultNode` tree will be an isomorphic subgraph of this tree (every `LayoutResultNode`
+/// corresponds to a `LayoutTreeNode`, but not every `LayoutTreeNode` produces a
+/// `LayoutResultNode`).
+///
+final class LayoutTreeNode {
+
+    typealias Subnode = LayoutTreeNode
+    typealias SubnodeKey = ElementIdentifier
+
+    private var subnodes: [SubnodeKey: Subnode] = [:]
+
+    let path: String
+    let sizeCache: HintingSizeCache
+
+    // These commonly used properties are strongly typed. If we need to hang more generalized
+    // things off this type we may want to store them in a heterogeneous dictionary.
+    private var _layoutSubelements: [LayoutSubelement]?
+    private var _associatedCache: Any?
+
+    init(path: String, signpostRef: AnyObject, options: LayoutOptions) {
+        self.path = path
+        sizeCache = HintingSizeCache(path: path, signpostRef: signpostRef, options: options)
+    }
+
+    func subnode(key: SubnodeKey) -> Subnode {
+        if let subnode = subnodes[key] {
+            return subnode
+        }
+        let subnode = Subnode(
+            path: "\(path)/\(key)",
+            signpostRef: sizeCache.signpostRef,
+            options: sizeCache.options
+        )
+        subnodes[key] = subnode
+        return subnode
+    }
+
+    func layoutSubelements(create: () -> [LayoutSubelement]) -> [LayoutSubelement] {
+        if let layoutSubelements = _layoutSubelements {
+            return layoutSubelements
+        }
+        let layoutSubelements = create()
+        _layoutSubelements = layoutSubelements
+        return layoutSubelements
+    }
+
+    func associatedCache<AssociatedCache>(create: () -> AssociatedCache) -> AssociatedCache {
+        if let associatedCache = _associatedCache as? AssociatedCache {
+            return associatedCache
+        }
+        let associatedCache = create()
+        _associatedCache = associatedCache
+        return associatedCache
+    }
+
+    func update<AssociatedCache>(associatedCache: AssociatedCache) {
+        _associatedCache = associatedCache
+    }
+}

--- a/BlueprintUI/Sources/Internal/Logger.swift
+++ b/BlueprintUI/Sources/Internal/Logger.swift
@@ -74,7 +74,7 @@ extension Logger {
 
     static func logSizeThatFitsStart(
         view: BlueprintView,
-        description: String
+        description: @autoclosure () -> String
     ) {
         guard BlueprintLogging.isEnabled else { return }
 
@@ -84,7 +84,7 @@ extension Logger {
             name: "View Sizing",
             signpostID: OSSignpostID(log: .active, object: view),
             "%{public}s",
-            description
+            description()
         )
     }
 
@@ -128,6 +128,60 @@ extension Logger {
             log: .active,
             name: "Measuring",
             signpostID: OSSignpostID(log: .active, object: object)
+        )
+    }
+
+    static func logCacheHit(object: AnyObject, description: @autoclosure () -> String, constraint: SizeConstraint) {
+        guard shouldRecordMeasurePass() else { return }
+
+        os_signpost(
+            .event,
+            log: .active,
+            name: "Cache hit",
+            signpostID: OSSignpostID(log: .active, object: object),
+            "%{public}s in %{public}s×%{public}s",
+            description(),
+            String(format: "%.1f", constraint.width.constrainedValue ?? .infinity),
+            String(format: "%.1f", constraint.height.constrainedValue ?? .infinity)
+        )
+    }
+
+    static func logCacheMiss(object: AnyObject, description: @autoclosure () -> String, constraint: SizeConstraint) {
+        guard shouldRecordMeasurePass() else { return }
+
+        os_signpost(
+            .event,
+            log: .active,
+            name: "Cache miss",
+            signpostID: OSSignpostID(log: .active, object: object),
+            "%{public}s in %{public}s×%{public}s",
+            description(),
+            String(format: "%.1f", constraint.width.constrainedValue ?? .infinity),
+            String(format: "%.1f", constraint.height.constrainedValue ?? .infinity)
+        )
+    }
+
+    static func logCacheUnconstrainedSearchMatch(
+        object: AnyObject,
+        description: @autoclosure () -> String,
+        constraint: SizeConstraint,
+        match: @autoclosure () -> SizeConstraint
+    ) {
+        guard shouldRecordMeasurePass() else { return }
+
+        let match = match()
+
+        os_signpost(
+            .event,
+            log: .active,
+            name: "Cache unconstrained search match",
+            signpostID: OSSignpostID(log: .active, object: object),
+            "%{public}s in %{public}s×%{public}s matched %{public}s×%{public}s",
+            description(),
+            String(format: "%.1f", constraint.width.constrainedValue ?? .infinity),
+            String(format: "%.1f", constraint.height.constrainedValue ?? .infinity),
+            String(format: "%.1f", match.width.constrainedValue ?? .infinity),
+            String(format: "%.1f", match.height.constrainedValue ?? .infinity)
         )
     }
 

--- a/BlueprintUI/Sources/Internal/MeasureContext.swift
+++ b/BlueprintUI/Sources/Internal/MeasureContext.swift
@@ -1,7 +1,7 @@
 import Foundation
 
+/// Information passed to content storage implementations during `sizeThatFits`.
 struct MeasureContext {
     var environment: Environment
-    // TODO:
-    // var node: LayoutTreeNode
+    var node: LayoutTreeNode
 }

--- a/BlueprintUI/Sources/Layout/LayoutAttributes.swift
+++ b/BlueprintUI/Sources/Layout/LayoutAttributes.swift
@@ -58,6 +58,14 @@ public struct LayoutAttributes {
         validateAlpha()
     }
 
+    init(frame: CGRect, attributes: LayoutSubelement.Attributes) {
+        self.init(frame: frame)
+        transform = attributes.transform
+        alpha = attributes.alpha
+        isUserInteractionEnabled = attributes.isUserInteractionEnabled
+        isHidden = attributes.isHidden
+    }
+
     public var frame: CGRect {
         get {
             var f = CGRect.zero

--- a/BlueprintUI/Sources/Layout/LayoutMode.swift
+++ b/BlueprintUI/Sources/Layout/LayoutMode.swift
@@ -15,6 +15,10 @@ public enum LayoutMode: Equatable {
     case legacy
 
     /// A newer layout system with some optimizations made possible by ensuring elements adhere
-    /// certain contract for behavior.
-    case caffeinated
+    /// to a certain contract for behavior.
+    case caffeinated(options: LayoutOptions = .default)
+
+    /// A newer layout system with some optimizations made possible by ensuring elements adhere
+    /// to a certain contract for behavior.
+    public static let caffeinated = Self.caffeinated()
 }

--- a/BlueprintUI/Sources/Layout/LayoutSubelement.swift
+++ b/BlueprintUI/Sources/Layout/LayoutSubelement.swift
@@ -1,8 +1,189 @@
 import CoreGraphics
+import Foundation
+import QuartzCore
 
-
+/// A collection of proxy values that represent the child elements of a layout.
 public typealias LayoutSubelements = [LayoutSubelement]
 
+/// A proxy that represents one child element of a layout.
+///
+/// This type acts as a proxy for a child element in a ``Layout``. Layout protocol methods receive a
+/// ``LayoutSubelements`` collection that contains exactly one proxy for each of the child elements
+/// managed by the layout.
+///
+/// Use this proxy to get information about the associated element, like its size and traits. You
+/// should also use the proxy to tell its corresponding element where to appear by calling the
+/// proxy’s ``place(at:anchor:size:)`` method. Do this once for each subview from your
+/// implementation of the layout’s ``CaffeinatedLayout/placeSubelements(in:subelements:cache:)``
+/// method.
+///
 public struct LayoutSubelement {
-    // TODO:
+
+    typealias SizeCache = HintingSizeCache
+
+    var identifier: ElementIdentifier
+    private var content: ElementContent
+    var measureContext: MeasureContext
+
+    var environment: Environment { measureContext.environment }
+    private var cache: HintingSizeCache { measureContext.node.sizeCache }
+
+    @Storage
+    private(set) var placement: Placement?
+
+    /// Optional attributes to apply to this subelement, such as opacity and transforms.
+    @Storage
+    public var attributes = Attributes()
+
+    // Once we are able to fully deprecate the old layout API we can remove the `LayoutType.Traits`
+    // and the `traits` parameter, and instead rely on setting `LayoutValueKey`s where needed.
+    private var traits: Any
+
+    init(
+        identifier: ElementIdentifier,
+        content: ElementContent,
+        measureContext: MeasureContext,
+        traits: Any
+    ) {
+        self.identifier = identifier
+        self.content = content
+        self.measureContext = measureContext
+        self.traits = traits
+    }
+
+    /// Assigns a position and size to a subelement.
+    ///
+    /// Call this method from your implementation of the `Layout` protocol’s
+    /// ``CaffeinatedLayout/placeSubelements(in:subelements:cache:)`` method for each subelement
+    /// arranged by the layout. Provide a position within the container’s bounds where the
+    /// subelement should appear, an anchor that indicates which part of the subelement appears at
+    /// that point, and a size.
+    ///
+    /// To learn the subelement's preferred size for a given proposal before calling this method,
+    /// you can call ``sizeThatFits(_:)`` method on the subelement.
+    ///
+    /// If you call this method more than once for a subelement, the last call takes precedence. If
+    /// you don’t call this method for a subelement, the subelement fills the bounds of its
+    /// container.
+    ///
+    /// - Parameters:
+    ///   - position: The place where the anchor of the subelement should appear in its container,
+    ///     relative to the container's bounds.
+    ///   - anchor: The unit point on the subelement that appears at `position`. You can use a
+    ///     built-in point, like ``UnitPoint/center``, or you can create a custom ``UnitPoint``.
+    ///   - size: The size of the subelement. In Blueprint, parents choose their children's size.
+    ///     You can determine a good size for a subelement by calling ``sizeThatFits(_:)`` on it.
+    public func place(
+        at position: CGPoint,
+        anchor: UnitPoint = .topLeading,
+        size: CGSize
+    ) {
+        placement = Placement(position: position, anchor: anchor, size: size)
+    }
+
+    /// Assigns a position and size to a subelement.
+    ///
+    /// This is a convenience for calling ``place(at:anchor:size:)`` with `frame.origin` and
+    /// `frame.size`.
+    ///
+    /// - Parameters:
+    ///   - frame: The position and size of the subelement. The origin of this frame represents the
+    ///     place where the anchor of the subelement should appear in its container, relative to the
+    ///     container's bounds. In Blueprint, parents choose their children's size. You can
+    ///     determine a good size for a subelement by calling ``sizeThatFits(_:)`` on it.
+    ///   - anchor: The unit point on the subelement that appears at `position`. You can use a
+    ///     built-in point, like ``UnitPoint/center``, or you can create a custom ``UnitPoint``.
+    public func place(
+        in frame: CGRect,
+        anchor: UnitPoint = .topLeading
+    ) {
+        place(at: frame.origin, anchor: anchor, size: frame.size)
+    }
+
+    /// Assigns a position and size to a subelement.
+    ///
+    /// This is a convenience for calling ``place(at:anchor:size:)`` with a position of `.zero` and
+    /// this size.
+    public func place(
+        filling size: CGSize
+    ) {
+        place(at: .zero, size: size)
+    }
+
+    /// Asks the subelement for its size.
+    ///
+    /// In Blueprint, elements are ultimately sized by their parents, but you can use this method to
+    /// determine the size that a subelement would prefer to choose.
+    ///
+    /// - Parameter proposal: A proposed size constraint for the subelement.
+    /// - Returns: The size that the subelement would choose for itself, given the proposal.
+    public func sizeThatFits(_ proposal: SizeConstraint) -> CGSize {
+        cache.get(key: proposal) { proposal in
+            content.sizeThatFits(proposal: proposal, context: measureContext)
+        }
+    }
+
+    /// Gets the layout traits of the subelement.
+    ///
+    /// Use this method to access the layout-specific ``LegacyLayout/Traits`` value for this
+    /// subelement.
+    ///
+    /// - Important: Only call this method with the type of your `Layout`. For compatibility with
+    ///   legacy layout, this is the only type of traits supported.
+    ///
+    /// - Parameter layoutType: The type of layout, which determines the type of the traits.
+    /// - Returns: The subelements's layout traits.
+    public func traits<LayoutType>(
+        forLayoutType layoutType: LayoutType.Type
+    ) -> LayoutType.Traits where LayoutType: Layout {
+        traits as! LayoutType.Traits
+    }
+}
+
+extension LayoutSubelement {
+    struct Placement {
+        var position: CGPoint
+        var anchor: UnitPoint
+        var size: CGSize
+
+        func origin(for size: CGSize) -> CGPoint {
+            position - CGPoint(
+                x: size.width * anchor.x,
+                y: size.height * anchor.y
+            )
+        }
+
+        static func filling(frame: CGRect) -> Self {
+            .init(
+                position: frame.center,
+                anchor: .center,
+                size: frame.size
+            )
+        }
+    }
+
+    /// Optional additional attributes that can be applied to a subelement.
+    public struct Attributes {
+
+        /// Corresponds to `UIView.layer.transform`.
+        public var transform: CATransform3D = CATransform3DIdentity
+
+        /// Corresponds to `UIView.alpha`.
+        public var alpha: CGFloat = 1
+
+        /// Corresponds to `UIView.isUserInteractionEnabled`.
+        public var isUserInteractionEnabled: Bool = true
+
+        /// Corresponds to `UIView.isHidden`.
+        public var isHidden: Bool = false
+    }
+
+    @propertyWrapper
+    class Storage<T> {
+        var wrappedValue: T
+
+        init(wrappedValue: T) {
+            self.wrappedValue = wrappedValue
+        }
+    }
 }

--- a/BlueprintUI/Sources/Layout/UnitPoint.swift
+++ b/BlueprintUI/Sources/Layout/UnitPoint.swift
@@ -1,0 +1,84 @@
+import CoreGraphics
+
+/// A normalized point in an element's coordinate space.
+///
+/// Use a unit point to represent a location in an element without having to know the element’s
+/// rendered size. The point stores a value in each dimension that indicates the fraction of the
+/// element’s size in that dimension — measured from the element’s origin — where the point appears.
+/// For example, you can create a unit point that represents the center of any element by using the
+/// value `0.5` for each dimension:
+///
+/// ```swift
+/// let unitPoint = UnitPoint(x: 0.5, y: 0.5)
+/// ```
+///
+/// To project the unit point into the rendered element’s coordinate space, multiply each component
+/// of the unit point with the corresponding component of the element’s size:
+///
+/// ```swift
+/// let projectedPoint = CGPoint(
+///     x: unitPoint.x * size.width,
+///     y: unitPoint.y * size.height
+/// )
+/// ```
+///
+/// You can perform this calculation yourself if you happen to know an element’s size, but Blueprint
+/// typically does this for you to carry out operations that you request, like when you place a
+/// subelement in a custom layout.
+///
+/// You can create custom unit points with explicit values, like the example above, or you can use
+/// one of the built-in unit points, like ``zero``, ``center``, or ``topTrailing``. The built-in
+/// values correspond to the alignment positions of the similarly named, built-in ``Alignment``
+/// types.
+///
+/// - Note: A unit point with one or more components outside the range `[0, 1]` projects to a point
+///   outside of the element.
+///
+public struct UnitPoint: Hashable {
+
+    /// The normalized distance from the origin to the point in the horizontal direction.
+    public var x: CGFloat
+    /// The normalized distance from the origin to the point in the vertical direction.
+    public var y: CGFloat
+
+    /// Creates a unit point at the origin.
+    public init() {
+        self.init(x: 0, y: 0)
+    }
+
+    /// Creates a unit point with the specified horizontal and vertical offsets.
+    public init(x: CGFloat, y: CGFloat) {
+        self.x = x
+        self.y = y
+    }
+
+    /// The origin of an element.
+    public static let zero: UnitPoint = .init(x: 0, y: 0)
+
+    /// A point that’s centered in an element.
+    public static let center: UnitPoint = .init(x: 0.5, y: 0.5)
+
+    /// A point that’s centered vertically on the leading edge of an element.
+    public static let leading: UnitPoint = .init(x: 0, y: 0.5)
+
+    /// A point that’s centered vertically on the trailing edge of an element.
+    public static let trailing: UnitPoint = .init(x: 1, y: 0.5)
+
+    /// A point that’s centered horizontally on the top edge of an element.
+    public static let top: UnitPoint = .init(x: 0.5, y: 0)
+
+    /// A point that’s centered horizontally on the bottom edge of an element.
+    public static let bottom: UnitPoint = .init(x: 0.5, y: 1)
+
+    /// A point that’s in the top leading corner of an element.
+    public static let topLeading: UnitPoint = .init(x: 0, y: 0)
+
+    /// A point that’s in the top trailing corner of an element.
+    public static let topTrailing: UnitPoint = .init(x: 1, y: 0)
+
+    /// A point that’s in the bottom leading corner of an element.
+    public static let bottomLeading: UnitPoint = .init(x: 0, y: 1)
+
+    /// A point that’s in the bottom trailing corner of an element.
+    public static let bottomTrailing: UnitPoint = .init(x: 1, y: 1)
+}

--- a/BlueprintUI/Tests/Element+Testing.swift
+++ b/BlueprintUI/Tests/Element+Testing.swift
@@ -38,10 +38,13 @@ extension ElementContent {
                 environment: .empty,
                 cache: CacheFactory.makeCache(name: "test")
             )
-        case .caffeinated:
+        case .caffeinated(let options):
             return performCaffeinatedLayout(
                 frame: attributes.frame,
-                context: LayoutContext(environment: .empty)
+                context: LayoutContext(
+                    environment: .empty,
+                    node: LayoutTreeNode(path: "test", signpostRef: SignpostToken(), options: options)
+                )
             )
         }
     }


### PR DESCRIPTION
This is PR 4 in a stack targeting `feature/caffeinated-layout`. You can see how it fits into the larger picture by looking at the staging branch in #434.

This PR provides the implementations for ContentStorage types:
- The `LayoutTreeNode` provides a structure to hold information re-used during the layout pass. It's roughly analogous to the `CacheTree` from legacy layout, but is not a cache itself, just a tree structure.
- `HintingSizeCache` is the new measurement cache. Hinting comes later — here it's just a dumb cache.
- `LayoutSubelement` is a proxy for child elements passed to layout implementations. It's analogous to the `(Traits, Measurable)` tuple from legacy layout, and has an API inspired by SwiftUI's [`LayoutSubview`](https://developer.apple.com/documentation/swiftui/layoutsubview)