### PR TITLE
5) Element implementations

### DIFF
--- a/BlueprintUI/Sources/Layout/Aligned.swift
+++ b/BlueprintUI/Sources/Layout/Aligned.swift
@@ -113,8 +113,70 @@ public struct Aligned: Element {
 
             return attributes
         }
+
+        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+            subelement.sizeThatFits(proposal)
+        }
+
+        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+            let x: CGFloat
+            let y: CGFloat
+
+            let subelementSize = subelement.sizeThatFits(SizeConstraint(size))
+            let clampedSize = subelementSize.upperBounded(maxWidth: size.width, maxHeight: size.height)
+
+            let width: CGFloat
+            let height: CGFloat
+
+            switch horizontalAlignment {
+            case .leading:
+                x = 0
+                width = clampedSize.width
+            case .center:
+                x = 0.5
+                width = clampedSize.width
+            case .trailing:
+                x = 1
+                width = clampedSize.width
+            case .fill:
+                x = 0
+                width = size.width
+            }
+
+            switch verticalAlignment {
+            case .top:
+                y = 0
+                height = clampedSize.height
+            case .center:
+                y = 0.5
+                height = clampedSize.height
+            case .bottom:
+                y = 1
+                height = clampedSize.height
+            case .fill:
+                y = 0
+                height = size.height
+            }
+
+            let position = CGPoint(x: x * size.width, y: y * size.height)
+
+            subelement.place(
+                at: position,
+                anchor: UnitPoint(x: x, y: y),
+                size: CGSize(width: width, height: height)
+            )
+        }
+    }
+
+
+}
+
+extension CGSize {
+    func upperBounded(maxWidth: CGFloat, maxHeight: CGFloat) -> CGSize {
+        CGSize(width: min(width, maxWidth), height: min(height, maxHeight))
     }
 }
+
 
 extension Element {
     /// Wraps the element in an `Aligned` element with the provided parameters.

--- a/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
@@ -158,6 +158,19 @@ public struct ConstrainedAspectRatio: Element {
         func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
             LayoutAttributes(size: size)
         }
+
+        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+            let contentSize = subelement.sizeThatFits(proposal)
+            return contentMode.constrain(
+                contentSize: contentSize,
+                in: proposal,
+                to: aspectRatio
+            )
+        }
+
+        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+            subelement.place(filling: size)
+        }
     }
 }
 

--- a/BlueprintUI/Sources/Layout/EqualStack.swift
+++ b/BlueprintUI/Sources/Layout/EqualStack.swift
@@ -153,6 +153,75 @@ extension EqualStack {
             return result
         }
 
+        func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout Cache) -> CGSize {
+            guard subelements.count > 0 else { return .zero }
+
+            let totalSpacing = (spacing * CGFloat(subelements.count - 1))
+            let itemProposal: SizeConstraint
+            switch direction {
+            case .horizontal:
+                itemProposal = .init(
+                    width: proposal.width.map { ($0 - totalSpacing) / CGFloat(subelements.count) },
+                    height: proposal.height
+                )
+            case .vertical:
+                itemProposal = .init(
+                    width: proposal.width,
+                    height: proposal.height.map { ($0 - totalSpacing) / CGFloat(subelements.count) }
+                )
+            }
+            let itemSizes = subelements.map { $0.sizeThatFits(itemProposal) }
+
+            let maximumItemWidth = itemSizes.map { $0.width }.max() ?? 0
+            let maximumItemHeight = itemSizes.map { $0.height }.max() ?? 0
+
+            let totalSize: CGSize
+            switch direction {
+            case .horizontal:
+                totalSize = CGSize(
+                    width: maximumItemWidth * CGFloat(subelements.count) + spacing * CGFloat(subelements.count - 1),
+                    height: maximumItemHeight
+                )
+            case .vertical:
+                totalSize = CGSize(
+                    width: maximumItemWidth,
+                    height: maximumItemHeight * CGFloat(subelements.count) + spacing * CGFloat(subelements.count - 1)
+                )
+            }
+
+            return totalSize
+        }
+
+        func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+            guard subelements.count > 0 else { return }
+
+            let totalSpacing = (spacing * CGFloat(subelements.count - 1))
+            let itemSize: CGSize
+            switch direction {
+            case .horizontal:
+                itemSize = CGSize(
+                    width: (size.width - totalSpacing) / CGFloat(subelements.count),
+                    height: size.height
+                )
+            case .vertical:
+                itemSize = CGSize(
+                    width: size.width,
+                    height: (size.height - totalSpacing) / CGFloat(subelements.count)
+                )
+            }
+
+            for (subelement, index) in zip(subelements, 0...) {
+                var origin = CGPoint.zero
+                switch direction {
+                case .horizontal:
+                    origin.x += (itemSize.width + spacing) * CGFloat(index)
+                case .vertical:
+                    origin.y += (itemSize.height + spacing) * CGFloat(index)
+                }
+
+                subelement.place(at: origin, size: itemSize)
+            }
+        }
     }
 
 }

--- a/BlueprintUI/Sources/Layout/Hidden.swift
+++ b/BlueprintUI/Sources/Layout/Hidden.swift
@@ -32,6 +32,14 @@ public struct Hidden: Element {
             attributes.isHidden = isHidden
             return attributes
         }
+
+        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+            subelement.sizeThatFits(proposal)
+        }
+
+        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+            subelement.attributes.isHidden = isHidden
+        }
     }
 }
 

--- a/BlueprintUI/Sources/Layout/Inset.swift
+++ b/BlueprintUI/Sources/Layout/Inset.swift
@@ -158,5 +158,34 @@ extension Inset {
             frame.size.height -= top + bottom
             return LayoutAttributes(frame: frame)
         }
+
+        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout ()) -> CGSize {
+            let insetProposal = proposal.inset(by: edgeInsets)
+            let childSize = subelement.sizeThatFits(insetProposal)
+            return childSize + CGSize(width: left + right, height: top + bottom)
+        }
+
+        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+            let insetSize = size.inset(by: edgeInsets)
+
+            subelement.place(
+                at: CGPoint(x: edgeInsets.left, y: edgeInsets.top),
+                anchor: .topLeading,
+                size: insetSize
+            )
+        }
+
+        private var edgeInsets: UIEdgeInsets {
+            .init(top: top, left: left, bottom: bottom, right: right)
+        }
+    }
+}
+
+extension CGSize {
+    func inset(by insets: UIEdgeInsets) -> Self {
+        CGSize(
+            width: width - insets.left - insets.right,
+            height: height - insets.top - insets.bottom
+        )
     }
 }

--- a/BlueprintUI/Sources/Layout/Keyed.swift
+++ b/BlueprintUI/Sources/Layout/Keyed.swift
@@ -69,6 +69,14 @@ public struct Keyed: Element {
         func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
             LayoutAttributes(size: size)
         }
+
+        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+            subelement.sizeThatFits(proposal)
+        }
+
+        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+            subelement.place(at: .zero, size: size)
+        }
     }
 }
 

--- a/BlueprintUI/Sources/Layout/Layout.swift
+++ b/BlueprintUI/Sources/Layout/Layout.swift
@@ -278,23 +278,3 @@ public protocol CaffeinatedLayout {
 extension CaffeinatedLayout where Cache == () {
     public func makeCache(subelements: Subelements) { () }
 }
-
-// TODO: Temporary conformance fulfillment
-
-extension CaffeinatedLayout {
-    public func sizeThatFits(
-        proposal: SizeConstraint,
-        subelements: Subelements,
-        cache: inout Cache
-    ) -> CGSize {
-        fatalError("not implemented")
-    }
-
-    public func placeSubelements(
-        in size: CGSize,
-        subelements: Subelements,
-        cache: inout Cache
-    ) {
-        fatalError("not implemented")
-    }
-}

--- a/BlueprintUI/Sources/Layout/LayoutWriter.swift
+++ b/BlueprintUI/Sources/Layout/LayoutWriter.swift
@@ -272,6 +272,19 @@ extension LayoutWriter {
                     .init(frame: child.frame)
                 }
             }
+
+            func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout Cache) -> CGSize {
+                builder.sizing.measure(with: builder)
+            }
+
+            func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+                for (child, subelement) in zip(builder.children, subelements) {
+                    subelement.place(
+                        at: child.frame.origin,
+                        size: child.frame.size
+                    )
+                }
+            }
         }
     }
 }

--- a/BlueprintUI/Sources/Layout/Opacity.swift
+++ b/BlueprintUI/Sources/Layout/Opacity.swift
@@ -42,6 +42,14 @@ public struct Opacity: Element {
             attributes.alpha = opacity
             return attributes
         }
+
+        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout ()) -> CGSize {
+            subelement.sizeThatFits(proposal)
+        }
+
+        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+            subelement.attributes.alpha = opacity
+        }
     }
 }
 

--- a/BlueprintUI/Sources/Layout/Overlay.swift
+++ b/BlueprintUI/Sources/Layout/Overlay.swift
@@ -78,6 +78,19 @@ fileprivate struct OverlayLayout: Layout {
         )
     }
 
+    func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout Cache) -> CGSize {
+        subelements.reduce(into: CGSize.zero) { result, subelement in
+            let measuredSize = subelement.sizeThatFits(proposal)
+            result.width = max(result.width, measuredSize.width)
+            result.height = max(result.height, measuredSize.height)
+        }
+    }
+
+    func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+        for subelement in subelements {
+            subelement.place(filling: size)
+        }
+    }
 }
 
 extension Overlay {

--- a/BlueprintUI/Sources/Layout/SingleChildLayout.swift
+++ b/BlueprintUI/Sources/Layout/SingleChildLayout.swift
@@ -170,23 +170,3 @@ public protocol CaffeinatedSingleChildLayout {
 extension CaffeinatedSingleChildLayout where Cache == () {
     public func makeCache(subelement: Subelement) { () }
 }
-
-// TODO: temporary conformance
-
-extension CaffeinatedSingleChildLayout {
-    public func sizeThatFits(
-        proposal: SizeConstraint,
-        subelement: Subelement,
-        cache: inout Cache
-    ) -> CGSize {
-        fatalError("not implemented")
-    }
-
-    public func placeSubelement(
-        in size: CGSize,
-        subelement: Subelement,
-        cache: inout Cache
-    ) {
-        fatalError("not implemented")
-    }
-}

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -379,7 +379,7 @@ extension StackLayout {
         // During layout the constraints are always `.exactly` to fit the provided size
         let vectorConstraint = size.vectorConstraint(axis: axis)
 
-        let frames = _frames(for: items, in: vectorConstraint)
+        let frames = _frames(for: items.map(StackLayoutItem.init), in: vectorConstraint)
 
         return frames.map { frame in
             LayoutAttributes(frame: frame.rect(axis: axis))
@@ -392,7 +392,7 @@ extension StackLayout {
         // During measurement the constraints may be `.atMost` or `.unconstrained` to fit the measurement constraint
         let vectorConstraint = constraint.vectorConstraint(on: axis)
 
-        let frames = _frames(for: items, in: vectorConstraint)
+        let frames = _frames(for: items.map(StackLayoutItem.init), in: vectorConstraint)
 
         let vector = frames.reduce(Vector.zero) { vector, frame -> Vector in
             Vector(
@@ -405,16 +405,18 @@ extension StackLayout {
     }
 
     private func _frames(
-        for items: [(traits: Traits, content: Measurable)],
+        for items: [StackLayoutItem],
         in vectorConstraint: VectorConstraint
     ) -> [VectorFrame] {
         // First allocate available space along the layout axis.
         let axisSegments = _axisSegments(for: items, in: vectorConstraint)
 
+        let axisConstraints = axisSegments.map { $0.magnitude }
+
         // Then measure cross axis for each item based on the space it was allocated.
         let crossSegments = _crossSegments(
             for: items,
-            axisConstraints: axisSegments.map { $0.magnitude },
+            axisConstraints: axisConstraints,
             crossConstraint: vectorConstraint.cross
         )
 
@@ -446,7 +448,7 @@ extension StackLayout {
     ///   - in: The constraint for all measurements.
     /// - Returns: The axis measurements as segments.
     private func _axisSegments(
-        for items: [(traits: Traits, content: Measurable)],
+        for items: [StackLayoutItem],
         in vectorConstraint: VectorConstraint
     ) -> [Segment] {
 
@@ -457,7 +459,7 @@ extension StackLayout {
 
             final class Measurement {
 
-                let item: (traits: Traits, content: Measurable)
+                let item: StackLayoutItem
                 var size: CGSize?
 
                 let isFixed: Bool
@@ -466,7 +468,7 @@ extension StackLayout {
                     isFixed == false
                 }
 
-                init(item: (traits: StackLayout.Traits, content: Measurable)) {
+                init(item: StackLayoutItem) {
                     self.item = item
                     size = nil
 
@@ -483,9 +485,7 @@ extension StackLayout {
             measurements.forEach { measurement in
                 guard measurement.isFixed else { return }
 
-                measurement.size = measurement
-                    .item
-                    .content
+                measurement.size = measurement.item
                     .measure(in: constraint)
             }
 
@@ -515,7 +515,6 @@ extension StackLayout {
 
                     measurement.size = measurement
                         .item
-                        .content
                         .measure(in: flexibleConstraint)
                 }
             } else {
@@ -756,7 +755,7 @@ extension StackLayout {
     ///   - crossConstraint: The cross component of the constraint for all measurements.
     /// - Returns: The cross measurements as segments.
     private func _crossSegments(
-        for items: [(traits: Traits, content: Measurable)],
+        for items: [StackLayoutItem],
         axisConstraints: [CGFloat],
         crossConstraint: VectorConstraint.Axis
     ) -> [Segment] {
@@ -768,7 +767,7 @@ extension StackLayout {
                     cross: crossConstraint
                 )
                 let constraint = vector.constraint(axis: axis)
-                let measuredSize = item.content.measure(in: constraint)
+                let measuredSize = item.measure(in: constraint)
 
                 return measuredSize.cross(on: axis)
             }
@@ -865,9 +864,76 @@ extension StackLayout {
             return alignSegments(to: id)
         }
     }
+}
 
-    // MARK: - Layout types
+extension LayoutSubelement {
+    var stackLayoutTraits: StackLayout.Traits {
+        traits(forLayoutType: StackLayout.self)
+    }
+}
 
+extension StackLayout {
+    public func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout ()) -> CGSize {
+        guard subelements.isEmpty == false else { return .zero }
+
+        let constraint = proposal.vectorConstraint(on: axis)
+
+        let frames = _frames(for: subelements.map(StackLayoutItem.init), in: constraint)
+
+        let vector = frames.reduce(Vector.zero) { vector, frame -> Vector in
+            Vector(
+                axis: max(vector.axis, frame.maxAxis),
+                cross: max(vector.cross, frame.maxCross)
+            )
+        }
+
+        return vector.size(axis: axis)
+    }
+
+    public func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+
+        let constraint = size.vectorConstraint(axis: axis)
+
+        let frames = _frames(for: subelements.map(StackLayoutItem.init), in: constraint)
+
+        for i in 0..<subelements.count {
+            let vectorFrame = frames[i]
+            let subelement = subelements[i]
+
+            let frame = vectorFrame.rect(axis: axis)
+
+            subelement.place(
+                at: frame.origin,
+                anchor: .topLeading,
+                size: frame.size
+            )
+        }
+    }
+
+    private struct StackLayoutItem {
+
+        let traits: Traits
+        private let measure: (SizeConstraint) -> CGSize
+
+        init(_ tuple: (Traits, Measurable)) {
+            traits = tuple.0
+            measure = tuple.1.measure(in:)
+        }
+
+        init(_ subelement: LayoutSubelement) {
+            traits = subelement.stackLayoutTraits
+            measure = subelement.sizeThatFits(_:)
+        }
+
+        func measure(in constraint: SizeConstraint) -> CGSize {
+            measure(constraint)
+        }
+    }
+}
+
+// MARK: - Layout types
+
+extension StackLayout {
     /// Represents an origin and size value in a single axis.
     struct Segment {
         var origin: CGFloat
@@ -934,11 +1000,6 @@ extension StackLayout {
     struct VectorFrame {
         var origin: Vector
         var size: Vector
-
-        init(origin: Vector, size: Vector) {
-            self.origin = origin
-            self.size = size
-        }
 
         init(axis: Segment, cross: Segment) {
             origin = Vector(axis: axis.origin, cross: cross.origin)

--- a/BlueprintUI/Sources/Layout/Transformed.swift
+++ b/BlueprintUI/Sources/Layout/Transformed.swift
@@ -56,6 +56,14 @@ public struct Transformed: Element {
             attributes.transform = transform
             return attributes
         }
+
+        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+            subelement.sizeThatFits(proposal)
+        }
+
+        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+            subelement.attributes.transform = transform
+        }
     }
 }
 

--- a/BlueprintUI/Sources/Layout/UserInteractionEnabled.swift
+++ b/BlueprintUI/Sources/Layout/UserInteractionEnabled.swift
@@ -32,6 +32,14 @@ public struct UserInteractionEnabled: Element {
             attributes.isUserInteractionEnabled = isEnabled
             return attributes
         }
+
+        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+            subelement.sizeThatFits(proposal)
+        }
+
+        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+            subelement.attributes.isUserInteractionEnabled = isEnabled
+        }
     }
 }
 

--- a/BlueprintUI/Sources/Measuring/SizeConstraint.swift
+++ b/BlueprintUI/Sources/Measuring/SizeConstraint.swift
@@ -57,6 +57,12 @@ extension SizeConstraint {
         )
     }
 
+    public func inset(by insets: UIEdgeInsets) -> SizeConstraint {
+        inset(
+            width: insets.left + insets.right,
+            height: insets.top + insets.bottom
+        )
+    }
 }
 
 extension SizeConstraint {
@@ -107,6 +113,16 @@ extension SizeConstraint {
                 return value
             case .unconstrained:
                 return nil
+            }
+        }
+
+        func map(transform: (CGFloat) -> (CGFloat)) -> Self {
+            switch self {
+            case .atMost(let value):
+                return .atMost(transform(value))
+
+            case .unconstrained:
+                return .unconstrained
             }
         }
 

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -801,6 +801,16 @@ private struct TestContainer: Element {
         func layout(size: CGSize, items: [(traits: (), content: Measurable)]) -> [LayoutAttributes] {
             Array(repeating: LayoutAttributes(size: .zero), count: items.count)
         }
+
+        func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout ()) -> CGSize {
+            .zero
+        }
+
+        func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+            for subelement in subelements {
+                subelement.place(in: .zero)
+            }
+        }
     }
 }
 

--- a/BlueprintUI/Tests/EnvironmentTests.swift
+++ b/BlueprintUI/Tests/EnvironmentTests.swift
@@ -267,6 +267,19 @@ private struct TestElement: Element {
         func layout(size: CGSize, items: [(traits: (), content: Measurable)]) -> [LayoutAttributes] {
             [value.layoutAttributes]
         }
+
+        func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout ()) -> CGSize {
+            value.size
+        }
+
+        func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+            for subelement in subelements {
+                subelement.place(
+                    at: value.layoutAttributes.frame.origin,
+                    size: value.layoutAttributes.frame.size
+                )
+            }
+        }
     }
 
     func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {

--- a/BlueprintUI/Tests/LayoutResultNodeTests.swift
+++ b/BlueprintUI/Tests/LayoutResultNodeTests.swift
@@ -53,6 +53,15 @@ fileprivate struct AbstractElement: Element {
         func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
             LayoutAttributes(frame: CGRect(origin: .zero, size: size).insetBy(dx: 10, dy: 10))
         }
+
+        func sizeThatFits(proposal: SizeConstraint, subelement: Subelement, cache: inout ()) -> CGSize {
+            .zero
+        }
+
+        func placeSubelement(in size: CGSize, subelement: Subelement, cache: inout ()) {
+            let frame = CGRect(origin: .zero, size: size).insetBy(dx: 10, dy: 10)
+            subelement.place(in: frame)
+        }
     }
 
 }

--- a/BlueprintUI/Tests/PixelBoundaryTests.swift
+++ b/BlueprintUI/Tests/PixelBoundaryTests.swift
@@ -162,7 +162,8 @@ class PixelBoundaryTests: XCTestCase {
     }
 
     func assert(rect rect1: CGRect, closeTo rect2: CGRect, file: StaticString = #file, line: UInt = #line) {
-        let accuracy: CGFloat = .ulpOfOne * 64.0
+        // Not scientifically chosen, just the smallest exponent that passes these tests.
+        let accuracy: CGFloat = 1e-13
         XCTAssertEqual(rect1.minY, rect2.minY, accuracy: accuracy, file: file, line: line)
         XCTAssertEqual(rect1.minX, rect2.minX, accuracy: accuracy, file: file, line: line)
         XCTAssertEqual(rect1.maxY, rect2.maxY, accuracy: accuracy, file: file, line: line)

--- a/BlueprintUI/Tests/StackTests.swift
+++ b/BlueprintUI/Tests/StackTests.swift
@@ -1185,6 +1185,21 @@ class StackTests: XCTestCase {
 
     func test_measurementCounts() {
 
+        // For this test to be meaningful, cache hinting must be disabled.
+
+        let layoutMode: LayoutMode
+        switch LayoutMode.default {
+        case .legacy:
+            layoutMode = .legacy
+        case .caffeinated:
+            layoutMode = .caffeinated(options: .optimizationsDisabled)
+        }
+
+        RenderContext(layoutMode: layoutMode).perform(block: assertMeasurementCounts)
+    }
+
+    private func assertMeasurementCounts() {
+
         struct MeasurementCounter: Element {
 
             var size: Size
@@ -1414,4 +1429,11 @@ extension VerticalAlignment {
     }
 
     static let test25 = VerticalAlignment(Test25.self)
+}
+
+extension LayoutOptions {
+    static let optimizationsDisabled: Self = .init(
+        hintRangeBoundaries: false,
+        searchUnconstrainedKeys: false
+    )
 }

--- a/BlueprintUICommonControls/Tests/Sources/BoxTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/BoxTests.swift
@@ -132,6 +132,14 @@ private struct InsettingElement: Element {
         func layout(size: CGSize, child: Measurable) -> LayoutAttributes {
             LayoutAttributes(frame: CGRect(origin: .zero, size: size).insetBy(dx: 20, dy: 20))
         }
+
+        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout ()) -> CGSize {
+            .zero
+        }
+
+        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+            subelement.place(in: CGRect(origin: .zero, size: size).insetBy(dx: 20, dy: 20))
+        }
     }
 
 }


### PR DESCRIPTION
This is PR 5 in a stack targeting `feature/caffeinated-layout`. You can see how it fits into the larger picture by looking at the staging branch in #434.

This PR provides the implementations for built-in Elements, removing the default conformances from `Layout` and `SingleChildLayout`. Most of these are trivial; they either re-use the previous implementation or duplicate.