### PR TITLE
Constrain label measurements to the provided size constraint

### DIFF
--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -128,8 +128,16 @@ public struct AttributedLabel: Element, Hashable {
 
         return ElementContent { constraint, environment -> CGSize in
             let label = Self.prototypeLabel
+            let constraint = constraint.maximum
+
             label.update(model: self, text: text, environment: environment, isMeasuring: true)
-            return label.sizeThatFits(constraint.maximum)
+
+            let size = label.sizeThatFits(constraint)
+
+            return CGSize(
+                width: min(constraint.width, size.width),
+                height: min(constraint.height, size.height)
+            )
         }
     }
 

--- a/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
@@ -191,7 +191,7 @@ class AttributedLabelTests: XCTestCase {
 
         test(
             in: CGSize(width: 30, height: 20),
-            expectedSize: CGSize(width: 30, height: 235.5)
+            expectedSize: CGSize(width: 30, height: 20.0)
         )
         test(
             in: CGSize(width: 100, height: 300),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `AttributedLabel` and `Label` will now restrict their measured size to the provided measurement constraint.
+
 ### Deprecated
 
 ### Security


### PR DESCRIPTION
This fixes an on again off again issue we run into, where `UILabel` will return measurements larger than are provided to it. We constrain the measurement to the min of the measurement, or the input constraint.