### PR TITLE
9) Add Environment to API

### DIFF
--- a/BlueprintUI/Sources/Element/ContentStorage.swift
+++ b/BlueprintUI/Sources/Element/ContentStorage.swift
@@ -22,11 +22,13 @@ protocol LegacyContentStorage {
 protocol CaffeinatedContentStorage {
     func sizeThatFits(
         proposal: SizeConstraint,
-        context: MeasureContext
+        environment: Environment,
+        node: LayoutTreeNode
     ) -> CGSize
 
     func performCaffeinatedLayout(
         frame: CGRect,
-        context: LayoutContext
+        environment: Environment,
+        node: LayoutTreeNode
     ) -> [ElementContent.IdentifiedNode]
 }

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -42,7 +42,8 @@ public struct ElementContent {
             )
             return sizeThatFits(
                 proposal: constraint,
-                context: MeasureContext(environment: environment, node: node)
+                environment: environment,
+                node: node
             )
         }
     }
@@ -51,8 +52,12 @@ public struct ElementContent {
         storage.measure(in: constraint, environment: environment, cache: cache)
     }
 
-    func sizeThatFits(proposal: SizeConstraint, context: MeasureContext) -> CGSize {
-        storage.sizeThatFits(proposal: proposal, context: context)
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        environment: Environment,
+        node: LayoutTreeNode
+    ) -> CGSize {
+        storage.sizeThatFits(proposal: proposal, environment: environment, node: node)
     }
 
     public var childCount: Int {
@@ -75,11 +80,13 @@ public struct ElementContent {
 
     func performCaffeinatedLayout(
         frame: CGRect,
-        context: LayoutContext
+        environment: Environment,
+        node: LayoutTreeNode
     ) -> [IdentifiedNode] {
         storage.performCaffeinatedLayout(
             frame: frame,
-            context: context
+            environment: environment,
+            node: node
         )
     }
 }

--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -304,12 +304,14 @@ fileprivate struct SingleChildLayoutHost<WrappedLayout: SingleChildLayout>: Layo
     func sizeThatFits(
         proposal: SizeConstraint,
         subelements: Subelements,
+        environment: Environment,
         cache: inout Cache
     ) -> CGSize {
         precondition(subelements.count == 1)
         return wrapped.sizeThatFits(
             proposal: proposal,
             subelement: subelements[0],
+            environment: environment,
             cache: &cache
         )
     }
@@ -317,19 +319,21 @@ fileprivate struct SingleChildLayoutHost<WrappedLayout: SingleChildLayout>: Layo
     func placeSubelements(
         in size: CGSize,
         subelements: Subelements,
+        environment: Environment,
         cache: inout Cache
     ) {
         precondition(subelements.count == 1)
         wrapped.placeSubelement(
             in: size,
             subelement: subelements[0],
+            environment: environment,
             cache: &cache
         )
     }
 
-    func makeCache(subelements: Subelements) -> Cache {
+    func makeCache(subelements: Subelements, environment: Environment) -> Cache {
         precondition(subelements.count == 1)
-        return wrapped.makeCache(subelement: subelements[0])
+        return wrapped.makeCache(subelement: subelements[0], environment: environment)
     }
 }
 

--- a/BlueprintUI/Sources/Element/EnvironmentAdaptingStorage.swift
+++ b/BlueprintUI/Sources/Element/EnvironmentAdaptingStorage.swift
@@ -80,26 +80,24 @@ extension EnvironmentAdaptingStorage: LegacyContentStorage {
 
 extension EnvironmentAdaptingStorage: CaffeinatedContentStorage {
 
-    func sizeThatFits(proposal: SizeConstraint, context: MeasureContext) -> CGSize {
-        let environment = adapted(environment: context.environment)
-        let context = MeasureContext(
-            environment: environment,
-            node: context.node.subnode(key: identifier)
-        )
-        return content.sizeThatFits(proposal: proposal, context: context)
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        environment: Environment,
+        node: LayoutTreeNode
+    ) -> CGSize {
+        let environment = adapted(environment: environment)
+        let subnode = node.subnode(key: identifier)
+        return content.sizeThatFits(proposal: proposal, environment: environment, node: subnode)
     }
 
     func performCaffeinatedLayout(
         frame: CGRect,
-        context: LayoutContext
+        environment: Environment,
+        node: LayoutTreeNode
     ) -> [IdentifiedNode] {
-        let environment = adapted(environment: context.environment)
+        let environment = adapted(environment: environment)
         let childAttributes = LayoutAttributes(size: frame.size)
-
-        let context = LayoutContext(
-            environment: environment,
-            node: context.node.subnode(key: identifier)
-        )
+        let subnode = node.subnode(key: identifier)
 
         let node = LayoutResultNode(
             element: child,
@@ -107,7 +105,8 @@ extension EnvironmentAdaptingStorage: CaffeinatedContentStorage {
             environment: environment,
             children: content.performCaffeinatedLayout(
                 frame: frame,
-                context: context
+                environment: environment,
+                node: subnode
             )
         )
 

--- a/BlueprintUI/Sources/Element/LayoutStorage.swift
+++ b/BlueprintUI/Sources/Element/LayoutStorage.swift
@@ -151,12 +151,13 @@ extension LayoutStorage: CaffeinatedContentStorage {
         let subelements = subelements(from: context.node, environment: context.environment)
 
         var associatedCache = context.node.associatedCache {
-            layout.makeCache(subelements: subelements)
+            layout.makeCache(subelements: subelements, environment: environment)
         }
 
         let size = layout.sizeThatFits(
             proposal: proposal,
             subelements: subelements,
+            environment: context.environment,
             cache: &associatedCache
         )
 
@@ -174,12 +175,13 @@ extension LayoutStorage: CaffeinatedContentStorage {
         let subelements = subelements(from: context.node, environment: context.environment)
 
         var associatedCache = context.node.associatedCache {
-            layout.makeCache(subelements: subelements)
+            layout.makeCache(subelements: subelements, environment: environment)
         }
 
         layout.placeSubelements(
             in: frame.size,
             subelements: subelements,
+            environment: context.environment,
             cache: &associatedCache
         )
 

--- a/BlueprintUI/Sources/Element/LazyStorage.swift
+++ b/BlueprintUI/Sources/Element/LazyStorage.swift
@@ -68,46 +68,49 @@ extension LazyStorage: LegacyContentStorage {
 
 extension LazyStorage: CaffeinatedContentStorage {
 
-    func sizeThatFits(proposal: SizeConstraint, context: MeasureContext) -> CGSize {
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        environment: Environment,
+        node: LayoutTreeNode
+    ) -> CGSize {
         let child = buildChild(
             for: .measurement,
             in: proposal,
-            environment: context.environment
+            environment: environment
         )
         let identifier = ElementIdentifier(elementType: type(of: child), key: nil, count: 1)
-        let context = MeasureContext(
-            environment: context.environment,
-            node: context.node.subnode(key: identifier)
+        let subnode = node.subnode(key: identifier)
+
+        return child.content.sizeThatFits(
+            proposal: proposal,
+            environment: environment,
+            node: subnode
         )
-        return child.content.sizeThatFits(proposal: proposal, context: context)
     }
 
     func performCaffeinatedLayout(
         frame: CGRect,
-        context: LayoutContext
+        environment: Environment,
+        node: LayoutTreeNode
     ) -> [IdentifiedNode] {
         let child = buildChild(
             for: .layout,
             in: SizeConstraint(frame.size),
-            environment: context.environment
+            environment: environment
         )
 
         let childAttributes = LayoutAttributes(size: frame.size)
-
         let identifier = ElementIdentifier(elementType: type(of: child), key: nil, count: 1)
-
-        let context = LayoutContext(
-            environment: context.environment,
-            node: context.node.subnode(key: identifier)
-        )
+        let subnode = node.subnode(key: identifier)
 
         let node = LayoutResultNode(
             element: child,
             layoutAttributes: childAttributes,
-            environment: context.environment,
+            environment: environment,
             children: child.content.performCaffeinatedLayout(
                 frame: frame,
-                context: context
+                environment: environment,
+                node: subnode
             )
         )
 

--- a/BlueprintUI/Sources/Element/MeasurableStorage.swift
+++ b/BlueprintUI/Sources/Element/MeasurableStorage.swift
@@ -37,13 +37,18 @@ extension MeasurableStorage: LegacyContentStorage {
 
 extension MeasurableStorage: CaffeinatedContentStorage {
 
-    func sizeThatFits(proposal: SizeConstraint, context: MeasureContext) -> CGSize {
-        measurer(proposal, context.environment)
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        environment: Environment,
+        node: LayoutTreeNode
+    ) -> CGSize {
+        measurer(proposal, environment)
     }
 
     func performCaffeinatedLayout(
         frame: CGRect,
-        context: LayoutContext
+        environment: Environment,
+        node: LayoutTreeNode
     ) -> [IdentifiedNode] {
         []
     }

--- a/BlueprintUI/Sources/Element/MeasureElementStorage.swift
+++ b/BlueprintUI/Sources/Element/MeasureElementStorage.swift
@@ -53,17 +53,23 @@ extension MeasureElementStorage: LegacyContentStorage {
 
 extension MeasureElementStorage: CaffeinatedContentStorage {
 
-    func sizeThatFits(proposal: SizeConstraint, context: MeasureContext) -> CGSize {
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        environment: Environment,
+        node: LayoutTreeNode
+    ) -> CGSize {
         content.sizeThatFits(
             proposal: proposal,
-            context: MeasureContext(
-                environment: context.environment,
-                node: context.node.subnode(key: identifier)
-            )
+            environment: environment,
+            node: node.subnode(key: identifier)
         )
     }
 
-    func performCaffeinatedLayout(frame: CGRect, context: LayoutContext) -> [IdentifiedNode] {
+    func performCaffeinatedLayout(
+        frame: CGRect,
+        environment: Environment,
+        node: LayoutTreeNode
+    ) -> [IdentifiedNode] {
         []
     }
 }

--- a/BlueprintUI/Sources/Element/PassthroughStorage.swift
+++ b/BlueprintUI/Sources/Element/PassthroughStorage.swift
@@ -72,30 +72,34 @@ extension PassthroughStorage: LegacyContentStorage {
 
 extension PassthroughStorage: CaffeinatedContentStorage {
 
-    func sizeThatFits(proposal: SizeConstraint, context: MeasureContext) -> CGSize {
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        environment: Environment,
+        node: LayoutTreeNode
+    ) -> CGSize {
         content.sizeThatFits(
             proposal: proposal,
-            context: MeasureContext(
-                environment: context.environment,
-                node: context.node.subnode(key: identifier)
-            )
+            environment: environment,
+            node: node.subnode(key: identifier)
         )
     }
 
-    func performCaffeinatedLayout(frame: CGRect, context: LayoutContext) -> [IdentifiedNode] {
+    func performCaffeinatedLayout(
+        frame: CGRect,
+        environment: Environment,
+        node: LayoutTreeNode
+    ) -> [IdentifiedNode] {
         let childAttributes = LayoutAttributes(size: frame.size)
-        let context = LayoutContext(
-            environment: context.environment,
-            node: context.node.subnode(key: identifier)
-        )
+        let subnode = node.subnode(key: identifier)
 
         let node = LayoutResultNode(
             element: child,
             layoutAttributes: childAttributes,
-            environment: context.environment,
+            environment: environment,
             children: content.performCaffeinatedLayout(
                 frame: frame,
-                context: context
+                environment: environment,
+                node: subnode
             )
         )
 

--- a/BlueprintUI/Sources/Internal/LayoutContext.swift
+++ b/BlueprintUI/Sources/Internal/LayoutContext.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-/// Information passed to content storage implementations during layout.
-struct LayoutContext {
-    var environment: Environment
-    var node: LayoutTreeNode
-}

--- a/BlueprintUI/Sources/Internal/LayoutResultNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutResultNode.swift
@@ -21,13 +21,11 @@ extension Element {
         case .caffeinated(let options):
             return caffeinatedLayout(
                 frame: frame,
-                context: LayoutContext(
-                    environment: environment,
-                    node: LayoutTreeNode(
-                        path: "\(type(of: self))",
-                        signpostRef: SignpostToken(),
-                        options: options
-                    )
+                environment: environment,
+                node: LayoutTreeNode(
+                    path: "\(type(of: self))",
+                    signpostRef: SignpostToken(),
+                    options: options
                 )
             )
         }
@@ -49,16 +47,21 @@ extension Element {
         )
     }
 
-    private func caffeinatedLayout(frame: CGRect, context: LayoutContext) -> LayoutResultNode {
+    private func caffeinatedLayout(
+        frame: CGRect,
+        environment: Environment,
+        node: LayoutTreeNode
+    ) -> LayoutResultNode {
         let children = content.performCaffeinatedLayout(
             frame: frame,
-            context: context
+            environment: environment,
+            node: node
         )
 
         return LayoutResultNode(
             element: self,
             layoutAttributes: LayoutAttributes(frame: frame),
-            environment: context.environment,
+            environment: environment,
             children: children
         )
     }

--- a/BlueprintUI/Sources/Internal/MeasureContext.swift
+++ b/BlueprintUI/Sources/Internal/MeasureContext.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-/// Information passed to content storage implementations during `sizeThatFits`.
-struct MeasureContext {
-    var environment: Environment
-    var node: LayoutTreeNode
-}

--- a/BlueprintUI/Sources/Layout/Aligned.swift
+++ b/BlueprintUI/Sources/Layout/Aligned.swift
@@ -114,11 +114,21 @@ public struct Aligned: Element {
             return attributes
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout Cache
+        ) -> CGSize {
             subelement.sizeThatFits(proposal)
         }
 
-        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+        func placeSubelement(
+            in size: CGSize,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) {
             let x: CGFloat
             let y: CGFloat
 

--- a/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
@@ -159,7 +159,12 @@ public struct ConstrainedAspectRatio: Element {
             LayoutAttributes(size: size)
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout Cache
+        ) -> CGSize {
             let contentSize = subelement.sizeThatFits(proposal)
             return contentMode.constrain(
                 contentSize: contentSize,
@@ -168,7 +173,12 @@ public struct ConstrainedAspectRatio: Element {
             )
         }
 
-        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+        func placeSubelement(
+            in size: CGSize,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) {
             subelement.place(filling: size)
         }
     }

--- a/BlueprintUI/Sources/Layout/ConstrainedSize.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedSize.swift
@@ -208,7 +208,12 @@ extension ConstrainedSize {
             LayoutAttributes(size: size)
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout Cache
+        ) -> CGSize {
             if case let .absolute(width) = width, case let .absolute(height) = height {
                 return CGSize(width: width, height: height)
             }
@@ -225,7 +230,12 @@ extension ConstrainedSize {
             )
         }
 
-        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+        func placeSubelement(
+            in size: CGSize,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) {
             subelement.place(filling: size)
         }
     }

--- a/BlueprintUI/Sources/Layout/EqualStack.swift
+++ b/BlueprintUI/Sources/Layout/EqualStack.swift
@@ -153,7 +153,12 @@ extension EqualStack {
             return result
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout Cache) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelements: Subelements,
+            environment: Environment,
+            cache: inout Cache
+        ) -> CGSize {
             guard subelements.count > 0 else { return .zero }
 
             let totalSpacing = (spacing * CGFloat(subelements.count - 1))
@@ -192,7 +197,12 @@ extension EqualStack {
             return totalSize
         }
 
-        func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+        func placeSubelements(
+            in size: CGSize,
+            subelements: Subelements,
+            environment: Environment,
+            cache: inout ()
+        ) {
             guard subelements.count > 0 else { return }
 
             let totalSpacing = (spacing * CGFloat(subelements.count - 1))

--- a/BlueprintUI/Sources/Layout/GridRow.swift
+++ b/BlueprintUI/Sources/Layout/GridRow.swift
@@ -130,7 +130,12 @@ extension GridRow {
             }
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout Cache) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelements: Subelements,
+            environment: Environment,
+            cache: inout Cache
+        ) -> CGSize {
             guard subelements.count > 0 else {
                 return .zero
             }
@@ -147,7 +152,12 @@ extension GridRow {
             return size
         }
 
-        func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+        func placeSubelements(
+            in size: CGSize,
+            subelements: Subelements,
+            environment: Environment,
+            cache: inout ()
+        ) {
             guard subelements.count > 0 else {
                 return
             }

--- a/BlueprintUI/Sources/Layout/Hidden.swift
+++ b/BlueprintUI/Sources/Layout/Hidden.swift
@@ -33,11 +33,21 @@ public struct Hidden: Element {
             return attributes
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout Cache
+        ) -> CGSize {
             subelement.sizeThatFits(proposal)
         }
 
-        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+        func placeSubelement(
+            in size: CGSize,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) {
             subelement.attributes.isHidden = isHidden
         }
     }

--- a/BlueprintUI/Sources/Layout/Inset.swift
+++ b/BlueprintUI/Sources/Layout/Inset.swift
@@ -159,13 +159,23 @@ extension Inset {
             return LayoutAttributes(frame: frame)
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout ()) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) -> CGSize {
             let insetProposal = proposal.inset(by: edgeInsets)
             let childSize = subelement.sizeThatFits(insetProposal)
             return childSize + CGSize(width: left + right, height: top + bottom)
         }
 
-        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+        func placeSubelement(
+            in size: CGSize,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) {
             let insetSize = size.inset(by: edgeInsets)
 
             subelement.place(

--- a/BlueprintUI/Sources/Layout/Keyed.swift
+++ b/BlueprintUI/Sources/Layout/Keyed.swift
@@ -70,11 +70,21 @@ public struct Keyed: Element {
             LayoutAttributes(size: size)
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout Cache
+        ) -> CGSize {
             subelement.sizeThatFits(proposal)
         }
 
-        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+        func placeSubelement(
+            in size: CGSize,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) {
             subelement.place(at: .zero, size: size)
         }
     }

--- a/BlueprintUI/Sources/Layout/LayoutSubelement.swift
+++ b/BlueprintUI/Sources/Layout/LayoutSubelement.swift
@@ -27,11 +27,11 @@ public struct LayoutSubelement {
 
     var identifier: ElementIdentifier
     private var content: ElementContent
-    var measureContext: MeasureContext
+    var environment: Environment
+    var node: LayoutTreeNode
     private var traits: Any
 
-    var environment: Environment { measureContext.environment }
-    private var cache: HintingSizeCache { measureContext.node.sizeCache }
+    private var cache: HintingSizeCache { node.sizeCache }
 
     @Storage
     private(set) var placement: Placement?
@@ -43,12 +43,14 @@ public struct LayoutSubelement {
     init(
         identifier: ElementIdentifier,
         content: ElementContent,
-        measureContext: MeasureContext,
+        environment: Environment,
+        node: LayoutTreeNode,
         traits: Any
     ) {
         self.identifier = identifier
         self.content = content
-        self.measureContext = measureContext
+        self.environment = environment
+        self.node = node
         self.traits = traits
     }
 
@@ -120,7 +122,7 @@ public struct LayoutSubelement {
     /// - Returns: The size that the subelement would choose for itself, given the proposal.
     public func sizeThatFits(_ proposal: SizeConstraint) -> CGSize {
         cache.get(key: proposal) { proposal in
-            content.sizeThatFits(proposal: proposal, context: measureContext)
+            content.sizeThatFits(proposal: proposal, environment: environment, node: node)
         }
     }
 

--- a/BlueprintUI/Sources/Layout/LayoutSubelement.swift
+++ b/BlueprintUI/Sources/Layout/LayoutSubelement.swift
@@ -14,8 +14,8 @@ public typealias LayoutSubelements = [LayoutSubelement]
 /// Use this proxy to get information about the associated element, like its size and traits. You
 /// should also use the proxy to tell its corresponding element where to appear by calling the
 /// proxy’s ``place(at:anchor:size:)`` method. Do this once for each subview from your
-/// implementation of the layout’s ``CaffeinatedLayout/placeSubelements(in:subelements:cache:)``
-/// method.
+/// implementation of the layout’s
+/// ``CaffeinatedLayout/placeSubelements(in:subelements:environment:cache:)`` method.
 ///
 /// - Note: The ``LayoutSubelement`` API, and its documentation, are modeled after SwiftUI's
 ///   [LayoutSubview](https://developer.apple.com/documentation/swiftui/layoutsubview), with major
@@ -55,10 +55,10 @@ public struct LayoutSubelement {
     /// Assigns a position and size to a subelement.
     ///
     /// Call this method from your implementation of the `Layout` protocol’s
-    /// ``CaffeinatedLayout/placeSubelements(in:subelements:cache:)`` method for each subelement
-    /// arranged by the layout. Provide a position within the container’s bounds where the
-    /// subelement should appear, an anchor that indicates which part of the subelement appears at
-    /// that point, and a size.
+    /// ``CaffeinatedLayout/placeSubelements(in:subelements:environment:cache:)`` method for each
+    /// subelement arranged by the layout. Provide a position within the container’s bounds where
+    /// the subelement should appear, an anchor that indicates which part of the subelement appears
+    /// at that point, and a size.
     ///
     /// To learn the subelement's preferred size for a given proposal before calling this method,
     /// you can call ``sizeThatFits(_:)`` method on the subelement.

--- a/BlueprintUI/Sources/Layout/LayoutWriter.swift
+++ b/BlueprintUI/Sources/Layout/LayoutWriter.swift
@@ -273,11 +273,21 @@ extension LayoutWriter {
                 }
             }
 
-            func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout Cache) -> CGSize {
+            func sizeThatFits(
+                proposal: SizeConstraint,
+                subelements: Subelements,
+                environment: Environment,
+                cache: inout Cache
+            ) -> CGSize {
                 builder.sizing.measure(with: builder)
             }
 
-            func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+            func placeSubelements(
+                in size: CGSize,
+                subelements: Subelements,
+                environment: Environment,
+                cache: inout ()
+            ) {
                 for (child, subelement) in zip(builder.children, subelements) {
                     subelement.place(
                         at: child.frame.origin,

--- a/BlueprintUI/Sources/Layout/Opacity.swift
+++ b/BlueprintUI/Sources/Layout/Opacity.swift
@@ -43,11 +43,21 @@ public struct Opacity: Element {
             return attributes
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout ()) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) -> CGSize {
             subelement.sizeThatFits(proposal)
         }
 
-        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+        func placeSubelement(
+            in size: CGSize,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) {
             subelement.attributes.alpha = opacity
         }
     }

--- a/BlueprintUI/Sources/Layout/Overlay.swift
+++ b/BlueprintUI/Sources/Layout/Overlay.swift
@@ -78,7 +78,12 @@ fileprivate struct OverlayLayout: Layout {
         )
     }
 
-    func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout Cache) -> CGSize {
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        subelements: Subelements,
+        environment: Environment,
+        cache: inout Cache
+    ) -> CGSize {
         subelements.reduce(into: CGSize.zero) { result, subelement in
             let measuredSize = subelement.sizeThatFits(proposal)
             result.width = max(result.width, measuredSize.width)
@@ -86,7 +91,12 @@ fileprivate struct OverlayLayout: Layout {
         }
     }
 
-    func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+    func placeSubelements(
+        in size: CGSize,
+        subelements: Subelements,
+        environment: Environment,
+        cache: inout ()
+    ) {
         for subelement in subelements {
             subelement.place(filling: size)
         }

--- a/BlueprintUI/Sources/Layout/SingleChildLayout.swift
+++ b/BlueprintUI/Sources/Layout/SingleChildLayout.swift
@@ -40,7 +40,7 @@ public protocol CaffeinatedSingleChildLayout {
     /// as your data storage type. Alternatively, you can refer to the data storage type directly in
     /// all the places where you work with the cache.
     ///
-    /// See ``makeCache(subelement:)-33y4l`` for more information.
+    /// See ``makeCache(subelement:environment:)-8vyl9`` for more information.
     associatedtype Cache = Void
 
     /// Returns the size of the element, given a proposed size constraint and the container's
@@ -54,7 +54,8 @@ public protocol CaffeinatedSingleChildLayout {
     /// In Blueprint, parents ultimately choose the size of their children, so the actual size that
     /// this container is laid out in may not be a size that was returned from this method.
     ///
-    /// For more information, see ``CaffeinatedLayout/sizeThatFits(proposal:subelements:cache:)``.
+    /// For more information, see
+    /// ``CaffeinatedLayout/sizeThatFits(proposal:subelements:environment:cache:)``.
     ///
     /// - Parameters:
     ///   - proposal: A size constraint for the container. The container's parent element that calls
@@ -63,13 +64,17 @@ public protocol CaffeinatedSingleChildLayout {
     ///   - subelement: A proxy that represents the element that the container arranges. You can use
     ///     the proxy to get information about the subelement as you determine how much space the
     ///     container needs to display it.
+    ///   - environment: The environment of the container. You can use properties from the
+    ///     environment when calculating the size of this container, as long as you adhere to the
+    ///     sizing rules.
     ///   - cache: Optional storage for calculated data that you can share among the methods of your
-    ///     custom layout container. See ``makeCache(subelement:)-33y4l`` for details.
+    ///     custom layout container. See ``makeCache(subelement:environment:)-8vyl9`` for details.
     /// - Returns: A size that indicates how much space the container needs to arrange its
     ///   subelement.
     func sizeThatFits(
         proposal: SizeConstraint,
         subelement: Subelement,
+        environment: Environment,
         cache: inout Cache
     ) -> CGSize
 
@@ -85,20 +90,24 @@ public protocol CaffeinatedSingleChildLayout {
     /// Be sure that you use computations during placement that are consistent with those in your
     /// implementation of other protocol methods for a given set of inputs. For example, if you add
     /// spacing during placement, make sure your implementation of
-    /// ``sizeThatFits(proposal:subelement:cache:)`` accounts for the extra space.
+    /// ``sizeThatFits(proposal:subelement:environment:cache:)`` accounts for the extra space.
     ///
     /// - Parameters:
     ///   - size: The region that the container's parent allocates to the container. Place the
     ///     container's subelement within the region. The size of this region may not match any size
-    ///     that was returned from a call to ``sizeThatFits(proposal:subelement:cache:)``.
+    ///     that was returned from a call to
+    ///     ``sizeThatFits(proposal:subelement:environment:cache:)``.
     ///   - subelement: A proxy that represents the element that the container arranges. Use the
     ///     proxy to get information about the subelement and to tell the subelement where to
     ///     appear.
+    ///   - environment: The environment of this container. You can use properties from the
+    ///     environment to vary the placement of the subelement.
     ///   - cache: Optional storage for calculated data that you can share among the methods of your
-    ///     custom layout container. See ``makeCache(subelement:)-33y4l`` for details.
+    ///     custom layout container. See ``makeCache(subelement:environment:)-8vyl9`` for details.
     func placeSubelement(
         in size: CGSize,
         subelement: Subelement,
+        environment: Environment,
         cache: inout Cache
     )
 
@@ -111,27 +120,29 @@ public protocol CaffeinatedSingleChildLayout {
     /// method if you don’t need a cache.
     ///
     /// However you might find a cache useful when the layout container repeats complex intermediate
-    /// calculations across calls to ``sizeThatFits(proposal:subelement:cache:)`` and
-    /// ``placeSubelement(in:subelement:cache:)``. You might be able to improve performance by
-    /// calculating values once and storing them in a cache.
+    /// calculations across calls to ``sizeThatFits(proposal:subelement:environment:cache:)`` and
+    /// ``placeSubelement(in:subelement:environment:cache:)``. You might be able to improve
+    /// performance by calculating values once and storing them in a cache.
     ///
     /// - Note: A cache's lifetime is limited to a single render pass, so you cannot use it to store
-    ///   values across multiple calls to ``placeSubelement(in:subelement:cache:)``. A render pass
-    ///   includes zero, one, or many calls to ``sizeThatFits(proposal:subelement:cache:)``,
-    ///   followed by a single call to ``placeSubelement(in:subelement:cache:)``.
+    ///   values across multiple calls to ``placeSubelement(in:subelement:environment:cache:)``. A
+    ///   render pass includes zero, one, or many calls to
+    ///   ``sizeThatFits(proposal:subelement:environment:cache:)``, followed by a single call to
+    ///   ``placeSubelement(in:subelement:environment:cache:)``.
     ///
     /// Only implement a cache if profiling shows that it improves performance.
     ///
-    /// For more information, see ``CaffeinatedLayout/makeCache(subelements:)-d3w``.
+    /// For more information, see ``CaffeinatedLayout/makeCache(subelements:environment:)-8ciko``.
     ///
     /// - Parameter subelement: A proxy that represent the subelement that the container arranges.
     ///   You can use the proxy to get information about the subelement as you calculate values to
     ///   store in the cache.
+    /// - Parameter environment: The environment of this container.
     /// - Returns: Storage for calculated data that you share among the methods of your custom
     ///   layout container.
-    func makeCache(subelement: Subelement) -> Cache
+    func makeCache(subelement: Subelement, environment: Environment) -> Cache
 }
 
 extension CaffeinatedSingleChildLayout where Cache == () {
-    public func makeCache(subelement: Subelement) { () }
+    public func makeCache(subelement: Subelement, environment: Environment) { () }
 }

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -873,7 +873,12 @@ extension LayoutSubelement {
 }
 
 extension StackLayout {
-    public func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout ()) -> CGSize {
+    public func sizeThatFits(
+        proposal: SizeConstraint,
+        subelements: Subelements,
+        environment: Environment,
+        cache: inout ()
+    ) -> CGSize {
         guard subelements.isEmpty == false else { return .zero }
 
         let constraint = proposal.vectorConstraint(on: axis)
@@ -890,8 +895,12 @@ extension StackLayout {
         return vector.size(axis: axis)
     }
 
-    public func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
-
+    public func placeSubelements(
+        in size: CGSize,
+        subelements: Subelements,
+        environment: Environment,
+        cache: inout ()
+    ) {
         let constraint = size.vectorConstraint(axis: axis)
 
         let frames = _frames(for: subelements.map(StackLayoutItem.init), in: constraint)

--- a/BlueprintUI/Sources/Layout/Transformed.swift
+++ b/BlueprintUI/Sources/Layout/Transformed.swift
@@ -57,11 +57,21 @@ public struct Transformed: Element {
             return attributes
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout Cache
+        ) -> CGSize {
             subelement.sizeThatFits(proposal)
         }
 
-        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+        func placeSubelement(
+            in size: CGSize,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) {
             subelement.attributes.transform = transform
         }
     }

--- a/BlueprintUI/Sources/Layout/UserInteractionEnabled.swift
+++ b/BlueprintUI/Sources/Layout/UserInteractionEnabled.swift
@@ -33,11 +33,21 @@ public struct UserInteractionEnabled: Element {
             return attributes
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout Cache
+        ) -> CGSize {
             subelement.sizeThatFits(proposal)
         }
 
-        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+        func placeSubelement(
+            in size: CGSize,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) {
             subelement.attributes.isUserInteractionEnabled = isEnabled
         }
     }

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -802,11 +802,21 @@ private struct TestContainer: Element {
             Array(repeating: LayoutAttributes(size: .zero), count: items.count)
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout ()) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelements: Subelements,
+            environment: Environment,
+            cache: inout ()
+        ) -> CGSize {
             .zero
         }
 
-        func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+        func placeSubelements(
+            in size: CGSize,
+            subelements: Subelements,
+            environment: Environment,
+            cache: inout ()
+        ) {
             for subelement in subelements {
                 subelement.place(in: .zero)
             }

--- a/BlueprintUI/Tests/Element+Testing.swift
+++ b/BlueprintUI/Tests/Element+Testing.swift
@@ -41,10 +41,8 @@ extension ElementContent {
         case .caffeinated(let options):
             return performCaffeinatedLayout(
                 frame: attributes.frame,
-                context: LayoutContext(
-                    environment: .empty,
-                    node: LayoutTreeNode(path: "test", signpostRef: SignpostToken(), options: options)
-                )
+                environment: .empty,
+                node: LayoutTreeNode(path: "test", signpostRef: SignpostToken(), options: options)
             )
         }
     }

--- a/BlueprintUI/Tests/ElementContentTests.swift
+++ b/BlueprintUI/Tests/ElementContentTests.swift
@@ -280,7 +280,12 @@ fileprivate struct FrameLayout: Layout {
         items.map { LayoutAttributes(frame: $0.traits) }
     }
 
-    func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout ()) -> CGSize {
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        subelements: Subelements,
+        environment: Environment,
+        cache: inout ()
+    ) -> CGSize {
         subelements.reduce(into: CGSize.zero) { result, subview in
             let traits = subview.traits(forLayoutType: FrameLayout.self)
             result.width = max(result.width, traits.maxX)
@@ -288,7 +293,12 @@ fileprivate struct FrameLayout: Layout {
         }
     }
 
-    func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+    func placeSubelements(
+        in size: CGSize,
+        subelements: Subelements,
+        environment: Environment,
+        cache: inout ()
+    ) {
         for subelement in subelements {
             let frame = subelement.traits(forLayoutType: FrameLayout.self)
             subelement.place(
@@ -324,26 +334,22 @@ private struct HalfLayout: Layout {
         }
     }
 
-    func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout ()) -> CGSize {
-        let halfConstraint = SizeConstraint(
-            width: proposal.width / 2,
-            height: proposal.height / 2
-        )
-        let measurements = subelements.map { $0.sizeThatFits(halfConstraint) }
-        return CGSize(
-            width: measurements.map(\.width).reduce(0, +),
-            height: measurements.map(\.height).reduce(0, +)
-        )
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        subelements: Subelements,
+        environment: Environment,
+        cache: inout ()
+    ) -> CGSize {
+        fatalError("Not supported in Caffeinated Layout")
     }
 
-    func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
-        let halfConstraint = SizeConstraint(CGSize(width: size.width / 2, height: size.height / 2))
-        for subelement in subelements {
-            subelement.place(
-                at: .zero,
-                size: subelement.sizeThatFits(halfConstraint)
-            )
-        }
+    func placeSubelements(
+        in size: CGSize,
+        subelements: Subelements,
+        environment: Environment,
+        cache: inout ()
+    ) {
+        fatalError("Not supported in Caffeinated Layout")
     }
 }
 
@@ -368,21 +374,37 @@ private struct MeasureCountingLayout<WrappedLayout>: Layout where WrappedLayout:
         layout.layout(size: size, items: items)
     }
 
-    func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout WrappedLayout.Cache) -> CGSize {
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        subelements: Subelements,
+        environment: Environment,
+        cache: inout WrappedLayout.Cache
+    ) -> CGSize {
         counts.measures += 1
-        return layout.sizeThatFits(proposal: proposal, subelements: subelements, cache: &cache)
+        return layout.sizeThatFits(
+            proposal: proposal,
+            subelements: subelements,
+            environment: environment,
+            cache: &cache
+        )
     }
 
     func placeSubelements(
         in size: CGSize,
         subelements: Subelements,
+        environment: Environment,
         cache: inout WrappedLayout.Cache
     ) {
-        layout.placeSubelements(in: size, subelements: subelements, cache: &cache)
+        layout.placeSubelements(
+            in: size,
+            subelements: subelements,
+            environment: environment,
+            cache: &cache
+        )
     }
 
-    func makeCache(subelements: LayoutSubelements) -> WrappedLayout.Cache {
-        layout.makeCache(subelements: subelements)
+    func makeCache(subelements: Subelements, environment: Environment) -> WrappedLayout.Cache {
+        layout.makeCache(subelements: subelements, environment: environment)
     }
 }
 
@@ -411,11 +433,21 @@ private struct MeasureCountingSpacer: Element {
             []
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout ()) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelements: Subelements,
+            environment: Environment,
+            cache: inout ()
+        ) -> CGSize {
             size
         }
 
-        func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+        func placeSubelements(
+            in size: CGSize,
+            subelements: Subelements,
+            environment: Environment,
+            cache: inout ()
+        ) {
             // No-op
         }
     }

--- a/BlueprintUI/Tests/EnvironmentTests.swift
+++ b/BlueprintUI/Tests/EnvironmentTests.swift
@@ -268,11 +268,21 @@ private struct TestElement: Element {
             [value.layoutAttributes]
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelements: Subelements, cache: inout ()) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelements: Subelements,
+            environment: Environment,
+            cache: inout ()
+        ) -> CGSize {
             value.size
         }
 
-        func placeSubelements(in size: CGSize, subelements: Subelements, cache: inout ()) {
+        func placeSubelements(
+            in size: CGSize,
+            subelements: Subelements,
+            environment: Environment,
+            cache: inout ()
+        ) {
             for subelement in subelements {
                 subelement.place(
                     at: value.layoutAttributes.frame.origin,

--- a/BlueprintUI/Tests/LayoutResultNodeTests.swift
+++ b/BlueprintUI/Tests/LayoutResultNodeTests.swift
@@ -54,11 +54,21 @@ fileprivate struct AbstractElement: Element {
             LayoutAttributes(frame: CGRect(origin: .zero, size: size).insetBy(dx: 10, dy: 10))
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelement: Subelement, cache: inout ()) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) -> CGSize {
             .zero
         }
 
-        func placeSubelement(in size: CGSize, subelement: Subelement, cache: inout ()) {
+        func placeSubelement(
+            in size: CGSize,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) {
             let frame = CGRect(origin: .zero, size: size).insetBy(dx: 10, dy: 10)
             subelement.place(in: frame)
         }

--- a/BlueprintUICommonControls/Sources/ScrollView.swift
+++ b/BlueprintUICommonControls/Sources/ScrollView.swift
@@ -164,7 +164,7 @@ extension ScrollView {
             return contentAttributes
         }
 
-        func fittedSize(in proposal: SizeConstraint, subelement: LayoutSubelement) -> CGSize {
+        func fittedSize(in proposal: SizeConstraint, subelement: Subelement) -> CGSize {
             switch contentSize {
             case .custom(let size):
                 return size
@@ -190,7 +190,12 @@ extension ScrollView {
             }
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout Cache) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout Cache
+        ) -> CGSize {
             let adjustedProposal = proposal.inset(by: contentInset)
 
             var result = fittedSize(in: adjustedProposal, subelement: subelement)
@@ -208,7 +213,12 @@ extension ScrollView {
             return result
         }
 
-        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+        func placeSubelement(
+            in size: CGSize,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) {
             var insetSize = size
             insetSize.width -= contentInset.left + contentInset.right
             insetSize.height -= contentInset.top + contentInset.bottom

--- a/BlueprintUICommonControls/Tests/Sources/BoxTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/BoxTests.swift
@@ -133,11 +133,21 @@ private struct InsettingElement: Element {
             LayoutAttributes(frame: CGRect(origin: .zero, size: size).insetBy(dx: 20, dy: 20))
         }
 
-        func sizeThatFits(proposal: SizeConstraint, subelement: LayoutSubelement, cache: inout ()) -> CGSize {
+        func sizeThatFits(
+            proposal: SizeConstraint,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) -> CGSize {
             .zero
         }
 
-        func placeSubelement(in size: CGSize, subelement: LayoutSubelement, cache: inout ()) {
+        func placeSubelement(
+            in size: CGSize,
+            subelement: Subelement,
+            environment: Environment,
+            cache: inout ()
+        ) {
             subelement.place(in: CGRect(origin: .zero, size: size).insetBy(dx: 20, dy: 20))
         }
     }


### PR DESCRIPTION
This is PR 9 in a stack targeting `feature/caffeinated-layout`. See #447 

This PR adds an `Environment` parameter to the `CaffeinatedLayout` API methods.

It also removes the `LayoutContext` and `MeasureContext` types that were used internally, flattening them into two parameters in all usages.