### PR TITLE
Fix exact match case of constrained aspect ratios and contract adherence

### DIFF
--- a/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
+++ b/BlueprintUI/Sources/Layout/ConstrainedAspectRatio.swift
@@ -66,13 +66,14 @@ public struct ConstrainedAspectRatio: Element {
                     } else if constrainedHeight > availableHeight {
                         return aspectRatio.size(forHeight: constrainedHeight)
                     }
+                    return contentSize
                 } else if constraint.width.constrainedValue == nil {
                     return aspectRatio.size(forWidth: constrainedWidth)
                 } else if constraint.height.constrainedValue == nil {
                     return aspectRatio.size(forHeight: constrainedHeight)
                 } else if constrainedWidth < availableWidth {
                     return aspectRatio.size(forHeight: constrainedHeight)
-                } else if constrainedHeight < availableHeight {
+                } else {
                     return aspectRatio.size(forWidth: constrainedWidth)
                 }
 
@@ -85,13 +86,14 @@ public struct ConstrainedAspectRatio: Element {
                     } else if constrainedHeight > availableHeight {
                         return aspectRatio.size(forHeight: constrainedHeight)
                     }
+                    return contentSize
                 } else if constraint.width.constrainedValue == nil {
                     return aspectRatio.size(forWidth: constrainedWidth)
                 } else if constraint.height.constrainedValue == nil {
                     return aspectRatio.size(forHeight: constrainedHeight)
                 } else if constrainedWidth > availableWidth {
                     return aspectRatio.size(forHeight: constrainedHeight)
-                } else if constrainedHeight > availableHeight {
+                } else {
                     return aspectRatio.size(forWidth: constrainedWidth)
                 }
 
@@ -101,6 +103,7 @@ public struct ConstrainedAspectRatio: Element {
                 } else if constrainedHeight > availableHeight {
                     return aspectRatio.size(forHeight: constrainedHeight)
                 }
+                return contentSize
 
             case .shrinkContent:
                 if constrainedWidth < availableWidth {
@@ -108,9 +111,8 @@ public struct ConstrainedAspectRatio: Element {
                 } else if constrainedHeight < availableHeight {
                     return aspectRatio.size(forHeight: constrainedHeight)
                 }
+                return contentSize
             }
-
-            return contentSize
         }
     }
 

--- a/BlueprintUI/Tests/AssertLayoutContract.swift
+++ b/BlueprintUI/Tests/AssertLayoutContract.swift
@@ -1,0 +1,128 @@
+import BlueprintUI
+import XCTest
+
+/// Asserts that an element's layout adheres to the Caffeinated Layout contract, by probing its size
+/// in a variety of constraints.
+///
+/// - Parameters:
+///   - element: The element under test.
+///   - file: The file in which failure occurred. Defaults to `#file`.
+///   - line: The line on which failure occurred. Defaults to `#line`.
+public func assertLayoutContract(
+    of element: Element,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+
+    let content = element.content
+
+    let constraintValues: [CGFloat] = [
+        0,
+        1,
+        5,
+        10,
+        50,
+        100,
+        500,
+        1000,
+        5000,
+        10000,
+        .infinity,
+    ]
+    let adjacentConstraintValues = Array(zip(constraintValues, constraintValues.dropFirst()))
+
+    var sizes: [SizeConstraint: CGSize] = [:]
+
+    func sizeThatFits(width: CGFloat, height: CGFloat) -> CGSize {
+        let constraint = SizeConstraint(CGSize(width: width, height: height))
+
+        if let size = sizes[constraint] {
+            return size
+        }
+
+        let size = LayoutMode.caffeinated.performAsDefault {
+            content.measure(in: constraint, environment: .empty)
+        }
+        sizes[constraint] = size
+
+        return size
+    }
+
+    for width in constraintValues {
+        for (lowerHeight, upperHeight) in adjacentConstraintValues {
+            let lowerSize = sizeThatFits(width: width, height: lowerHeight)
+            let upperSize = sizeThatFits(width: width, height: upperHeight)
+
+            if upperSize.height <= lowerHeight, lowerHeight <= upperHeight {
+                XCTAssertEqual(
+                    lowerSize.height,
+                    upperSize.height,
+                    """
+                    Caffeinated layout contract violation:
+                      At fixed width \(width),
+                      measured height \(upperHeight) => \(upperSize.height)
+                      implies a range [\(upperSize.height)...\(upperHeight)] => \(upperSize.height),
+                      so we expect \(lowerHeight) => \(upperSize.height)
+                    However, we observed:
+                      \(lowerHeight) => \(lowerSize.height)
+                    """,
+                    file: file,
+                    line: line
+                )
+            } else {
+                XCTAssertLessThanOrEqual(
+                    lowerSize.height,
+                    upperSize.height,
+                    """
+                    Caffeinated layout contract violation:
+                      At fixed width \(width),
+                      measured height \(lowerHeight) => \(lowerSize.height)
+                      and height \(upperHeight) => \(upperSize.height)
+                    Size must grow monotonically.
+                    """,
+                    file: file,
+                    line: line
+                )
+            }
+        }
+    }
+
+    for height in constraintValues {
+        for (lowerWidth, upperWidth) in adjacentConstraintValues {
+            let lowerSize = sizeThatFits(width: lowerWidth, height: height)
+            let upperSize = sizeThatFits(width: upperWidth, height: height)
+
+            if upperSize.width <= lowerWidth, lowerWidth <= upperWidth {
+                XCTAssertEqual(
+                    lowerSize.width,
+                    upperSize.width,
+                    """
+                    Caffeinated layout contract violation:
+                      At fixed height \(height),
+                      measured width \(upperWidth) => \(upperSize.width)
+                      implies a range [\(upperSize.width)...\(upperWidth)] => \(upperSize.width),
+                      so we expect \(lowerWidth) => \(upperSize.width)
+                    However, we observed:
+                      \(lowerWidth) => \(lowerSize.width)
+                    """,
+                    file: file,
+                    line: line
+                )
+            } else {
+                XCTAssertLessThanOrEqual(
+                    lowerSize.width,
+                    upperSize.width,
+                    """
+                    Caffeinated layout contract violation:
+                      At fixed height \(height),
+                      measured width \(lowerWidth) => \(lowerSize.width)
+                      and width \(upperWidth) => \(upperSize.width)
+                    Size must grow monotonically.
+                    """,
+                    file: file,
+                    line: line
+                )
+            }
+        }
+    }
+}

--- a/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
+++ b/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
@@ -2,258 +2,527 @@ import BlueprintUI
 import XCTest
 
 class ConstrainedAspectRatioTests: XCTestCase {
-    func test_expandWide() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fitContent,
-            wrapping: TestElement()
-        )
 
-        let size = element.content.measure(in: .unconstrained)
-        XCTAssertEqual(size, CGSize(width: 200, height: 100))
+    let tallRatio = AspectRatio(width: 1, height: 4)
+    let wideRatio = AspectRatio(width: 4, height: 1)
+
+    func assert(
+        ratio: AspectRatio,
+        mode: ConstrainedAspectRatio.ContentMode,
+        constraint: SizeConstraint,
+        layoutModes: [LayoutMode] = LayoutMode.testModes,
+        expectedSize: CGSize,
+        line: UInt = #line
+    ) {
+        let element = TestElement()
+            .constrainedTo(aspectRatio: ratio, contentMode: mode)
+
+        for layoutMode in layoutModes {
+            layoutMode.performAsDefault {
+                let size = element.content.measure(in: constraint, environment: .empty)
+                XCTAssertEqual(
+                    size,
+                    expectedSize,
+                    """
+                    Element sized \(TestElement.size)
+                    constrained to aspect ratio \(ratio.ratio)
+                    content mode \(mode)
+                    expected to be size: \(expectedSize)
+                    in constraint: \(constraint)
+                    layout mode: \(layoutMode)
+                    """,
+                    line: line
+                )
+            }
+        }
     }
 
-    func test_expandTall() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 1, height: 2),
-            contentMode: .fitContent,
-            wrapping: TestElement()
-        )
+    func test_fillParent_wide() {
+        func assert(
+            constraint: SizeConstraint,
+            layoutModes: [LayoutMode] = LayoutMode.testModes,
+            expectedSize: CGSize,
+            line: UInt = #line
+        ) {
+            self.assert(
+                ratio: wideRatio,
+                mode: .fillParent,
+                constraint: constraint,
+                layoutModes: layoutModes,
+                expectedSize: expectedSize,
+                line: line
+            )
+        }
 
-        let size = element.content.measure(in: .unconstrained)
-        XCTAssertEqual(size, CGSize(width: 120, height: 240))
+        // Fixed large constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(100), height: .atMost(100)),
+            layoutModes: [.legacy],
+            expectedSize: CGSize(width: 400, height: 100)
+        )
+        // Fixed small constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(8), height: .atMost(8)),
+            layoutModes: [.legacy],
+            expectedSize: CGSize(width: 32, height: 8)
+        )
+        // Unconstrained height, larger width
+        assert(
+            constraint: SizeConstraint(width: 100),
+            expectedSize: CGSize(width: 100, height: 25)
+        )
+        // Unconstrained height, smaller width
+        assert(
+            constraint: SizeConstraint(width: 8),
+            expectedSize: CGSize(width: 8, height: 2)
+        )
+        // Unconstrained width, larger height
+        assert(
+            constraint: SizeConstraint(height: 100),
+            expectedSize: CGSize(width: 400, height: 100)
+        )
+        // Unconstrained width, smaller height
+        assert(
+            constraint: SizeConstraint(height: 8),
+            expectedSize: CGSize(width: 32, height: 8)
+        )
+        // Fully unconstrained
+        assert(
+            constraint: .unconstrained,
+            layoutModes: [.legacy],
+            expectedSize: CGSize(width: 40, height: 10)
+        )
+        // Exact fit
+        assert(
+            constraint: SizeConstraint(width: .atMost(80), height: .atMost(20)),
+            expectedSize: CGSize(width: 80, height: 20)
+        )
     }
 
-    func test_expandSquare() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: .square,
-            contentMode: .fitContent,
-            wrapping: TestElement()
-        )
+    func test_fillParent_tall() {
+        func assert(
+            constraint: SizeConstraint,
+            layoutModes: [LayoutMode] = LayoutMode.testModes,
+            expectedSize: CGSize,
+            line: UInt = #line
+        ) {
+            self.assert(
+                ratio: tallRatio,
+                mode: .fillParent,
+                constraint: constraint,
+                layoutModes: layoutModes,
+                expectedSize: expectedSize,
+                line: line
+            )
+        }
 
-        let size = element.content.measure(in: .unconstrained)
-        XCTAssertEqual(size, CGSize(width: 120, height: 120))
+        // Fixed large constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(100), height: .atMost(100)),
+            layoutModes: [.legacy],
+            expectedSize: CGSize(width: 100, height: 400)
+        )
+        // Fixed small constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(8), height: .atMost(8)),
+            layoutModes: [.legacy],
+            expectedSize: CGSize(width: 8, height: 32)
+        )
+        // Unconstrained height, larger width
+        assert(
+            constraint: SizeConstraint(width: 100),
+            expectedSize: CGSize(width: 100, height: 400)
+        )
+        // Unconstrained height, smaller width
+        assert(
+            constraint: SizeConstraint(width: 8),
+            expectedSize: CGSize(width: 8, height: 32)
+        )
+        // Unconstrained width, larger height
+        assert(
+            constraint: SizeConstraint(height: 100),
+            expectedSize: CGSize(width: 25, height: 100)
+        )
+        // Unconstrained width, smaller height
+        assert(
+            constraint: SizeConstraint(height: 8),
+            expectedSize: CGSize(width: 2, height: 8)
+        )
+        // Fully unconstrained
+        assert(
+            constraint: .unconstrained,
+            layoutModes: [.legacy],
+            expectedSize: CGSize(width: 12, height: 48)
+        )
+        // Exact fit
+        assert(
+            constraint: SizeConstraint(width: .atMost(20), height: .atMost(80)),
+            expectedSize: CGSize(width: 20, height: 80)
+        )
     }
 
-    func test_shrinkWide() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .shrinkContent,
-            wrapping: TestElement()
-        )
+    func test_fitParent_wide() {
+        func assert(
+            constraint: SizeConstraint,
+            layoutModes: [LayoutMode] = LayoutMode.testModes,
+            expectedSize: CGSize,
+            line: UInt = #line
+        ) {
+            self.assert(
+                ratio: wideRatio,
+                mode: .fitParent,
+                constraint: constraint,
+                layoutModes: layoutModes,
+                expectedSize: expectedSize,
+                line: line
+            )
+        }
 
-        let size = element.content.measure(in: .unconstrained)
-        XCTAssertEqual(size, CGSize(width: 120, height: 60))
+        // Fixed large constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(100), height: .atMost(100)),
+            expectedSize: CGSize(width: 100, height: 25)
+        )
+        // Fixed small constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(8), height: .atMost(8)),
+            expectedSize: CGSize(width: 8, height: 2)
+        )
+        // Unconstrained height, larger width
+        assert(
+            constraint: SizeConstraint(width: 100),
+            expectedSize: CGSize(width: 100, height: 25)
+        )
+        // Unconstrained height, smaller width
+        assert(
+            constraint: SizeConstraint(width: 8),
+            expectedSize: CGSize(width: 8, height: 2)
+        )
+        // Unconstrained width, larger height
+        assert(
+            constraint: SizeConstraint(height: 100),
+            expectedSize: CGSize(width: 400, height: 100)
+        )
+        // Unconstrained width, smaller height
+        assert(
+            constraint: SizeConstraint(height: 8),
+            expectedSize: CGSize(width: 32, height: 8)
+        )
+        // Fully unconstrained
+        assert(
+            constraint: .unconstrained,
+            layoutModes: [.legacy],
+            expectedSize: CGSize(width: 40, height: 10)
+        )
+        // Exact fit
+        assert(
+            constraint: SizeConstraint(width: .atMost(80), height: .atMost(20)),
+            expectedSize: CGSize(width: 80, height: 20)
+        )
     }
 
-    func test_shrinkTall() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 1, height: 2),
-            contentMode: .shrinkContent,
-            wrapping: TestElement()
-        )
+    func test_fitParent_tall() {
+        func assert(
+            constraint: SizeConstraint,
+            layoutModes: [LayoutMode] = LayoutMode.testModes,
+            expectedSize: CGSize,
+            line: UInt = #line
+        ) {
+            self.assert(
+                ratio: tallRatio,
+                mode: .fitParent,
+                constraint: constraint,
+                layoutModes: layoutModes,
+                expectedSize: expectedSize,
+                line: line
+            )
+        }
 
-        let size = element.content.measure(in: .unconstrained)
-        XCTAssertEqual(size, CGSize(width: 50, height: 100))
+        // Fixed large constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(100), height: .atMost(100)),
+            expectedSize: CGSize(width: 25, height: 100)
+        )
+        // Fixed small constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(8), height: .atMost(8)),
+            expectedSize: CGSize(width: 2, height: 8)
+        )
+        // Unconstrained height, larger width
+        assert(
+            constraint: SizeConstraint(width: 100),
+            expectedSize: CGSize(width: 100, height: 400)
+        )
+        // Unconstrained height, smaller width
+        assert(
+            constraint: SizeConstraint(width: 8),
+            expectedSize: CGSize(width: 8, height: 32)
+        )
+        // Unconstrained width, larger height
+        assert(
+            constraint: SizeConstraint(height: 100),
+            expectedSize: CGSize(width: 25, height: 100)
+        )
+        // Unconstrained width, smaller height
+        assert(
+            constraint: SizeConstraint(height: 8),
+            expectedSize: CGSize(width: 2, height: 8)
+        )
+        // Fully unconstrained
+        assert(
+            constraint: .unconstrained,
+            layoutModes: [.legacy],
+            expectedSize: CGSize(width: 12, height: 48)
+        )
+        // Exact fit
+        assert(
+            constraint: SizeConstraint(width: .atMost(20), height: .atMost(80)),
+            expectedSize: CGSize(width: 20, height: 80)
+        )
     }
 
-    func test_shrinkSquare() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: .square,
-            contentMode: .shrinkContent,
-            wrapping: TestElement()
-        )
+    func test_fitContent_wide() {
+        func assert(
+            constraint: SizeConstraint,
+            layoutModes: [LayoutMode] = LayoutMode.testModes,
+            expectedSize: CGSize,
+            line: UInt = #line
+        ) {
+            self.assert(
+                ratio: wideRatio,
+                mode: .fitContent,
+                constraint: constraint,
+                layoutModes: layoutModes,
+                expectedSize: expectedSize,
+                line: line
+            )
+        }
 
-        let size = element.content.measure(in: .unconstrained)
-        XCTAssertEqual(size, CGSize(width: 100, height: 100))
+        // Fixed large constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(100), height: .atMost(100)),
+            expectedSize: CGSize(width: 40, height: 10)
+        )
+        // Fixed small constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(8), height: .atMost(8)),
+            expectedSize: CGSize(width: 40, height: 10)
+        )
+        // Unconstrained height, larger width
+        assert(
+            constraint: SizeConstraint(width: 100),
+            expectedSize: CGSize(width: 40, height: 10)
+        )
+        // Unconstrained height, smaller width
+        assert(
+            constraint: SizeConstraint(width: 8),
+            expectedSize: CGSize(width: 40, height: 10)
+        )
+        // Unconstrained width, larger height
+        assert(
+            constraint: SizeConstraint(height: 100),
+            expectedSize: CGSize(width: 40, height: 10)
+        )
+        // Unconstrained width, smaller height
+        assert(
+            constraint: SizeConstraint(height: 8),
+            expectedSize: CGSize(width: 40, height: 10)
+        )
+        // Fully unconstrained
+        assert(
+            constraint: .unconstrained,
+            expectedSize: CGSize(width: 40, height: 10)
+        )
+        // Exact fit
+        assert(
+            constraint: SizeConstraint(width: .atMost(80), height: .atMost(20)),
+            expectedSize: CGSize(width: 40, height: 10)
+        )
     }
 
-    func test_expandWideFillParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fillParent,
-            wrapping: TestElement()
-        )
+    func test_fitContent_tall() {
+        func assert(
+            constraint: SizeConstraint,
+            layoutModes: [LayoutMode] = LayoutMode.testModes,
+            expectedSize: CGSize,
+            line: UInt = #line
+        ) {
+            self.assert(
+                ratio: tallRatio,
+                mode: .fitContent,
+                constraint: constraint,
+                layoutModes: layoutModes,
+                expectedSize: expectedSize,
+                line: line
+            )
+        }
 
-        let size = element.content.measure(
-            in: SizeConstraint(CGSize(width: 300, height: 400)))
-        XCTAssertEqual(size, CGSize(width: 800, height: 400))
+        // Fixed large constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(100), height: .atMost(100)),
+            expectedSize: CGSize(width: 12, height: 48)
+        )
+        // Fixed small constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(8), height: .atMost(8)),
+            expectedSize: CGSize(width: 12, height: 48)
+        )
+        // Unconstrained height, larger width
+        assert(
+            constraint: SizeConstraint(width: 100),
+            expectedSize: CGSize(width: 12, height: 48)
+        )
+        // Unconstrained height, smaller width
+        assert(
+            constraint: SizeConstraint(width: 8),
+            expectedSize: CGSize(width: 12, height: 48)
+        )
+        // Unconstrained width, larger height
+        assert(
+            constraint: SizeConstraint(height: 100),
+            expectedSize: CGSize(width: 12, height: 48)
+        )
+        // Unconstrained width, smaller height
+        assert(
+            constraint: SizeConstraint(height: 8),
+            expectedSize: CGSize(width: 12, height: 48)
+        )
+        // Fully unconstrained
+        assert(
+            constraint: .unconstrained,
+            expectedSize: CGSize(width: 12, height: 48)
+        )
+        // Exact fit
+        assert(
+            constraint: SizeConstraint(width: .atMost(80), height: .atMost(20)),
+            expectedSize: CGSize(width: 12, height: 48)
+        )
     }
 
-    func test_expandWideFitParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fitParent,
-            wrapping: TestElement()
-        )
+    func test_shrinkContent_wide() {
+        func assert(
+            constraint: SizeConstraint,
+            layoutModes: [LayoutMode] = LayoutMode.testModes,
+            expectedSize: CGSize,
+            line: UInt = #line
+        ) {
+            self.assert(
+                ratio: wideRatio,
+                mode: .shrinkContent,
+                constraint: constraint,
+                layoutModes: layoutModes,
+                expectedSize: expectedSize,
+                line: line
+            )
+        }
 
-        let size = element.content.measure(
-            in: SizeConstraint(CGSize(width: 300, height: 400)))
-        XCTAssertEqual(size, CGSize(width: 300, height: 150))
+        // Fixed large constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(100), height: .atMost(100)),
+            expectedSize: CGSize(width: 12, height: 3)
+        )
+        // Fixed small constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(8), height: .atMost(8)),
+            expectedSize: CGSize(width: 12, height: 3)
+        )
+        // Unconstrained height, larger width
+        assert(
+            constraint: SizeConstraint(width: 100),
+            expectedSize: CGSize(width: 12, height: 3)
+        )
+        // Unconstrained height, smaller width
+        assert(
+            constraint: SizeConstraint(width: 8),
+            expectedSize: CGSize(width: 12, height: 3)
+        )
+        // Unconstrained width, larger height
+        assert(
+            constraint: SizeConstraint(height: 100),
+            expectedSize: CGSize(width: 12, height: 3)
+        )
+        // Unconstrained width, smaller height
+        assert(
+            constraint: SizeConstraint(height: 8),
+            expectedSize: CGSize(width: 12, height: 3)
+        )
+        // Fully unconstrained
+        assert(
+            constraint: .unconstrained,
+            expectedSize: CGSize(width: 12, height: 3)
+        )
+        // Exact fit
+        assert(
+            constraint: SizeConstraint(width: .atMost(80), height: .atMost(20)),
+            expectedSize: CGSize(width: 12, height: 3)
+        )
     }
 
-    func test_expandTallFillParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 1, height: 2),
-            contentMode: .fillParent,
-            wrapping: TestElement()
+    func test_shrinkContent_tall() {
+        func assert(
+            constraint: SizeConstraint,
+            layoutModes: [LayoutMode] = LayoutMode.testModes,
+            expectedSize: CGSize,
+            line: UInt = #line
+        ) {
+            self.assert(
+                ratio: tallRatio,
+                mode: .shrinkContent,
+                constraint: constraint,
+                layoutModes: layoutModes,
+                expectedSize: expectedSize,
+                line: line
+            )
+        }
+
+        // Fixed large constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(100), height: .atMost(100)),
+            expectedSize: CGSize(width: 2.5, height: 10)
         )
-
-        let size = element.content.measure(
-            in: SizeConstraint(CGSize(width: 300, height: 400)))
-        XCTAssertEqual(size, CGSize(width: 300, height: 600))
-    }
-
-    func test_expandTallFitParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 1, height: 2),
-            contentMode: .fitParent,
-            wrapping: TestElement()
+        // Fixed small constraint
+        assert(
+            constraint: SizeConstraint(width: .atMost(8), height: .atMost(8)),
+            expectedSize: CGSize(width: 2.5, height: 10)
         )
-
-        let size = element.content.measure(
-            in: SizeConstraint(CGSize(width: 300, height: 400)))
-        XCTAssertEqual(size, CGSize(width: 200, height: 400))
-    }
-
-    func test_expandSquareFillParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: .square,
-            contentMode: .fillParent,
-            wrapping: TestElement()
+        // Unconstrained height, larger width
+        assert(
+            constraint: SizeConstraint(width: 100),
+            expectedSize: CGSize(width: 2.5, height: 10)
         )
-
-        let size = element.content.measure(
-            in: SizeConstraint(CGSize(width: 300, height: 400)))
-        XCTAssertEqual(size, CGSize(width: 400, height: 400))
-    }
-
-    func test_expandSquareFitParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: .square,
-            contentMode: .fitParent,
-            wrapping: TestElement()
+        // Unconstrained height, smaller width
+        assert(
+            constraint: SizeConstraint(width: 8),
+            expectedSize: CGSize(width: 2.5, height: 10)
         )
-
-        let size = element.content.measure(
-            in: SizeConstraint(CGSize(width: 300, height: 400)))
-        XCTAssertEqual(size, CGSize(width: 300, height: 300))
-    }
-
-    func test_unconstrainedFillParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fillParent,
-            wrapping: TestElement()
+        // Unconstrained width, larger height
+        assert(
+            constraint: SizeConstraint(height: 100),
+            expectedSize: CGSize(width: 2.5, height: 10)
         )
-
-        let size = element.content.measure(in: .unconstrained)
-        XCTAssertEqual(size, CGSize(width: 200, height: 100))
-    }
-
-    func test_unconstrainedFitParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fitParent,
-            wrapping: TestElement()
+        // Unconstrained width, smaller height
+        assert(
+            constraint: SizeConstraint(height: 8),
+            expectedSize: CGSize(width: 2.5, height: 10)
         )
-
-        let size = element.content.measure(in: .unconstrained)
-        XCTAssertEqual(size, CGSize(width: 200, height: 100))
-    }
-
-    func test_unconstrainedHeightFillLargerParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fillParent,
-            wrapping: TestElement()
+        // Fully unconstrained
+        assert(
+            constraint: .unconstrained,
+            expectedSize: CGSize(width: 2.5, height: 10)
         )
-
-        let size = element.content.measure(in: SizeConstraint(width: 300))
-        XCTAssertEqual(size, CGSize(width: 300, height: 150))
-    }
-
-    func test_unconstrainedHeightFillSmallerParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fillParent,
-            wrapping: TestElement()
+        // Exact fit
+        assert(
+            constraint: SizeConstraint(width: .atMost(80), height: .atMost(20)),
+            expectedSize: CGSize(width: 2.5, height: 10)
         )
-
-        let size = element.content.measure(in: SizeConstraint(width: 50))
-        XCTAssertEqual(size, CGSize(width: 50, height: 25))
-    }
-
-    func test_unconstrainedHeightFitLargerParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fitParent,
-            wrapping: TestElement()
-        )
-
-        let size = element.content.measure(in: SizeConstraint(width: 300))
-        XCTAssertEqual(size, CGSize(width: 300, height: 150))
-    }
-
-    func test_unconstrainedHeightFitSmallerParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fitParent,
-            wrapping: TestElement()
-        )
-
-        let size = element.content.measure(in: SizeConstraint(width: 50))
-        XCTAssertEqual(size, CGSize(width: 50, height: 25))
-    }
-
-    func test_unconstrainedWidthFillLargerParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fillParent,
-            wrapping: TestElement()
-        )
-
-        let size = element.content.measure(in: SizeConstraint(height: 300))
-        XCTAssertEqual(size, CGSize(width: 600, height: 300))
-    }
-
-    func test_unconstrainedWidthFillSmallerParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fillParent,
-            wrapping: TestElement()
-        )
-
-        let size = element.content.measure(in: SizeConstraint(height: 50))
-        XCTAssertEqual(size, CGSize(width: 100, height: 50))
-    }
-
-    func test_unconstrainedWidthFitLargerParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fitParent,
-            wrapping: TestElement()
-        )
-
-        let size = element.content.measure(in: SizeConstraint(height: 300))
-        XCTAssertEqual(size, CGSize(width: 600, height: 300))
-    }
-
-    func test_unconstrainedWidthFitSmallerParent() {
-        let element = ConstrainedAspectRatio(
-            aspectRatio: AspectRatio(width: 2, height: 1),
-            contentMode: .fitParent,
-            wrapping: TestElement()
-        )
-
-        let size = element.content.measure(in: SizeConstraint(height: 50))
-        XCTAssertEqual(size, CGSize(width: 100, height: 50))
     }
 }
 
 private struct TestElement: Element {
+    static let size = CGSize(width: 12, height: 10)
+
     var content: ElementContent {
-        ElementContent(intrinsicSize: CGSize(width: 120, height: 100))
+        ElementContent(intrinsicSize: Self.size)
     }
 
     func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {

--- a/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
+++ b/BlueprintUI/Tests/ConstrainedAspectRatioTests.swift
@@ -57,40 +57,67 @@ class ConstrainedAspectRatioTests: XCTestCase {
         // Fixed large constraint
         assert(
             constraint: SizeConstraint(width: .atMost(100), height: .atMost(100)),
-            layoutModes: [.legacy],
             expectedSize: CGSize(width: 400, height: 100)
         )
         // Fixed small constraint
         assert(
             constraint: SizeConstraint(width: .atMost(8), height: .atMost(8)),
-            layoutModes: [.legacy],
             expectedSize: CGSize(width: 32, height: 8)
         )
         // Unconstrained height, larger width
         assert(
             constraint: SizeConstraint(width: 100),
+            layoutModes: [.legacy],
             expectedSize: CGSize(width: 100, height: 25)
+        )
+        assert(
+            constraint: SizeConstraint(width: 100),
+            layoutModes: [.caffeinated],
+            expectedSize: .infinity
         )
         // Unconstrained height, smaller width
         assert(
             constraint: SizeConstraint(width: 8),
+            layoutModes: [.legacy],
             expectedSize: CGSize(width: 8, height: 2)
+        )
+        assert(
+            constraint: SizeConstraint(width: 8),
+            layoutModes: [.caffeinated],
+            expectedSize: .infinity
         )
         // Unconstrained width, larger height
         assert(
             constraint: SizeConstraint(height: 100),
+            layoutModes: [.legacy],
             expectedSize: CGSize(width: 400, height: 100)
+        )
+        assert(
+            constraint: SizeConstraint(height: 100),
+            layoutModes: [.caffeinated],
+            expectedSize: .infinity
         )
         // Unconstrained width, smaller height
         assert(
             constraint: SizeConstraint(height: 8),
+            layoutModes: [.legacy],
             expectedSize: CGSize(width: 32, height: 8)
+        )
+        assert(
+            constraint: SizeConstraint(height: 8),
+            layoutModes: [.caffeinated],
+            expectedSize: .infinity
         )
         // Fully unconstrained
         assert(
             constraint: .unconstrained,
             layoutModes: [.legacy],
             expectedSize: CGSize(width: 40, height: 10)
+        )
+        assert(
+            constraint: .unconstrained,
+            layoutModes: [.caffeinated],
+            expectedSize: .infinity
         )
         // Exact fit
         assert(
@@ -119,40 +146,67 @@ class ConstrainedAspectRatioTests: XCTestCase {
         // Fixed large constraint
         assert(
             constraint: SizeConstraint(width: .atMost(100), height: .atMost(100)),
-            layoutModes: [.legacy],
             expectedSize: CGSize(width: 100, height: 400)
         )
         // Fixed small constraint
         assert(
             constraint: SizeConstraint(width: .atMost(8), height: .atMost(8)),
-            layoutModes: [.legacy],
             expectedSize: CGSize(width: 8, height: 32)
         )
         // Unconstrained height, larger width
         assert(
             constraint: SizeConstraint(width: 100),
+            layoutModes: [.legacy],
             expectedSize: CGSize(width: 100, height: 400)
+        )
+        assert(
+            constraint: SizeConstraint(width: 100),
+            layoutModes: [.caffeinated],
+            expectedSize: .infinity
         )
         // Unconstrained height, smaller width
         assert(
             constraint: SizeConstraint(width: 8),
+            layoutModes: [.legacy],
             expectedSize: CGSize(width: 8, height: 32)
+        )
+        assert(
+            constraint: SizeConstraint(width: 8),
+            layoutModes: [.caffeinated],
+            expectedSize: .infinity
         )
         // Unconstrained width, larger height
         assert(
             constraint: SizeConstraint(height: 100),
+            layoutModes: [.legacy],
             expectedSize: CGSize(width: 25, height: 100)
+        )
+        assert(
+            constraint: SizeConstraint(height: 100),
+            layoutModes: [.caffeinated],
+            expectedSize: .infinity
         )
         // Unconstrained width, smaller height
         assert(
             constraint: SizeConstraint(height: 8),
+            layoutModes: [.legacy],
             expectedSize: CGSize(width: 2, height: 8)
+        )
+        assert(
+            constraint: SizeConstraint(height: 8),
+            layoutModes: [.caffeinated],
+            expectedSize: .infinity
         )
         // Fully unconstrained
         assert(
             constraint: .unconstrained,
             layoutModes: [.legacy],
             expectedSize: CGSize(width: 12, height: 48)
+        )
+        assert(
+            constraint: .unconstrained,
+            layoutModes: [.caffeinated],
+            expectedSize: .infinity
         )
         // Exact fit
         assert(
@@ -214,6 +268,11 @@ class ConstrainedAspectRatioTests: XCTestCase {
             layoutModes: [.legacy],
             expectedSize: CGSize(width: 40, height: 10)
         )
+        assert(
+            constraint: .unconstrained,
+            layoutModes: [.caffeinated],
+            expectedSize: .infinity
+        )
         // Exact fit
         assert(
             constraint: SizeConstraint(width: .atMost(80), height: .atMost(20)),
@@ -273,6 +332,11 @@ class ConstrainedAspectRatioTests: XCTestCase {
             constraint: .unconstrained,
             layoutModes: [.legacy],
             expectedSize: CGSize(width: 12, height: 48)
+        )
+        assert(
+            constraint: .unconstrained,
+            layoutModes: [.caffeinated],
+            expectedSize: .infinity
         )
         // Exact fit
         assert(
@@ -514,6 +578,64 @@ class ConstrainedAspectRatioTests: XCTestCase {
         assert(
             constraint: SizeConstraint(width: .atMost(80), height: .atMost(20)),
             expectedSize: CGSize(width: 2.5, height: 10)
+        )
+    }
+
+    func test_layoutContract() {
+        assertLayoutContract(
+            of: TestElement().constrainedTo(
+                aspectRatio: wideRatio,
+                contentMode: .fitParent
+            )
+        )
+
+        assertLayoutContract(
+            of: TestElement().constrainedTo(
+                aspectRatio: tallRatio,
+                contentMode: .fitParent
+            )
+        )
+
+        assertLayoutContract(
+            of: TestElement().constrainedTo(
+                aspectRatio: wideRatio,
+                contentMode: .fillParent
+            )
+        )
+
+        assertLayoutContract(
+            of: TestElement().constrainedTo(
+                aspectRatio: tallRatio,
+                contentMode: .fillParent
+            )
+        )
+
+        assertLayoutContract(
+            of: TestElement().constrainedTo(
+                aspectRatio: wideRatio,
+                contentMode: .fitContent
+            )
+        )
+
+        assertLayoutContract(
+            of: TestElement().constrainedTo(
+                aspectRatio: tallRatio,
+                contentMode: .fitContent
+            )
+        )
+
+        assertLayoutContract(
+            of: TestElement().constrainedTo(
+                aspectRatio: wideRatio,
+                contentMode: .shrinkContent
+            )
+        )
+
+        assertLayoutContract(
+            of: TestElement().constrainedTo(
+                aspectRatio: tallRatio,
+                contentMode: .shrinkContent
+            )
         )
     }
 }

--- a/BlueprintUI/Tests/LayoutMode+Testing.swift
+++ b/BlueprintUI/Tests/LayoutMode+Testing.swift
@@ -1,0 +1,16 @@
+import BlueprintUI
+
+extension LayoutMode {
+    static let testModes: [LayoutMode] = [.legacy, .caffeinated]
+
+    /// Run the given block with `self` as the default layout mode, restoring the previous default
+    /// afterwards, and returning the result of the block.
+    func performAsDefault<Result>(block: () throws -> Result) rethrows -> Result {
+        let oldLayoutMode = LayoutMode.default
+        defer { LayoutMode.default = oldLayoutMode }
+
+        LayoutMode.default = self
+
+        return try block()
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ConstrainedAspectRatio`  measures correctly in `fitParent` and `fillParent` modes when the proposed constraint has the same aspect ratio as the element's constraint.
+- `ConstrainedAspectRatio` adheres to the Caffeinated Layout contract when unconstrained in `fitParent` or `fillParent`, by reporting `infinity` instead of falling back to the constrained element's size.
+
 ### Added
 
 ### Removed
@@ -16,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Deprecated
+
+- `ConstrainedAspectRatio` content mode `fillParent` is deprecated, due to having limited utility in Caffeinated Layout.
 
 ### Security
 


### PR DESCRIPTION
There are two changes in this PR, and it may be easier to review by commit.

- A bugfix for the `fitParent` and `fillParent` modes of `ConstrainedAspectRatio`, where the measuring was falling through to the wrong value when the aspect ratio of the container matched the aspect ratio being constrained to.
- Some changes to the behavior when unconstrained to adhere to Caffeinated Layout. The `fillParent` behavior has very limited utility in Caffeinated Layout since it will aggressively fill and overflow any container. I can't think of any practical use case, and I also couldn't find any usage today, so I am proposing we deprecate it.

To validate the bugfix I wound up almost entirely rewriting the test class, so that diff is a mess.