### PR TITLE
fix: [AttributedLabel] Correct typo in enumeration

### DIFF
--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -347,6 +347,7 @@ extension AttributedLabel {
 
         private func links(at location: CGPoint) -> [Link] {
             guard let textStorage = makeTextStorage(),
+                  textStorage.string.isEmpty == false,
                   let layoutManager = textStorage.layoutManagers.first,
                   let textContainer = layoutManager.textContainers.first
             else {
@@ -354,18 +355,18 @@ extension AttributedLabel {
             }
 
             func alignmentMultiplier() -> CGFloat {
-                var alignment: NSTextAlignment = .natural
+                // If a paragraph style spans the range of the text, use its alignment.
+                // Otherwise, fall back to `.natural`.
+                let alignment: NSTextAlignment = {
+                    var range: NSRange = NSRange(location: -1, length: 0)
+                    let style = textStorage.attribute(.paragraphStyle, at: 0, effectiveRange: &range)
 
-                textStorage.enumerateAttribute(
-                    .paragraphStyle,
-                    in: textStorage.entireRange,
-                    options: []
-                ) { style, range, continuePointer in
-                    if let style = style as? NSParagraphStyle, range == textStorage.entireRange {
-                        alignment = style.alignment
-                        continuePointer.pointee = false
+                    guard let style = style as? NSParagraphStyle, range == textStorage.entireRange else {
+                        return .natural
                     }
-                }
+
+                    return style.alignment
+                }()
 
                 switch (alignment, layoutDirection) {
                 case (.left, _),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 
 - Update CI script to reference the `xcodesorg/made/xcodes` package for installing simulator runtimes.
+- Corrected a typo in `AttributedLabel`, which now exits paragraph style enumeration after encountering the first paragraph style. This is an optimization and not a functional change. The method continues to accept only a paragraph style which spans the length of the attributed string.
 
 # Past Releases
 


### PR DESCRIPTION
### Summary

This PR corrects a benign typo in `AttributedLabel`. When tapping a link, `AttributedLabel` attempts to discover alignment of a paragraph style that spans its entire range. By definition, there can only be one such style.

This means that the previous expression would continue enumeration after finding the a style which applies to a subrange, which is unnecessary. It also meant that the stop pointer - erroneously expressed as a continue pointer - did nothing.