### PR TITLE
Update CI script to reference the `xcodesorg/made/xcodes` package

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app
 
     - name: Install xcodes
-      run: brew install aria2 robotsandpencils/made/xcodes
+      run: brew install aria2 xcodesorg/made/xcodes
 
     - name: Install iOS ${{ matrix.sdk }}
       run: sudo xcodes runtimes install "iOS ${{ matrix.sdk }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Update CI script to reference the `xcodesorg/made/xcodes` package for installing simulator runtimes.
+
 # Past Releases
 
 ## [2.0.0] - 2023-05-02


### PR DESCRIPTION
- Update CI script to reference the `xcodesorg/made/xcodes` package for installing simulator runtimes.

This resolves build failures like [this one](https://github.com/square/Blueprint/actions/runs/5577004078/jobs/10189208586?pr=461).