### PR TITLE
Resolved a Swift 5.9 compilation warning related to `UnsafeRawPointer` object conversion

### DIFF
--- a/BlueprintUI/Sources/Environment/Environment.swift
+++ b/BlueprintUI/Sources/Environment/Environment.swift
@@ -103,5 +103,5 @@ extension UIView {
         }
     }
 
-    private static var environmentKey = NSObject()
+    private static var environmentKey: UInt8 = 0
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Resolved a Swift 5.9 compilation warning: Forming 'UnsafeRawPointer' to a variable of type 'NSObject'; this is likely incorrect because 'NSObject' may contain an object reference.
+
 ### Added
 
 ### Removed


### PR DESCRIPTION
[Swift 5.9](https://github.com/apple/swift/blob/main/CHANGELOG.md#swift-59) introduced a [new warning](https://github.com/apple/swift/issues/64927) related to object conversions to `UnsafeRawPointer`.

<details>

<img width="2044" alt="Screenshot 2023-08-29 at 9 57 21 AM" src="https://github.com/square/Blueprint/assets/430436/9868bc15-a857-45ab-ba73-bfc343453f43">

</details>

This updates the key type on associated object invocations to be a `UInt8` which avoids the warning.