### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Resolved a Swift 5.9 compilation warning: Forming 'UnsafeRawPointer' to a variable of type 'NSObject'; this is likely incorrect because 'NSObject' may contain an object reference.
-- `KeyboardObserver` has been updated to handle iOS 16.1+ changes that use the screen's coordinate space to report keyboard position. This can impact reported values when the app isn't full screen in Split View, Slide Over, and Stage Manager.
-
 ### Added
 
 ### Removed
 
 ### Changed
-
-- Lifecycle callbacks like `onAppear` and `onDisappear` now occur outside of the layout pass; allowing, eg, `onAppear` to safely trigger a re-render.
 
 ### Deprecated
 
@@ -30,10 +25,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+# Past Releases
+
+## [2.1.0] - 2023-09-06
+
+### Fixed
+
+- Resolved a Swift 5.9 compilation warning: Forming 'UnsafeRawPointer' to a variable of type 'NSObject'; this is likely incorrect because 'NSObject' may contain an object reference.
+- `KeyboardObserver` has been updated to handle iOS 16.1+ changes that use the screen's coordinate space to report keyboard position. This can impact reported values when the app isn't full screen in Split View, Slide Over, and Stage Manager.
+
+### Changed
+
+- Lifecycle callbacks like `onAppear` and `onDisappear` now occur outside of the layout pass; allowing, eg, `onAppear` to safely trigger a re-render.
+
+### Internal
+
 - Update CI script to reference the `xcodesorg/made/xcodes` package for installing simulator runtimes.
 - Corrected a typo in `AttributedLabel`, which now exits paragraph style enumeration after encountering the first paragraph style. This is an optimization and not a functional change. The method continues to accept only a paragraph style which spans the length of the attributed string.
-
-# Past Releases
 
 ## [2.0.0] - 2023-05-02
 
@@ -1015,7 +1023,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/2.0.0...HEAD
+[main]: https://github.com/square/Blueprint/square/2.1.0...HEAD
+[2.1.0]: https://github.com/square/Blueprint/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/square/Blueprint/compare/1.0.0...2.0.0
 [1.0.0]: https://github.com/square/Blueprint/compare/0.50.0...1.0.0
 [0.50.0]: https://github.com/square/Blueprint/compare/0.49.1...0.50.0

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (2.0.0)
-  - BlueprintUI/Tests (2.0.0)
-  - BlueprintUICommonControls (2.0.0):
-    - BlueprintUI (= 2.0.0)
+  - BlueprintUI (2.1.0)
+  - BlueprintUI/Tests (2.1.0)
+  - BlueprintUICommonControls (2.1.0):
+    - BlueprintUI (= 2.1.0)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 4f8d092313c4b5c35d2528b3b7655ff669a057a0
-  BlueprintUICommonControls: 9e02875bc6b8ef64aa9634c32d7156bd50c7b88d
+  BlueprintUI: 28927923fa2d40263758c27bfac9c5520a392e46
+  BlueprintUICommonControls: 2feade14574118d7d87c050e43d978455f222e3b
 
 PODFILE CHECKSUM: c795e247aa1c5eb825186ef8192821306c59c891
 

--- a/version.rb
+++ b/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '2.0.0'
+BLUEPRINT_VERSION ||= '2.1.0'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))


### PR DESCRIPTION
# Changes

## [2.1.0] - 2023-09-06

### Fixed

- Resolved a Swift 5.9 compilation warning: Forming 'UnsafeRawPointer' to a variable of type 'NSObject'; this is likely incorrect because 'NSObject' may contain an object reference.
- `KeyboardObserver` has been updated to handle iOS 16.1+ changes that use the screen's coordinate space to report keyboard position. This can impact reported values when the app isn't full screen in Split View, Slide Over, and Stage Manager.

### Changed

- Lifecycle callbacks like `onAppear` and `onDisappear` now occur outside of the layout pass; allowing, eg, `onAppear` to safely trigger a re-render.

### Internal

- Update CI script to reference the `xcodesorg/made/xcodes` package for installing simulator runtimes.
- Corrected a typo in `AttributedLabel`, which now exits paragraph style enumeration after encountering the first paragraph style. This is an optimization and not a functional change. The method continues to accept only a paragraph style which spans the length of the attributed string.