### PR TITLE
Don't cache subelements

### DIFF
--- a/BlueprintUI/Sources/Element/LayoutStorage.swift
+++ b/BlueprintUI/Sources/Element/LayoutStorage.swift
@@ -126,40 +126,19 @@ extension LayoutStorage: LegacyContentStorage {
 extension LayoutStorage: CaffeinatedContentStorage {
 
     private func subelements(from node: LayoutTreeNode, environment: Environment) -> LayoutSubelements {
-        if node.sizeCache.options.assumeStableSubelements {
-            // Current behavior
-            return node.layoutSubelements {
-                var identifierFactory = ElementIdentifier.Factory(elementCount: children.count)
-                return children.map { child in
-                    let identifier = identifierFactory.nextIdentifier(
-                        for: type(of: child.element),
-                        key: child.key
-                    )
-                    return LayoutSubelement(
-                        identifier: identifier,
-                        content: child.content,
-                        environment: environment,
-                        node: node.subnode(key: identifier),
-                        traits: child.traits
-                    )
-                }
-            }
-        } else {
-            // Proposed new behavior
-            var identifierFactory = ElementIdentifier.Factory(elementCount: children.count)
-            return children.map { child in
-                let identifier = identifierFactory.nextIdentifier(
-                    for: type(of: child.element),
-                    key: child.key
-                )
-                return LayoutSubelement(
-                    identifier: identifier,
-                    content: child.content,
-                    environment: environment,
-                    node: node.subnode(key: identifier),
-                    traits: child.traits
-                )
-            }
+        var identifierFactory = ElementIdentifier.Factory(elementCount: children.count)
+        return children.map { child in
+            let identifier = identifierFactory.nextIdentifier(
+                for: type(of: child.element),
+                key: child.key
+            )
+            return LayoutSubelement(
+                identifier: identifier,
+                content: child.content,
+                environment: environment,
+                node: node.subnode(key: identifier),
+                traits: child.traits
+            )
         }
     }
 

--- a/BlueprintUI/Sources/Element/LayoutStorage.swift
+++ b/BlueprintUI/Sources/Element/LayoutStorage.swift
@@ -126,7 +126,26 @@ extension LayoutStorage: LegacyContentStorage {
 extension LayoutStorage: CaffeinatedContentStorage {
 
     private func subelements(from node: LayoutTreeNode, environment: Environment) -> LayoutSubelements {
-        node.layoutSubelements {
+        if node.sizeCache.options.assumeStableSubelements {
+            // Current behavior
+            return node.layoutSubelements {
+                var identifierFactory = ElementIdentifier.Factory(elementCount: children.count)
+                return children.map { child in
+                    let identifier = identifierFactory.nextIdentifier(
+                        for: type(of: child.element),
+                        key: child.key
+                    )
+                    return LayoutSubelement(
+                        identifier: identifier,
+                        content: child.content,
+                        environment: environment,
+                        node: node.subnode(key: identifier),
+                        traits: child.traits
+                    )
+                }
+            }
+        } else {
+            // Proposed new behavior
             var identifierFactory = ElementIdentifier.Factory(elementCount: children.count)
             return children.map { child in
                 let identifier = identifierFactory.nextIdentifier(

--- a/BlueprintUI/Sources/Internal/LayoutTreeNode.swift
+++ b/BlueprintUI/Sources/Internal/LayoutTreeNode.swift
@@ -27,7 +27,6 @@ final class LayoutTreeNode {
 
     // These commonly used properties have dedicated storage. If we need to hang more generalized
     // things off this type we may want to store them in a heterogeneous dictionary.
-    private var _layoutSubelements: [LayoutSubelement]?
     private var _associatedCache: Any?
 
     init(path: String, signpostRef: AnyObject, options: LayoutOptions) {
@@ -46,15 +45,6 @@ final class LayoutTreeNode {
         )
         subnodes[key] = subnode
         return subnode
-    }
-
-    func layoutSubelements(create: () -> [LayoutSubelement]) -> [LayoutSubelement] {
-        if let layoutSubelements = _layoutSubelements {
-            return layoutSubelements
-        }
-        let layoutSubelements = create()
-        _layoutSubelements = layoutSubelements
-        return layoutSubelements
     }
 
     func associatedCache<AssociatedCache>(create: () -> AssociatedCache) -> AssociatedCache {

--- a/BlueprintUI/Sources/Layout/LayoutOptions.swift
+++ b/BlueprintUI/Sources/Layout/LayoutOptions.swift
@@ -9,7 +9,8 @@ public struct LayoutOptions: Equatable {
     /// The default configuration.
     public static let `default` = LayoutOptions(
         hintRangeBoundaries: true,
-        searchUnconstrainedKeys: true
+        searchUnconstrainedKeys: true,
+        assumeStableSubelements: true
     )
 
     /// Enables aggressive cache hinting along the boundaries of the range between constraints and
@@ -22,8 +23,15 @@ public struct LayoutOptions: Equatable {
     /// Layout contract for correct behavior.
     public var searchUnconstrainedKeys: Bool
 
-    public init(hintRangeBoundaries: Bool, searchUnconstrainedKeys: Bool) {
+    public var assumeStableSubelements: Bool
+
+    public init(
+        hintRangeBoundaries: Bool,
+        searchUnconstrainedKeys: Bool,
+        assumeStableSubelements: Bool = true
+    ) {
         self.hintRangeBoundaries = hintRangeBoundaries
         self.searchUnconstrainedKeys = searchUnconstrainedKeys
+        self.assumeStableSubelements = assumeStableSubelements
     }
 }

--- a/BlueprintUI/Sources/Layout/LayoutOptions.swift
+++ b/BlueprintUI/Sources/Layout/LayoutOptions.swift
@@ -9,8 +9,7 @@ public struct LayoutOptions: Equatable {
     /// The default configuration.
     public static let `default` = LayoutOptions(
         hintRangeBoundaries: true,
-        searchUnconstrainedKeys: true,
-        assumeStableSubelements: true
+        searchUnconstrainedKeys: true
     )
 
     /// Enables aggressive cache hinting along the boundaries of the range between constraints and
@@ -23,15 +22,8 @@ public struct LayoutOptions: Equatable {
     /// Layout contract for correct behavior.
     public var searchUnconstrainedKeys: Bool
 
-    public var assumeStableSubelements: Bool
-
-    public init(
-        hintRangeBoundaries: Bool,
-        searchUnconstrainedKeys: Bool,
-        assumeStableSubelements: Bool = true
-    ) {
+    public init(hintRangeBoundaries: Bool, searchUnconstrainedKeys: Bool) {
         self.hintRangeBoundaries = hintRangeBoundaries
         self.searchUnconstrainedKeys = searchUnconstrainedKeys
-        self.assumeStableSubelements = assumeStableSubelements
     }
 }

--- a/BlueprintUI/Tests/GeometryReaderTests.swift
+++ b/BlueprintUI/Tests/GeometryReaderTests.swift
@@ -100,7 +100,7 @@ final class GeometryReaderTests: XCTestCase {
             outerRow.addFlexible(
                 child: GeometryReader { geometry in
 
-                    return Row { innerRow in
+                    Row { innerRow in
                         innerRow.horizontalUnderflow = .growUniformly
                         innerRow.horizontalOverflow = .condenseUniformly
                         innerRow.verticalAlignment = .fill
@@ -127,30 +127,20 @@ final class GeometryReaderTests: XCTestCase {
         // 4. GR body evaluates as a row with 2 children
         // 5. Subelement count has changed, as well as content of child 1
 
-        LayoutMode.caffeinated(options: .notAssumingSubelementsStable).performAsDefault {
-            let frames = element
-                .layout(frame: CGRect(origin: .zero, size: size))
-                .queryLayout(for: Spacer.self)
-                .map { $0.layoutAttributes.frame }
+        let frames = element
+            .layout(frame: CGRect(origin: .zero, size: size))
+            .queryLayout(for: Spacer.self)
+            .map { $0.layoutAttributes.frame }
 
-            XCTAssertEqual(
-                frames,
-                [
-                    CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: 1, height: 120)),
-                    CGRect(origin: CGPoint(x: 1, y: 0), size: CGSize(width: 1, height: 120)),
-                    CGRect(origin: CGPoint(x: 85, y: 0), size: CGSize(width: 35, height: 120)),
-                ]
-            )
-        }
+        XCTAssertEqual(
+            frames,
+            [
+                CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: 1, height: 120)),
+                CGRect(origin: CGPoint(x: 1, y: 0), size: CGSize(width: 1, height: 120)),
+                CGRect(origin: CGPoint(x: 85, y: 0), size: CGSize(width: 35, height: 120)),
+            ]
+        )
     }
-}
-
-extension LayoutOptions {
-    static let notAssumingSubelementsStable = LayoutOptions(
-        hintRangeBoundaries: true,
-        searchUnconstrainedKeys: true,
-        assumeStableSubelements: false
-    )
 }
 
 extension SizeConstraint.Axis {

--- a/BlueprintUI/Tests/LayoutResultNode+Testing.swift
+++ b/BlueprintUI/Tests/LayoutResultNode+Testing.swift
@@ -14,4 +14,18 @@ extension LayoutResultNode {
         }
         return nil
     }
+
+    func queryLayout(for elementType: Element.Type) -> [LayoutResultNode] {
+        var results: [LayoutResultNode] = []
+
+        if type(of: element) == elementType {
+            results.append(self)
+        }
+
+        for child in children {
+            results.append(contentsOf: child.node.queryLayout(for: elementType))
+        }
+
+        return results
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a bug that could cause a crash or incorrect layout when an element with lazily resolved content (such as `GeometryReader`) generated a subtree that varied within a layout pass. ([#468])
+
 ### Added
 
 ### Removed
@@ -1095,6 +1097,7 @@ searchField
 [0.3.1]: https://github.com/square/Blueprint/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/square/Blueprint/compare/0.2.2...0.3.0
 [0.2.2]: https://github.com/square/Blueprint/releases/tag/0.2.2
+[#468]: https://github.com/square/Blueprint/pull/468
 [#264]: https://github.com/square/Blueprint/pull/264
 [#260]: https://github.com/square/Blueprint/pull/260
 [#259]: https://github.com/square/Blueprint/pull/259


### PR DESCRIPTION
# Summary

In `LayoutStorage` we cache subelements, under the assumption that they will remain stable during a layout pass. This PR removes the caching, because it was a faulty assumption.

# Details

In `LayoutStorage` we currently assume the array of `LayoutSubelement`s for subelements will be stable during a layout pass, and cache it on the `LayoutTreeNode`. This was assumed safe because `LayoutStorage`-backed themselves elements cannot vary during a layout pass, and `LazyStorage`, which can, does not cache its subelement at all.

Turns out there is a case where this assumption is violated, if a `LazyStorage` produces a subtree that varies somewhere in a descendant node. For example, a `GeometryReader` that contains a stack, and varies the number of children in the stack based on space available.

# Performance

This PR is broken into 2 commits:
- First, a fix that is guarded behind a `LayoutMode` option. This option was used to performance test this change against the current behavior as a baseline.
- The second commit removes the option and adopts the fix unconditionally.

I was expecting to incur a hit from removing this caching but benchmarking showed it to be completely negligible, and attempts to more cleverly cache actually performed _worse_. I'll put up a Market PR that shows this benchmark and a regression test.

# Testing
There's a new `GeometryReader` test to validate this case, and regression test will be on the Market side.

See UI-4599.