### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed a bug that could cause a crash or incorrect layout when an element with lazily resolved content (such as `GeometryReader`) generated a subtree that varied within a layout pass. ([#468])
-
 ### Added
 
 ### Removed
@@ -28,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 
 # Past Releases
+
+## [2.1.1] - 2023-09-22
+
+### Fixed
+
+- Fixed a bug that could cause a crash or incorrect layout when an element with lazily resolved content (such as `GeometryReader`) generated a subtree that varied within a layout pass. ([#468])
 
 ## [2.1.0] - 2023-09-06
 
@@ -1025,7 +1029,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/square/2.1.0...HEAD
+[main]: https://github.com/square/Blueprint/square/2.1.1...HEAD
+[2.1.1]: https://github.com/square/Blueprint/square/2.1.0...2.1.1
 [2.1.0]: https://github.com/square/Blueprint/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/square/Blueprint/compare/1.0.0...2.0.0
 [1.0.0]: https://github.com/square/Blueprint/compare/0.50.0...1.0.0

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (2.1.0)
-  - BlueprintUI/Tests (2.1.0)
-  - BlueprintUICommonControls (2.1.0):
-    - BlueprintUI (= 2.1.0)
+  - BlueprintUI (2.1.1)
+  - BlueprintUI/Tests (2.1.1)
+  - BlueprintUICommonControls (2.1.1):
+    - BlueprintUI (= 2.1.1)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 28927923fa2d40263758c27bfac9c5520a392e46
-  BlueprintUICommonControls: 2feade14574118d7d87c050e43d978455f222e3b
+  BlueprintUI: c006ab14a70db8e1190d58dc362813956572f16d
+  BlueprintUICommonControls: e069a8428561241b326ccc47c7fee8bb1e33aa38
 
 PODFILE CHECKSUM: c795e247aa1c5eb825186ef8192821306c59c891
 

--- a/version.rb
+++ b/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '2.1.0'
+BLUEPRINT_VERSION ||= '2.1.1'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))


### PR DESCRIPTION
# Changes

## [2.1.1] - 2023-09-22

### Fixed

- Fixed a bug that could cause a crash or incorrect layout when an element with lazily resolved content (such as `GeometryReader`) generated a subtree that varied within a layout pass. ([#468])