### PR TITLE
[wip] Add link attributes for detected links.

### DIFF
--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -263,7 +263,16 @@ extension AttributedLabel {
 
             if !isMeasuring {
                 if previousAttributedText != attributedText {
-                    links = attributedLinks(in: model.attributedText) + detectedDataLinks(in: model.attributedText)
+                    let attributedLinks = attributedLinks(in: model.attributedText)
+                    let detectedLinks = detectedDataLinks(in: model.attributedText)
+                    if let newText = attributedText {
+                        let mutableText = NSMutableAttributedString(attributedString: newText)
+                        detectedLinks.forEach { link in
+                            mutableText.addAttribute(.link, value: link.url.absoluteString, range: link.range)
+                        }
+                        attributedText = NSAttributedString(attributedString: mutableText)
+                    }
+                    links = attributedLinks + detectedLinks
                     accessibilityLinks = accessibilityLinks(for: links, in: model.attributedText)
                 }
 
@@ -591,6 +600,7 @@ extension AttributedLabel {
             self.link = link
             super.init(accessibilityContainer: container)
             accessibilityLabel = label
+            accessibilityTraits = [.link]
         }
 
         override var accessibilityFrameInContainerSpace: CGRect {

--- a/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
@@ -254,6 +254,7 @@ class AttributedLabelTests: XCTestCase {
         let string = NSAttributedString(string: "Phone: (555) 555-5555 Address: 1455 Market St URL: https://block.xyz Date: 12/1/12")
         let element = AttributedLabel(attributedText: string) {
             $0.linkDetectionTypes = [.link, .address, .phoneNumber, .date]
+            $0.linkAttributes = [.foregroundColor: UIColor.systemBlueColor]
         }
 
         compareSnapshot(of: element)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `AttributedLabel` now applies a `link` attribute key for detected links. 
+
 ### Added
 
 ### Removed


### PR DESCRIPTION
We need to add the `NSLinkAttributeName` to the attributed string for any detected links. This allows voiceover to announce that links are available when reading the label. 