### PR TITLE
Allow specifying which axes are included in the final measurement when using ElementContent(measuring:)

### DIFF
--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -279,8 +279,23 @@ extension ElementContent {
     ///
     /// This is useful if you are placing the element in a nested `BlueprintView`, for example (eg
     /// to create a stateful element) and just need this element to be correctly sized.
-    public init(measuring element: Element) {
-        storage = MeasureElementStorage(child: element)
+    ///
+    /// You can optionally pass which axes should be included in the final measurement. Defaults to both axes.
+    public init(
+        measuring element: Element,
+        on axes: MeasuringAxes = .both
+    ) {
+        storage = MeasureElementStorage(child: element, axes: axes)
+    }
+
+    /// The axes to include when measuring an element with `ElementContent(measuring:)`
+    public enum MeasuringAxes {
+        /// Only the width of the measurement will be included.
+        case horizontal
+        /// Only the height of the measurement will be included.
+        case vertical
+        /// Both the width and height of the measurement will be included.
+        case both
     }
 }
 

--- a/BlueprintUI/Tests/ElementContentTests.swift
+++ b/BlueprintUI/Tests/ElementContentTests.swift
@@ -206,8 +206,10 @@ class ElementContentTests: XCTestCase {
 
             var element: InnerTestElement
 
+            var axes: ElementContent.MeasuringAxes = .both
+
             var content: ElementContent {
-                ElementContent(measuring: element)
+                ElementContent(measuring: element, on: axes)
             }
 
             func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
@@ -217,20 +219,40 @@ class ElementContentTests: XCTestCase {
 
         var calls: [SizeConstraint] = []
 
-        let element = OuterTestElement(
+        var element = OuterTestElement(
             element: InnerTestElement { constraint in
                 calls.append(constraint)
                 return CGSize(width: 100, height: 10)
             }
         )
 
-        let cache = RenderPassCache(name: "Test", signpostRef: NSObject())
+        let cache = {
+            RenderPassCache(name: "Test", signpostRef: NSObject())
+        }
 
         /// Should output the size of the inner element.
 
+        let sizeConstraint = SizeConstraint(CGSize(width: 100, height: 100))
+
+        element.axes = .both
+
         XCTAssertEqual(
             CGSize(width: 100, height: 10),
-            element.content.measure(in: .init(CGSize(width: 100, height: 100)), environment: .empty, cache: cache)
+            element.content.measure(in: sizeConstraint, environment: .empty, cache: cache())
+        )
+
+        element.axes = .horizontal
+
+        XCTAssertEqual(
+            CGSize(width: 100, height: 0),
+            element.content.measure(in: sizeConstraint, environment: .empty, cache: cache())
+        )
+
+        element.axes = .vertical
+
+        XCTAssertEqual(
+            CGSize(width: 0, height: 10),
+            element.content.measure(in: sizeConstraint, environment: .empty, cache: cache())
         )
 
         let layoutResult = element.layout(frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 100)))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Allow specifying which axes are included in the final measurement when using `ElementContent(measuring:)`.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
When using `ElementContent(measuring:)` to create essentially a smart "`Spacer`" based on the size of an element, it's desirable to include in the final size on only one of the measurement dimensions. Thus, expose an `Axes` type you can optionally pass to the initializer to control this.