### PR TITLE
Bumping versions to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Added
+
+### Removed
+
+### Changed
+
+### Deprecated
+
+### Security
+
+### Documentation
+
+### Misc
+
+### Internal
+
+# Past Releases
+
+## [2.3.0] - 2024-02-21
+
+### Fixed
+
 - Fixed an issue where `AttributedLabel` would not properly handle tapping on links when a label was stretched.
 
 ### Added
@@ -22,22 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The behavior of `name` of `ElementPreview` has been change, affecting the SwiftUI `previewName`. Instead of including device or size information (i.e. `sizeThatFits - \(name)`), it now either defaults to the Xcode default if given an empty string, and shows _only_ the `name` if `name` is non-empty.
 - Updated minimum deployment target from iOS 14 to iOS 15.
 
-### Deprecated
-
-### Security
-
-### Documentation
-
-### Misc
-
 ### Internal
-
 - Updated CI to use M1 machines, Xcode 15.1, and Ruby 3.2.2.
 - Added iOS 17 snapshot images.
 - Bump Swift version to 5.9.
 - Update Ruby gems.
-
-# Past Releases
 
 ## [2.2.0] - 2023-09-22
 
@@ -1045,7 +1056,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/2.2.0...HEAD
+[main]: https://github.com/square/Blueprint/compare/2.3.0...HEAD
+[2.3.0]: https://github.com/square/Blueprint/compare/2.2.0...2.3.0
 [2.2.0]: https://github.com/square/Blueprint/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/square/Blueprint/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/square/Blueprint/compare/1.0.0...2.0.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
 
 DEPENDENCIES
   cocoapods (~> 1.11)

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (2.2.0)
-  - BlueprintUI/Tests (2.2.0)
-  - BlueprintUICommonControls (2.2.0):
-    - BlueprintUI (= 2.2.0)
+  - BlueprintUI (2.3.0)
+  - BlueprintUI/Tests (2.3.0)
+  - BlueprintUICommonControls (2.3.0):
+    - BlueprintUI (= 2.3.0)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 93a1d72fb4f987818dc2aa63754b4f954c76705f
-  BlueprintUICommonControls: 071ae9df5220ce4f441e5b61af3c89f2e012ca43
+  BlueprintUI: 53005d4172700e37b731efdca48be9b529af2683
+  BlueprintUICommonControls: 9dbd3238c7417dad13fed7ecfb882b0477004ffe
 
 PODFILE CHECKSUM: 1cffac4623851f31dc42270ba99701e3825e6d67
 

--- a/version.rb
+++ b/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '2.2.0'
+BLUEPRINT_VERSION ||= '2.3.0'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))
 


### PR DESCRIPTION
## [2.3.0] - 2024-02-21

### Fixed

- Fixed an issue where `AttributedLabel` would not properly handle tapping on links when a label was stretched.

### Added

- `AccessibilityElement` now supports providing arbitrary strings to assistive devices using the `AXCustomContent` protocol. 

### Removed

### Changed

- The behavior of `name` of `ElementPreview` has been change, affecting the SwiftUI `previewName`. Instead of including device or size information (i.e. `sizeThatFits - \(name)`), it now either defaults to the Xcode default if given an empty string, and shows _only_ the `name` if `name` is non-empty.
- Updated minimum deployment target from iOS 14 to iOS 15.

### Internal
- Updated CI to use M1 machines, Xcode 15.1, and Ruby 3.2.2.
- Added iOS 17 snapshot images.
- Bump Swift version to 5.9.
- Update Ruby gems.
