### PR TITLE
Added `startTimestamp` to `BlueprintViewRenderMetrics`

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -429,6 +429,7 @@ public final class BlueprintView: UIView {
             self,
             completedRenderWith: .init(
                 layoutMode: layoutMode,
+                startTimestamp: startTime,
                 totalDuration: viewUpdateEndTime - startTime,
                 layoutDuration: layoutEndTime - startTime,
                 viewUpdateDuration: viewUpdateEndTime - layoutEndTime
@@ -537,6 +538,9 @@ public struct BlueprintViewRenderMetrics {
 
     /// The layout mode used to render the view.
     public var layoutMode: LayoutMode
+
+    /// The mach time in seconds at which the view render started (from `CACurrentMediaTime()`).
+    public var startTimestamp: TimeInterval
 
     /// The total time it took to apply a new element.
     public var totalDuration: TimeInterval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for accessibility focus triggers to force VoiceOver to focus on any given element.
+- Added `startTimestamp` to `BlueprintViewRenderMetrics`. This represents the mach time in seconds at which the render started, from `CACurrentMediaTime()`.
 
 ### Removed
 


### PR DESCRIPTION
Added `startTimestamp` to `BlueprintViewRenderMetrics`. This will allow us to represent Blueprint renders as spans in our performance logging.