### PR TITLE
Prepare 3.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Main]
 
 ### Fixed
-- Fixed a bug where `AccessibilityBlocker` would block accessibility when `isBlocking` is `false`
 
 ### Added
-- Added support for accessibility focus triggers to force VoiceOver to focus on any given element.
-- Added `startTimestamp` to `BlueprintViewRenderMetrics`. This represents the mach time in seconds at which the render started, from `CACurrentMediaTime()`.
 
 ### Removed
 
@@ -29,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 
 # Past Releases
+
+## [3.1.0] - 2024-03-26
+
+### Fixed
+- Fixed a bug where `AccessibilityBlocker` would block accessibility when `isBlocking` is `false`.
+
+### Added
+- Added support for accessibility focus triggers to force VoiceOver to focus on any given element.
+- Added `startTimestamp` to `BlueprintViewRenderMetrics`. This represents the mach time in seconds at which the render started, from `CACurrentMediaTime()`.
 
 ## [3.0.0] - 2024-02-21
 
@@ -1059,7 +1065,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/3.0.0...HEAD
+[main]: https://github.com/square/Blueprint/compare/3.1.0...HEAD
+[3.1.0]: https://github.com/square/Blueprint/compare/3.0.0...3.1.0
 [3.0.0]: https://github.com/square/Blueprint/compare/2.2.0...3.0.0
 [2.2.0]: https://github.com/square/Blueprint/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/square/Blueprint/compare/2.0.0...2.1.0

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (3.0.0)
-  - BlueprintUI/Tests (3.0.0)
-  - BlueprintUICommonControls (3.0.0):
-    - BlueprintUI (= 3.0.0)
+  - BlueprintUI (3.1.0)
+  - BlueprintUI/Tests (3.1.0)
+  - BlueprintUICommonControls (3.1.0):
+    - BlueprintUI (= 3.1.0)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 76e054862aceb2b014a7953464c5769af55c13d5
-  BlueprintUICommonControls: 9219a0b82ea4b95bbeef44d3fbc65b9b01f1acba
+  BlueprintUI: bce9191b14558a0a6e608b6e512643ac2fdd83b7
+  BlueprintUICommonControls: 47c2e45a5d45cf40381ea60189e8b6b67b0f945e
 
 PODFILE CHECKSUM: 1cffac4623851f31dc42270ba99701e3825e6d67
 

--- a/version.rb
+++ b/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '3.0.0'
+BLUEPRINT_VERSION ||= '3.1.0'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))
 


### PR DESCRIPTION
### Fixed
- Fixed a bug where `AccessibilityBlocker` would block accessibility when `isBlocking` is `false`.

### Added
- Added support for accessibility focus triggers to force VoiceOver to focus on any given element.
- Added `startTimestamp` to `BlueprintViewRenderMetrics`. This represents the mach time in seconds at which the render started, from `CACurrentMediaTime()`.