### PR TITLE
updating custom content

### DIFF
--- a/BlueprintUICommonControls/Sources/AccessibilityElement.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityElement.swift
@@ -372,7 +372,7 @@ extension AccessibilityElement {
         /// The importance of the content.
         public enum Importance: Equatable {
             /// By default custom content is available through the rotor.
-            case regular
+            case `default`
             /// In addtion to being available through the rotor, high importance content will announced in the main VoiceOver utterance.
             /// High Importance content is announced follllowing the `accessibilityValue` but preceding any `accessibilityHint`.
             case high
@@ -382,18 +382,18 @@ extension AccessibilityElement {
         public var value: String?
         public var importance: Importance
 
-        public init(label: String, value: String? = nil, importance: Importance = .regular) {
+        public init(label: String, value: String? = nil, importance: Importance = .default) {
             self.label = label
             self.value = value
             self.importance = importance
         }
 
-        internal var axCustomContent: AXCustomContent {
+        public var axCustomContent: AXCustomContent {
             let importance: AXCustomContent.Importance
             switch self.importance {
             case .high:
                 importance = .high
-            default:
+            case .default:
                 importance = .default
             }
             return .init(label: label, value: value, importance: importance)
@@ -403,7 +403,11 @@ extension AccessibilityElement {
 
 
 extension AXCustomContent {
-    internal convenience init(label: String, value: String?, importance: AXCustomContent.Importance = .default) {
+    public convenience init(_ content: AccessibilityElement.CustomContent) {
+        self.init(label: content.label, value: content.value, importance: content.importance == .high ? .high : .default)
+    }
+
+    public convenience init(label: String, value: String?, importance: AXCustomContent.Importance = .default) {
         self.init(label: label, value: value ?? "")
         self.importance = importance
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Added
+- `AccessibilityElement.CustomContent` now exposes previously internal methods for creating `AXCustomContent` objects. 
 
 ### Removed
 
 ### Changed
+- `AccessibilityElement.CustomContent.Importance.Regular` renamed to `Default`.
 
 ### Deprecated
 


### PR DESCRIPTION
In integrating this into  market i realized that some internal methods should be public. 

Furthermore I discovered how to use the name default without bothering the compiler, so we should rename this for sake of constancy. 