### PR TITLE
improving accessibility activation of labels containing a single link

### DIFF
--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -553,6 +553,20 @@ extension AttributedLabel {
             attributedText = mutableString
         }
 
+        override func accessibilityActivate() -> Bool {
+            /// No links: Not interactive, no effect.
+            guard links.isEmpty == false else {
+                return false
+            }
+            /// Exactly one link: Activate the link.
+            if links.count == 1, let url = links.first?.url {
+                urlHandler?.onTap(url: url)
+                return true
+            }
+            /// More than one link: Ambiguous selection, no effect, Select links using the rotor..
+            return false
+        }
+
         override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
             guard links.isEmpty == false, let first = touches.first else {
                 return super.touchesBegan(touches, with: event)
@@ -614,6 +628,7 @@ extension AttributedLabel {
             self.link = link
             super.init(accessibilityContainer: container)
             accessibilityLabel = label
+            accessibilityTraits = [.link]
         }
 
         override var accessibilityFrameInContainerSpace: CGRect {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+- `AttributedLabel` now activates a single contained link when activated by accessible technologies. 
 - `AccessibilityElement.CustomContent.Importance.Regular` renamed to `Default`.
 
 ### Deprecated


### PR DESCRIPTION
Previously, activating the element would send a touch event to the label's accessibility activation point which defaults to the center of the view. This would occasionally activate a link that happened to overlap that particular position.

We now provide the following behavior:

No links: Not interactive, no effect.
Exactly one link: Activate the link.
More than one link: Ambiguous selection, no effect.
as always we additionally allow link selection and activation through the rotor.


Extracted from 
https://github.com/square/Blueprint/pull/459