### PR TITLE
bumping version to 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Past Releases
 
+## [4.1.0] - 2024-06-04
+
+### Fixed
+- Fixed a bug where `AttributedLabel`'s accessibility utterance was not properly announcing links.
+
 ## [4.0.1] - 2024-06-04
 
 ### Fixed
@@ -1080,7 +1085,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/4.0.1...HEAD
+[main]: https://github.com/square/Blueprint/compare/4.1.0...HEAD
+[4.1.0]: https://github.com/square/Blueprint/compare/4.0.1...4.1.0
 [4.0.1]: https://github.com/square/Blueprint/compare/4.0.0...4.0.1
 [4.0.0]: https://github.com/square/Blueprint/compare/3.1.0...4.0.0
 [3.1.0]: https://github.com/square/Blueprint/compare/3.0.0...3.1.0

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (4.0.1)
-  - BlueprintUI/Tests (4.0.1)
-  - BlueprintUICommonControls (4.0.1):
-    - BlueprintUI (= 4.0.1)
+  - BlueprintUI (4.1.0)
+  - BlueprintUI/Tests (4.1.0)
+  - BlueprintUICommonControls (4.1.0):
+    - BlueprintUI (= 4.1.0)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 9628bfc92acbe53cb9bed04978a552c343a09726
-  BlueprintUICommonControls: 1b0c018299c541dd57459e76512a025bdc3d4ee7
+  BlueprintUI: e3977b3657a5ce03b61b55a8e5cfdcae32c772b4
+  BlueprintUICommonControls: 8c3c5a718be323baab2c01093978f2735553e035
 
 PODFILE CHECKSUM: 1cffac4623851f31dc42270ba99701e3825e6d67
 

--- a/version.rb
+++ b/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '4.0.1'
+BLUEPRINT_VERSION ||= '4.1.0'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))
 


### PR DESCRIPTION
Bump to 4.1.0 to include new link accessibility fixes https://github.com/square/Blueprint/pull/459/