### PR TITLE
Fix string index out of bounds crash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Main]
 
 ### Fixed
-- Fixed a string range bug when a closed range should be half open. 
 
 ### Added
 
@@ -27,8 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 
 # Past Releases
+## [4.1.1] - 2024-06-14
+- Fixed a string range bug when a closed range should be half open.
 
-## [4.1.0] - 2024-06-04
+## [4.1.0] - 2024-06-13
 
 ### Fixed
 - Fixed a bug where `AttributedLabel`'s accessibility utterance was not properly announcing links.
@@ -1086,7 +1087,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/4.1.0...HEAD
+[main]: https://github.com/square/Blueprint/compare/4.1.1...HEAD
+[4.1.1]: https://github.com/square/Blueprint/compare/4.1.0...4.1.1
 [4.1.0]: https://github.com/square/Blueprint/compare/4.0.1...4.1.0
 [4.0.1]: https://github.com/square/Blueprint/compare/4.0.0...4.0.1
 [4.0.0]: https://github.com/square/Blueprint/compare/3.1.0...4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Main]
 
 ### Fixed
+- Fixed a string range bug when a closed range should be half open. 
 
 ### Added
 

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (4.1.0)
-  - BlueprintUI/Tests (4.1.0)
-  - BlueprintUICommonControls (4.1.0):
-    - BlueprintUI (= 4.1.0)
+  - BlueprintUI (4.1.1)
+  - BlueprintUI/Tests (4.1.1)
+  - BlueprintUICommonControls (4.1.1):
+    - BlueprintUI (= 4.1.1)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: e3977b3657a5ce03b61b55a8e5cfdcae32c772b4
-  BlueprintUICommonControls: 8c3c5a718be323baab2c01093978f2735553e035
+  BlueprintUI: 7f09cc438e04105800fae3d634578a0a4d779081
+  BlueprintUICommonControls: 7eb7688ca0308772a9cef0af840531be4e12f5e8
 
 PODFILE CHECKSUM: 1cffac4623851f31dc42270ba99701e3825e6d67
 

--- a/version.rb
+++ b/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '4.1.0'
+BLUEPRINT_VERSION ||= '4.1.1'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))
 


### PR DESCRIPTION
Well, this is always embarrassing.

`string.startIndex...string.endIndex` is out of bounds, which seems counter to my understanding of either ranges or string indices but I'm not sure which . 

Regardless, we need a half open range here.

