### PR TITLE
Replace newlines in a11y labels with spaces

### DIFF
--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -559,7 +559,7 @@ extension AttributedLabel {
                   !links.isEmpty
             else {
                 // We need to replace all newlines with " "
-                return string.components(separatedBy: .newlines).filter { !$0.isEmpty }.joined(separator: " ")
+                return string.removingNewlines
             }
             var label = string
             // Wrap the word in [brackets] to indicate that it is a tag distinct from the content string. This is transparent to voiceover but should be helpful when the accessibility label is printed e.g. in the accessibility inspector.
@@ -601,7 +601,7 @@ extension AttributedLabel {
             }
 
             // We need to replace all newlines with " "
-            return label.components(separatedBy: .newlines).filter { !$0.isEmpty }.joined(separator: " ")
+            return label.removingNewlines
         }
 
         func applyLinkColors(activeLinks: [Link] = []) {
@@ -855,3 +855,8 @@ extension NSTextCheckingResult.CheckingType {
     }
 }
 
+extension String {
+    var removingNewlines: String {
+        components(separatedBy: .newlines).filter { !$0.isEmpty }.joined(separator: " ")
+    }
+}

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -556,7 +556,11 @@ extension AttributedLabel {
             // Insert the word "link" after each link in the label. This mirrors the VoiceOver behavior when encountering a `.link` attribute.
 
             guard let localizedLinkString = linkAccessibilityLabel,
-                  !links.isEmpty else { return string }
+                  !links.isEmpty
+            else {
+                // We need to replace all newlines with " "
+                return string.components(separatedBy: .newlines).filter { !$0.isEmpty }.joined(separator: " ")
+            }
             var label = string
             // Wrap the word in [brackets] to indicate that it is a tag distinct from the content string. This is transparent to voiceover but should be helpful when the accessibility label is printed e.g. in the accessibility inspector.
 
@@ -595,7 +599,9 @@ extension AttributedLabel {
                 }
                 label.insert(contentsOf: insertionString, at: insertionPoint)
             }
-            return label
+
+            // We need to replace all newlines with " "
+            return label.components(separatedBy: .newlines).filter { !$0.isEmpty }.joined(separator: " ")
         }
 
         func applyLinkColors(activeLinks: [Link] = []) {

--- a/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
@@ -357,6 +357,20 @@ class AttributedLabelTests: XCTestCase {
         compareSnapshot(of: element)
     }
 
+    func test_multilineAccessibility() {
+        let labelview = AttributedLabel.LabelView()
+
+        for (text, expected) in [
+            ("Test Test", "Test Test"),
+            ("Test\nTest", "Test Test"),
+            ("Test\n\nTest", "Test Test"),
+            ("\n\n\n\nTest\n\n\nTest\n\n\n", "Test Test"),
+        ] {
+            let result = labelview.accessibilityLabel(with: [], in: text, linkAccessibilityLabel: nil)
+            XCTAssertEqual(expected, result)
+        }
+    }
+
     func test_linkAccessibility() {
         let labelview = AttributedLabel.LabelView()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix a bug in which newlines were preserved in accessibility labels.
+
 ### Added
 
 ### Removed


### PR DESCRIPTION
The built in accessibility labels do some mangling of newlines to remove them. Our implementation in `0e9041b4714cac99baa69f4b1b484503868311ba` caused regressions in snapshot and KIF testing.