### PR TITLE
Prepare 4.1.2 Release

### DIFF
--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -856,7 +856,7 @@ extension NSTextCheckingResult.CheckingType {
 }
 
 extension String {
-    var removingNewlines: String {
+    fileprivate var removingNewlines: String {
         components(separatedBy: .newlines).filter { !$0.isEmpty }.joined(separator: " ")
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix a bug in which newlines were preserved in accessibility labels.
-
 ### Added
 
 ### Removed
@@ -28,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Internal
 
 # Past Releases
+
+## [4.1.2] - 2024-06-17
+- Fix a bug in which newlines were preserved in accessibility labels.
+
 ## [4.1.1] - 2024-06-14
 - Fixed a string range bug when a closed range should be half open.
 
@@ -1089,7 +1091,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/4.1.1...HEAD
+[main]: https://github.com/square/Blueprint/compare/4.1.2...HEAD
+[4.1.1]: https://github.com/square/Blueprint/compare/4.1.1...4.1.2
 [4.1.1]: https://github.com/square/Blueprint/compare/4.1.0...4.1.1
 [4.1.0]: https://github.com/square/Blueprint/compare/4.0.1...4.1.0
 [4.0.1]: https://github.com/square/Blueprint/compare/4.0.0...4.0.1

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (4.1.1)
-  - BlueprintUI/Tests (4.1.1)
-  - BlueprintUICommonControls (4.1.1):
-    - BlueprintUI (= 4.1.1)
+  - BlueprintUI (4.1.2)
+  - BlueprintUI/Tests (4.1.2)
+  - BlueprintUICommonControls (4.1.2):
+    - BlueprintUI (= 4.1.2)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 7f09cc438e04105800fae3d634578a0a4d779081
-  BlueprintUICommonControls: 7eb7688ca0308772a9cef0af840531be4e12f5e8
+  BlueprintUI: a05960580dbdbb9aa5ff4658dd969846dc3b95a7
+  BlueprintUICommonControls: 119616850083675a7abcbf92021051ace2dd4ed9
 
 PODFILE CHECKSUM: 1cffac4623851f31dc42270ba99701e3825e6d67
 

--- a/version.rb
+++ b/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '4.1.1'
+BLUEPRINT_VERSION ||= '4.1.2'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))
 


### PR DESCRIPTION
## [4.1.2] - 2024-06-17
- Fix a bug in which newlines were preserved in accessibility labels.