### PR TITLE
Make public the UIBezierPath helper using Box.CornerStyle

### DIFF
--- a/BlueprintUICommonControls/Sources/Internal/UIBezierPath+Extensions.swift
+++ b/BlueprintUICommonControls/Sources/Internal/UIBezierPath+Extensions.swift
@@ -3,7 +3,7 @@ import UIKit
 
 extension UIBezierPath {
 
-    convenience init(
+    public convenience init(
         rect: CGRect,
         corners: Box.CornerStyle
     ) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Made public the `UIBezierPath` convenience init that uses a `Box.CornerStyle`.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
Exposes the convenience initializer on `UIBezierPath` that accepts a `Box.CornerStyle`.