### PR TITLE
Add passThroughTouches to BlueprintView, PassthroughView

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -343,7 +343,6 @@ public final class BlueprintView: UIView {
 
         if passThroughTouches {
             return result == self ? nil : result
-
         } else {
             return result
         }

--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -118,6 +118,16 @@ public final class BlueprintView: UIView {
     /// Provides performance metrics about the duration of layouts, updates, etc.
     public weak var metricsDelegate: BlueprintViewMetricsDelegate? = nil
 
+    /// Defaults to `false`. If enabled, Blueprint will pass through any touches
+    /// not recieved by an element to the view hierarchy behind the `BlueprintView`.
+    public var passThroughTouches: Bool = false {
+        didSet {
+            if oldValue != passThroughTouches {
+                setNeedsViewHierarchyUpdate()
+            }
+        }
+    }
+
     private var isVisible: Bool = false {
         didSet {
             switch (oldValue, isVisible) {
@@ -141,7 +151,7 @@ public final class BlueprintView: UIView {
 
         rootController = NativeViewController(
             node: NativeViewNode(
-                content: UIView.describe { _ in },
+                content: PassthroughView.describe { _ in },
                 // Because no layout update occurs here, passing an empty environment is fine;
                 // the correct environment will be passed during update.
                 environment: .empty,
@@ -327,6 +337,18 @@ public final class BlueprintView: UIView {
         setNeedsViewHierarchyUpdate()
     }
 
+    /// Ignore any touches on this view and (pass through) by returning nil if the default `hitTest` implementation returns this view.
+    public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let result = super.hitTest(point, with: event)
+
+        if passThroughTouches {
+            return result == self ? nil : result
+
+        } else {
+            return result
+        }
+    }
+
     /// Clears any sizing caches, invalidates the `intrinsicContentSize` of the
     /// view, and marks the view as needing a layout.
     private func setNeedsViewHierarchyUpdate() {
@@ -391,7 +413,9 @@ public final class BlueprintView: UIView {
         rootController.view.frame = bounds
 
         var rootNode = NativeViewNode(
-            content: UIView.describe { _ in },
+            content: PassthroughView.describe { [weak self] config in
+                config[\.passThroughTouches] = self?.passThroughTouches ?? false
+            },
             environment: environment,
             layoutAttributes: LayoutAttributes(frame: rootFrame),
             children: viewNodes

--- a/BlueprintUI/Sources/Internal/PassthroughView.swift
+++ b/BlueprintUI/Sources/Internal/PassthroughView.swift
@@ -16,7 +16,6 @@ import UIKit
 
         if passThroughTouches {
             return result == self ? nil : result
-
         } else {
             return result
         }

--- a/BlueprintUI/Sources/Internal/PassthroughView.swift
+++ b/BlueprintUI/Sources/Internal/PassthroughView.swift
@@ -8,10 +8,17 @@ import UIKit
         CATransformLayer.self
     }
 
-    /// Ignore any touches on this view and (pass through) by returning nil if the
-    /// default `hitTest` implementation returns this view.
+    public var passThroughTouches: Bool = true
+
+    /// Ignore any touches on this view and (pass through) by returning nil if the default `hitTest` implementation returns this view.
     public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         let result = super.hitTest(point, with: event)
-        return result == self ? nil : result
+
+        if passThroughTouches {
+            return result == self ? nil : result
+
+        } else {
+            return result
+        }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Moved `CornerStyle` out of the `Box` namespace, and is now a root type in `BlueprintUICommonControls`. `Box.CornerStyle` is still available as a typealias.
+- `BlueprintView` will now pass through touches to views lower in the view hierarchy if `passThroughTouches` is true.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `BlueprintView` will now pass through touches to views lower in the view hierarchy if `passThroughTouches` is true.
+
 ### Removed
 
 ### Changed
 
 - Moved `CornerStyle` out of the `Box` namespace, and is now a root type in `BlueprintUICommonControls`. `Box.CornerStyle` is still available as a typealias.
-- `BlueprintView` will now pass through touches to views lower in the view hierarchy if `passThroughTouches` is true.
 
 ### Deprecated
 


### PR DESCRIPTION
Without this, Blueprint will eat any touches that are meant for views behind it – in particular relevant if you're layering them in the z-index and the one on "top" is largely visually transparent.

<img width="1604" alt="image" src="https://github.com/user-attachments/assets/6d8844ab-1cec-4add-aefa-a505dbec23c2">

https://github.com/user-attachments/assets/43c10ec2-0c9b-4b66-ba4e-1134fab32223