### PR TITLE
Make `GeometryProxy.environment` public

### DIFF
--- a/BlueprintUI/Sources/Layout/GeometryReader.swift
+++ b/BlueprintUI/Sources/Layout/GeometryReader.swift
@@ -43,7 +43,7 @@ public struct GeometryReader: Element {
 
 /// Contains information about the current layout being measured by GeometryReader
 public struct GeometryProxy {
-    var environment: Environment
+    public var environment: Environment
 
     /// The size constraint of the element being laid out.
     public var constraint: SizeConstraint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `GeometryProxy.environment` is now `public`.
+
 ### Deprecated
 
 ### Security


### PR DESCRIPTION
Makes the `environment` property of `GeometryReader` public.

The immediate need for this is to enable the use of `displayScale` values inside of `GeometryReader` calculations.