### PR TITLE
Renamed accessibility(...) to deprecated_accessibility(...)

### DIFF
--- a/BlueprintUICommonControls/Sources/AccessibilityElement.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityElement.swift
@@ -204,7 +204,7 @@ extension Element {
         deprecated,
         renamed: "accessibilityElement(label:value:traits:hint:identifier:accessibilityFrameSize:)"
     )
-    public func accessibility(
+    public func deprecated_accessibility(
         label: String? = nil,
         value: String? = nil,
         hint: String? = nil,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Changed
+Renamed deprecated function `accessibility(label:value:traits:hint:identifier:accessibilityFrameSize:)` to `deprecated_accessibility(label:value:traits:hint:identifier:accessibilityFrameSize:)`.
 
 ### Deprecated
 


### PR DESCRIPTION
Opening up the namespace for a more proper `accessibility(value:label:hint:identifier:traits:)`