### PR TITLE
Add main queue preconditions within BlueprintView

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -350,7 +350,16 @@ public final class BlueprintView: UIView {
 
     /// Clears any sizing caches, invalidates the `intrinsicContentSize` of the
     /// view, and marks the view as needing a layout.
+    @MainActor
     private func setNeedsViewHierarchyUpdate() {
+        MainActor.preconditionIsolated(
+            """
+            setNeedsViewHierarchyUpdate() must only execute on the main actor.
+
+            Examine your stack trace to determine what caused this to be called
+            off of the main actor.
+            """
+        )
 
         invalidateIntrinsicContentSize()
         sizesThatFit.removeAll()
@@ -366,7 +375,14 @@ public final class BlueprintView: UIView {
 
     @MainActor
     private func updateViewHierarchyIfNeeded() {
-        MainActor.preconditionIsolated("updateViewHierarchyIfNeeded must only execute on the main actor.")
+        MainActor.preconditionIsolated(
+            """
+            updateViewHierarchyIfNeeded() must only execute on the main actor.
+
+            Examine your stack trace to determine what caused this to be called
+            off of the main actor.
+            """
+        )
 
         guard needsViewHierarchyUpdate || bounds != lastViewHierarchyUpdateBounds else { return }
 
@@ -617,7 +633,15 @@ extension BlueprintView {
 
         @MainActor
         fileprivate func update(node: NativeViewNode, context: UpdateContext) -> UpdateResult {
-            MainActor.preconditionIsolated("BlueprintView.NativeViewController.update(node:context:) must only execute on the main actor.")
+            MainActor.preconditionIsolated(
+                """
+                BlueprintView.NativeViewController.update(node:context:) must 
+                only execute on the main actor.
+
+                Examine your stack trace to determine what caused this to be 
+                called off of the main actor.
+                """
+            )
 
             assert(node.viewDescription.viewType == type(of: view))
 

--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -364,7 +364,10 @@ public final class BlueprintView: UIView {
         setNeedsLayout()
     }
 
+    @MainActor
     private func updateViewHierarchyIfNeeded() {
+        MainActor.preconditionIsolated("updateViewHierarchyIfNeeded must only execute on the main actor.")
+
         guard needsViewHierarchyUpdate || bounds != lastViewHierarchyUpdateBounds else { return }
 
         precondition(
@@ -612,7 +615,9 @@ extension BlueprintView {
             node.viewDescription.viewType == type(of: view)
         }
 
+        @MainActor
         fileprivate func update(node: NativeViewNode, context: UpdateContext) -> UpdateResult {
+            MainActor.preconditionIsolated("BlueprintView.NativeViewController.update(node:context:) must only execute on the main actor.")
 
             assert(node.viewDescription.viewType == type(of: view))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `BlueprintView` has added preconditions to some methods to ensure they are only invoked on the main queue.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
This adds main queue preconditions to BlueprintView to help diagnose some `EXC_BAD_ACCESS` crashes we've seen in Bugsnag.