### PR TITLE
Bump CI Xcode to 15.4 (from 15.1)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Generate docs with jazzy and publish to Github pages
-    runs-on: macos-13-xlarge
+    runs-on: macos-14-xlarge
 
     steps:
       - name: Checkout

--- a/.github/workflows/env.properties
+++ b/.github/workflows/env.properties
@@ -1,1 +1,1 @@
-xcode_version=15.1
+xcode_version=15.4.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint:
     name: Lint Swift code with SwiftFormat
-    runs-on: macos-13-xlarge
+    runs-on: macos-14-xlarge
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
   spm:
     name: "iOS ${{ matrix.sdk }}"
 
-    runs-on: macos-13-xlarge
+    runs-on: macos-14-xlarge
 
     strategy:
       fail-fast: false # Don’t fail-fast so that we get all snapshot test changes
@@ -66,7 +66,7 @@ jobs:
   cocoapods:
     name: "CocoaPods"
 
-    runs-on: macos-13-xlarge
+    runs-on: macos-14-xlarge
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Bump CI Xcode version to 15.4.
+
 # Past Releases
 
 ## [4.3.0] - 2024-09-18


### PR DESCRIPTION
Bumps CI Xcode to 15.4 (from 15.1)

This required bumping the macOS image used by Github Actions as the previous one didn't come with Xcode 15.4.

This is required so that we can use the `MainActor.preconditionIsolated()` API in https://github.com/square/Blueprint/pull/518 (It was annotated as iOS 17+ in Xcode 15.1 sdk).