### PR TITLE
Prepare 5.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `BlueprintView` has added preconditions to some methods to ensure they are only invoked on the main queue.
-
 ### Removed
 
 ### Changed
-Renamed deprecated function `accessibility(label:value:traits:hint:identifier:accessibilityFrameSize:)` to `deprecated_accessibility(label:value:traits:hint:identifier:accessibilityFrameSize:)`.
 
 ### Deprecated
 
@@ -31,6 +28,16 @@ Renamed deprecated function `accessibility(label:value:traits:hint:identifier:ac
 - Bump CI Xcode version to 15.4.
 
 # Past Releases
+
+## [5.0.0] - 2024-10-30
+
+### Added
+
+- `BlueprintView` has added preconditions to some methods to ensure they are only invoked on the main queue.
+
+### Changed
+
+- Renamed deprecated function `accessibility(label:value:traits:hint:identifier:accessibilityFrameSize:)` to `deprecated_accessibility(label:value:traits:hint:identifier:accessibilityFrameSize:)`.
 
 ## [4.3.0] - 2024-09-18
 
@@ -1118,7 +1125,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/4.3.0...HEAD
+[main]: https://github.com/square/Blueprint/compare/5.0.0...HEAD
+[5.0.0]: https://github.com/square/Blueprint/compare/4.3.0...5.0.0
 [4.3.0]: https://github.com/square/Blueprint/compare/4.2.1...4.3.0
 [4.2.1]: https://github.com/square/Blueprint/compare/4.2.0...4.2.1
 [4.2.0]: https://github.com/square/Blueprint/compare/4.1.2...4.2.0

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (4.3.0)
-  - BlueprintUI/Tests (4.3.0)
-  - BlueprintUICommonControls (4.3.0):
-    - BlueprintUI (= 4.3.0)
+  - BlueprintUI (5.0.0)
+  - BlueprintUI/Tests (5.0.0)
+  - BlueprintUICommonControls (5.0.0):
+    - BlueprintUI (= 5.0.0)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: be852bd1c895f5405af2c75a6aa8bef0dacf41a8
-  BlueprintUICommonControls: 41b66f55f4bbc8454e0e6fa01dbbabdd499accba
+  BlueprintUI: 0e2d2944bca6c0d6d96df711a43bce01154bb7ef
+  BlueprintUICommonControls: 8f400ee3ecf2bc58bd21cce29caba9f7c83d22b8
 
 PODFILE CHECKSUM: 1cffac4623851f31dc42270ba99701e3825e6d67
 

--- a/version.rb
+++ b/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '4.3.0'
+BLUEPRINT_VERSION ||= '5.0.0'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))
 


### PR DESCRIPTION
## [5.0.0] - 2024-10-30

### Added

- `BlueprintView` has added preconditions to some methods to ensure they are only invoked on the main queue.

### Changed

- Renamed deprecated function `accessibility(label:value:traits:hint:identifier:accessibilityFrameSize:)` to `deprecated_accessibility(label:value:traits:hint:identifier:accessibilityFrameSize:)`.