### PR TITLE
Prepare 5.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Flow` children now support a layout `priority`, to specify if they should grow to use the extra space in a run.
-
 ### Removed
 
 ### Changed
@@ -27,9 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
-- Bump CI Xcode version to 15.4.
-
 # Past Releases
+
+## [5.0.1] - 2024-11-04
+
+### Added
+
+- `Flow` children now support a layout `priority`, to specify if they should grow to use the extra space in a run.
+
+### Internal
+
+- Bump CI Xcode version to 15.4.
 
 ## [5.0.0] - 2024-10-30
 
@@ -1127,7 +1133,8 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/5.0.0...HEAD
+[main]: https://github.com/square/Blueprint/compare/5.0.1...HEAD
+[5.0.1]: https://github.com/square/Blueprint/compare/5.0.0...5.0.1
 [5.0.0]: https://github.com/square/Blueprint/compare/4.3.0...5.0.0
 [4.3.0]: https://github.com/square/Blueprint/compare/4.2.1...4.3.0
 [4.2.1]: https://github.com/square/Blueprint/compare/4.2.0...4.2.1

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (5.0.0)
-  - BlueprintUI/Tests (5.0.0)
-  - BlueprintUICommonControls (5.0.0):
-    - BlueprintUI (= 5.0.0)
+  - BlueprintUI (5.0.1)
+  - BlueprintUI/Tests (5.0.1)
+  - BlueprintUICommonControls (5.0.1):
+    - BlueprintUI (= 5.0.1)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 0e2d2944bca6c0d6d96df711a43bce01154bb7ef
-  BlueprintUICommonControls: 8f400ee3ecf2bc58bd21cce29caba9f7c83d22b8
+  BlueprintUI: 8d6991d64adcd61b7421266ccad95b2a3a3ca656
+  BlueprintUICommonControls: 060db17f4b9b72920aa950e2dfbd7808840f4b52
 
 PODFILE CHECKSUM: 1cffac4623851f31dc42270ba99701e3825e6d67
 

--- a/version.rb
+++ b/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '5.0.0'
+BLUEPRINT_VERSION ||= '5.0.1'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))
 


### PR DESCRIPTION
## [5.0.1] - 2024-11-04

### Added

- `Flow` children now support a layout `priority`, to specify if they should grow to use the extra space in a run.

### Internal

- Bump CI Xcode version to 15.4.