### PR TITLE
feat: `accessibilityIdentifier` can now be set on `AttributedLabel`

### DIFF
--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -86,6 +86,8 @@ public struct AttributedLabel: Element, Hashable {
     /// A localized string that describes the result of performing an action on the element, when the result is non-obvious.
     public var accessibilityHint: String?
 
+    public var accessibilityIdentifier: String?
+
     /// An array containing one or more `AccessibilityElement.CustomAction`s, defining additional supported actions. Assistive technologies, such as VoiceOver, will display your custom actions to the user at appropriate times.
     public var accessibilityCustomActions: [AccessibilityElement.CustomAction] = []
 
@@ -259,6 +261,7 @@ extension AttributedLabel {
                 isAccessibilityElement = model.isAccessibilityElement
                 accessibilityHint = model.accessibilityHint
                 accessibilityValue = model.accessibilityValue
+                accessibilityIdentifier = model.accessibilityIdentifier
                 updateAccessibilityTraits(with: model)
                 accessibilityCustomActions = model.accessibilityCustomActions.map { action in
                     UIAccessibilityCustomAction(name: action.name) { _ in action.onActivation() }

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -86,6 +86,7 @@ public struct AttributedLabel: Element, Hashable {
     /// A localized string that describes the result of performing an action on the element, when the result is non-obvious.
     public var accessibilityHint: String?
 
+    /// A string that identifies the element.
     public var accessibilityIdentifier: String?
 
     /// An array containing one or more `AccessibilityElement.CustomAction`s, defining additional supported actions. Assistive technologies, such as VoiceOver, will display your custom actions to the user at appropriate times.

--- a/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
@@ -70,6 +70,26 @@ class AttributedLabelTests: XCTestCase {
         }
     }
 
+    func test_accessibilityConfiguration() {
+        let string = NSAttributedString(string: "Hello, World!")
+
+        let label = AttributedLabel(attributedText: string) { label in
+            label.isAccessibilityElement = true
+            label.accessibilityHint = "Hint"
+            label.accessibilityValue = "Value"
+            label.accessibilityIdentifier = "Identifier"
+        }
+
+        let view = BlueprintView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+
+        label.accessBackingView(in: view) { view in
+            XCTAssertTrue(view.isAccessibilityElement)
+            XCTAssertEqual(view.accessibilityHint, "Hint")
+            XCTAssertEqual(view.accessibilityValue, "Value")
+            XCTAssertEqual(view.accessibilityIdentifier, "Identifier")
+        }
+    }
+
     func test_displaysText() {
         let string = NSAttributedString()
             .appending(string: "H", font: .boldSystemFont(ofSize: 24.0), color: .red)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The `accessibilityIdentifier` can now be set on `AttributedLabel`.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
This allows `accessibilityIdentifier` to be set on `AttributedLabel`.