### PR TITLE
release: Blueprint 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
-# Past Releases
+- Added release and changelog managements scripts to streamline releases.
 
 ## [5.0.1] - 2024-11-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The `accessibilityIdentifier` can now be set on `AttributedLabel`.
-
 ### Removed
 
 ### Changed
@@ -24,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 ### Misc
+
+### Internal
+
+## [5.1.0] - 2024-11-25
+
+### Added
+
+- The `accessibilityIdentifier` can now be set on `AttributedLabel`.
 
 ### Internal
 
@@ -115,8 +121,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `AccessibilityElement` now supports providing arbitrary strings to assistive devices using the `AXCustomContent` protocol. 
-
-### Removed
 
 ### Changed
 
@@ -1135,7 +1139,7 @@ searchField
 
 - First stable release.
 
-[main]: https://github.com/square/Blueprint/compare/5.0.1...HEAD
+[main]: https://github.com/square/Blueprint/compare/5.1.0...HEAD
 [5.0.1]: https://github.com/square/Blueprint/compare/5.0.0...5.0.1
 [5.0.0]: https://github.com/square/Blueprint/compare/4.3.0...5.0.0
 [4.3.0]: https://github.com/square/Blueprint/compare/4.2.1...4.3.0
@@ -1273,3 +1277,4 @@ searchField
 [#19]: https://github.com/square/Blueprint/pull/19
 [#18]: https://github.com/square/Blueprint/pull/18
 [#15]: https://github.com/square/Blueprint/pull/15
+[5.1.0]: https://github.com/square/Blueprint/compare/5.0.1...5.1.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,16 @@
 # Releasing a new version
 
+1. Prepare a release
+
+   ```
+   # Cuts a release off of main with the given version number.
+   Scripts/release.sh --version 1.2.3
+   ```
+
+Manual instructions can be found here:
+
+<details>
+
 1. You must be listed as an owner of the pods `BlueprintUI` and `BlueprintUICommonControls`.
 
    To check this run:
@@ -17,7 +28,7 @@
 
 1. Update the library version in `version.rb` if it has not already been updated (it should match the version number that you are about to release).
 
-1. Update `CHANGELOG.md` (in the root of the repo), moving current changes under `Main` to a new section under `Past Releases` for the version you are releasing.
+1. Update `CHANGELOG.md` (in the root of the repo), moving current changes under `Main` to a new section for the version you are releasing.
   
    The changelog uses [reference links](https://daringfireball.net/projects/markdown/syntax#link) to link each version's changes. Remember to add a link to the new version at the bottom of the file, and to update the link to `[main]`.
 
@@ -31,6 +42,8 @@
    ```
 
 1. Push your branch and open a PR into `main`.
+
+</details>
 
 1. Once the PR is merged, fetch changes and tag the release, using the merge commit:
    ```bash
@@ -49,3 +62,4 @@
    # version of BlueprintUI that we just published.
    bundle exec pod trunk push --synchronous BlueprintUICommonControls.podspec
    ```
+   

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - BlueprintUI (5.0.1)
-  - BlueprintUI/Tests (5.0.1)
-  - BlueprintUICommonControls (5.0.1):
-    - BlueprintUI (= 5.0.1)
+  - BlueprintUI (5.1.0)
+  - BlueprintUI/Tests (5.1.0)
+  - BlueprintUICommonControls (5.1.0):
+    - BlueprintUI (= 5.1.0)
 
 DEPENDENCIES:
   - BlueprintUI (from `../BlueprintUI.podspec`)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
     :path: "../BlueprintUICommonControls.podspec"
 
 SPEC CHECKSUMS:
-  BlueprintUI: 8d6991d64adcd61b7421266ccad95b2a3a3ca656
-  BlueprintUICommonControls: 060db17f4b9b72920aa950e2dfbd7808840f4b52
+  BlueprintUI: 9ba3799699c813cf86165fc36e646bb10e7e5b47
+  BlueprintUICommonControls: 91307b32a90175365c389ef0a033c516bd56feb7
 
 PODFILE CHECKSUM: 1cffac4623851f31dc42270ba99701e3825e6d67
 

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+set -euo pipefail
+
+branch="main"
+diff_check=false
+
+# Function to display usage
+usage() {
+  echo "Usage: $0 --version <version> [--branch <branch>] [--no-diff-check]"
+  exit 1
+}
+
+# Parse options
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -v|--version) version="$2"; shift 2 ;;
+    -b|--branch) branch="$2"; shift 2 ;;
+    -n|--no-diff-check) diff_check=false; shift ;;
+    --) shift; break ;;
+    -*|--*) echo "Unknown option $1"; usage ;;
+    *) break ;;
+  esac
+done
+
+# Check if version argument is provided
+if [ -z "${version:-}" ]; then
+  echo "Error: You must provide a version number."
+  usage
+fi
+
+# Ensure there are no unstaged changes
+if [ "$diff_check" = true ] && ! git diff --quiet origin/"$branch"; then
+  echo "Error: This branch has differences compared to origin/$branch. Please push or undo these changes before continuing."
+  echo "You can bypass this check with the --no-diff-check flag."
+  exit 1
+fi
+
+# This timestamp is used during branch creation.
+# It's helpful in cases where the script fails and a new branch needs to
+# be created on a subsequent attempt.
+timestamp=$(date +"%Y-%m-%d-%H_%M_%S") 
+
+git checkout "$branch"
+git pull
+
+# Create a new branch with the version and timestamp
+branch_name="$(whoami)/release-$version-$timestamp"
+git checkout -b "$branch_name"
+
+# Define the git repo root
+repo_root=$(git rev-parse --show-toplevel)
+
+# Extract the previous version number from version.rb
+previous_version=$(grep 'BLUEPRINT_VERSION' "$repo_root/version.rb" | awk -F"'" '{print $2}')
+
+# Update the library version in version.rb
+sed -i '' "s/BLUEPRINT_VERSION ||= .*/BLUEPRINT_VERSION ||= '$version'/" "$repo_root/version.rb"
+
+# Update CHANGELOG.md using stamp-changelog.sh
+"$repo_root/Scripts/stamp-changelog.sh" --version "$version" --previous-version "$previous_version"
+
+# Change directory into the SampleApp dir and update Podfile.lock using a subshell
+(
+  cd "$repo_root/SampleApp"
+  bundle exec pod install
+)
+
+# Commit the changes
+git add .
+git commit -m "Bumping versions to $version."
+
+# Push the branch and open a PR into main
+git push origin "$branch_name"
+
+pr_body=$(cat <<-END
+https://github.com/square/Blueprint/blob/main/CHANGELOG.md
+
+Post-merge steps:
+
+- Once the PR is merged, fetch changes and tag the release, using the merge commit:
+  ```
+  git fetch
+  git tag $version <merge commit SHA>
+  git push origin $version
+  ```
+
+- Publish to CocoaPods:
+  ```
+  bundle exec pod trunk push BlueprintUI.podspec
+  bundle exec pod trunk push --synchronous BlueprintUICommonControls.podspec
+  ```
+END
+)
+
+gh pr create --draft --title "release: Blueprint $version" --body "https://github.com/square/Blueprint/blob/main/CHANGELOG.md"
+
+gh pr view --web
+
+echo "Branch $branch_name created and pushed. A draft PR has been created."

--- a/Scripts/stamp-changelog.sh
+++ b/Scripts/stamp-changelog.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Function to display usage
+usage() {
+  echo "Usage: $0 -v <version> -p <previous-version>"
+  echo "  -v, --version           Version number (required)"
+  echo "  -p, --previous-version  Previous version number (required)"
+  echo "  -d, --release-date      The date of the release (optional). Defaults to: date +%Y-%m-%d"
+  exit 1
+}
+
+# Parse options
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        -v|--version) version="$2"; shift 2 ;;
+        -p|--previous-version) previous_version="$2"; shift 2 ;;
+        -d|--release-date) release_date="$2"; shift 2 ;;
+        --) shift; break ;;
+        -*|--*) echo "Unknown option $1"; usage ;;
+        *) break ;;
+  esac
+done
+
+# Check if both version and previous_version arguments are provided
+if [ -z "$version" ] || [ -z "$previous_version" ]; then
+  echo "Error: You must provide both version and previous version numbers."
+  usage
+fi
+
+if [ -z "$release_date" ]; then
+    release_date=$(date +%Y-%m-%d)
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+changelog_file="$repo_root/CHANGELOG.md"
+
+changelog=$(ruby <<EOF
+changelog_contents = File.read('$changelog_file')
+changelog_contents.gsub!(/(###.*\n\n)+#/, '#')
+puts changelog_contents
+EOF
+)
+
+# Define the changelog template
+unreleased_changelog_template="## [Main]\n\
+\n\
+### Fixed\n\
+\n\
+### Added\n\
+\n\
+### Removed\n\
+\n\
+### Changed\n\
+\n\
+### Deprecated\n\
+\n\
+### Security\n\
+\n\
+### Documentation\n\
+\n\
+### Misc\n\
+\n\
+### Internal\n\
+\n\
+## [$version] - $release_date"
+
+# Replace the Main section with the new template
+changelog=$(echo "$changelog" | sed "s/^## \[Main\]/$unreleased_changelog_template/")
+
+# Replace the line starting with "[main]: " to the new URL
+changelog=$(echo "$changelog" | sed "s|^\[main\]: .*|\[main\]: https://github.com/square/Blueprint/compare/$version...HEAD|")
+
+# Append the new version comparison link at the end of the file
+changelog="$changelog"$'\n'"[$version]: https://github.com/square/Blueprint/compare/$previous_version...$version"
+
+# Write the updated contents back to the changelog file
+echo "$changelog" > "$changelog_file"
+
+echo "CHANGELOG.md updated for version $version."

--- a/version.rb
+++ b/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-BLUEPRINT_VERSION ||= '5.0.1'
+BLUEPRINT_VERSION ||= '5.1.0'
 
 SWIFT_VERSION ||= File.read(File.join(__dir__, '.swift-version'))
 


### PR DESCRIPTION
https://github.com/square/Blueprint/blob/main/CHANGELOG.md

Post-merge steps:

- Once the PR is merged, fetch changes and tag the release, using the merge commit:
  

- Publish to CocoaPods:
  Updating spec repo `trunk`

CocoaPods 1.16.1 is available.
To update use: `gem install cocoapods`

For more information, see https://blog.cocoapods.org and the CHANGELOG for this version at https://github.com/CocoaPods/CocoaPods/releases/tag/1.16.1

Validating podspec
 -> BlueprintUI -> BlueprintUI (5.1.0)
    - ERROR | [iOS] unknown: Encountered an unknown error ([!] /opt/homebrew/bin/git clone https://github.com/square/blueprint.git /var/folders/fb/bfghsm1n7ps8dp0cvv6gppkh0000gn/T/d20241125-84659-6li85w --template= --single-branch --depth 1 --branch 5.1.0

Cloning into '/var/folders/fb/bfghsm1n7ps8dp0cvv6gppkh0000gn/T/d20241125-84659-6li85w'...
warning: Could not find remote branch 5.1.0 to clone.
fatal: Remote branch 5.1.0 not found in upstream origin
) during validation.

[!] The spec did not pass validation, due to 1 error.
Updating spec repo `cocoapods`
Validating podspec
 -> BlueprintUICommonControls -> BlueprintUICommonControls (5.1.0)
    - ERROR | [iOS] unknown: Encountered an unknown error (CocoaPods could not find compatible versions for pod "BlueprintUI":
  In Podfile:
    BlueprintUICommonControls (from `/Users/robmaceachern/Development/Blueprint/BlueprintUICommonControls.podspec`) was resolved to 5.1.0, which depends on
      BlueprintUI (= 5.1.0)

None of your spec sources contain a spec satisfying the dependency: `BlueprintUI (= 5.1.0)`.

You have either:
 * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.) during validation.

[!] The spec did not pass validation, due to 1 error.