### PR TITLE
feat: deprecate legacy layout mode

### DIFF
--- a/BlueprintUI/Sources/Layout/LayoutMode.swift
+++ b/BlueprintUI/Sources/Layout/LayoutMode.swift
@@ -21,7 +21,12 @@ public enum LayoutMode: Equatable {
         }
     }
 
-    /// The "standard" layout system.
+    /// Blueprint's original layout system. This mode is deprecated and will be removed.
+    @available(
+        *,
+        deprecated,
+        message: "Legacy mode is deprecated and will be removed in a future release. Switch to the default layout mode."
+    )
     case legacy
 
     /// A newer layout system with some optimizations made possible by ensuring elements adhere

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+- `LayoutMode.legacy` is deprecated and will be removed in a future release.
+
 ### Security
 
 ### Documentation


### PR DESCRIPTION
Marks `LayoutMode.legacy` as deprecated, as a courtesy to any open source consumers before we fully kill it off.