### PR TITLE
AttributedLabel Accessibility Links

### DIFF
--- a/BlueprintUI/Sources/Extensions/BidirectionalCollection+Blueprint.swift
+++ b/BlueprintUI/Sources/Extensions/BidirectionalCollection+Blueprint.swift
@@ -10,19 +10,12 @@ extension BidirectionalCollection where Element: Equatable, Element: NSObjectPro
             return UIAccessibilityCustomRotorItemResult(targetElement: first, targetRange: nil)
         }
         let newIndex = (predicate.searchDirection == .next ? index(after: currentIndex) : index(before: currentIndex))
-            .clamped(min: startIndex, max: index(before: endIndex))
+        guard newIndex >= startIndex, newIndex < endIndex else { return nil }
         return .init(targetElement: self[newIndex], targetRange: nil)
     }
 
     /// Returns a UIAccessibilityCustomRotor with the provided system type which cycles through the contained elements.
     public func accessibilityRotor(systemType type: UIAccessibilityCustomRotor.SystemRotorType) -> UIAccessibilityCustomRotor {
         UIAccessibilityCustomRotor(systemType: type) { itemSearch($0) }
-    }
-}
-
-// MARK: Misc. Internal
-extension Comparable {
-    fileprivate func clamped(min: Self, max: Self) -> Self {
-        Swift.max(Swift.min(self, max), min)
     }
 }

--- a/BlueprintUI/Sources/Extensions/BidirectionalCollection+Blueprint.swift
+++ b/BlueprintUI/Sources/Extensions/BidirectionalCollection+Blueprint.swift
@@ -1,0 +1,28 @@
+import UIKit
+
+extension BidirectionalCollection where Element: Equatable, Element: NSObjectProtocol {
+    private func itemSearch(_ predicate: UIAccessibilityCustomRotorSearchPredicate) -> UIAccessibilityCustomRotorItemResult? {
+        guard let first else { return nil }
+        guard let currentItem = predicate.currentItem.targetElement as? Element,
+              let currentIndex = firstIndex(of: currentItem),
+              predicate.searchDirection == .previous || predicate.searchDirection == .next
+        else {
+            return UIAccessibilityCustomRotorItemResult(targetElement: first, targetRange: nil)
+        }
+        let newIndex = (predicate.searchDirection == .next ? index(after: currentIndex) : index(before: currentIndex))
+            .clamped(min: startIndex, max: index(before: endIndex))
+        return .init(targetElement: self[newIndex], targetRange: nil)
+    }
+
+    /// Returns a UIAccessibilityCustomRotor with the provided system type which cycles through the contained elements.
+    public func accessibilityRotor(systemType type: UIAccessibilityCustomRotor.SystemRotorType) -> UIAccessibilityCustomRotor {
+        UIAccessibilityCustomRotor(systemType: type) { itemSearch($0) }
+    }
+}
+
+// MARK: Misc. Internal
+extension Comparable {
+    fileprivate func clamped(min: Self, max: Self) -> Self {
+        Swift.max(Swift.min(self, max), min)
+    }
+}

--- a/BlueprintUI/Sources/Extensions/BidirectionalCollection+Blueprint.swift
+++ b/BlueprintUI/Sources/Extensions/BidirectionalCollection+Blueprint.swift
@@ -1,6 +1,12 @@
 import UIKit
 
-extension BidirectionalCollection where Element: Equatable, Element: NSObjectProtocol {
+extension BidirectionalCollection where Element: Equatable & NSObjectProtocol {
+
+    /// Returns a UIAccessibilityCustomRotor with the provided system type which cycles through the contained elements.
+    public func accessibilityRotor(systemType type: UIAccessibilityCustomRotor.SystemRotorType) -> UIAccessibilityCustomRotor {
+        UIAccessibilityCustomRotor(systemType: type) { itemSearch($0) }
+    }
+
     private func itemSearch(_ predicate: UIAccessibilityCustomRotorSearchPredicate) -> UIAccessibilityCustomRotorItemResult? {
         guard let first else { return nil }
         guard let currentItem = predicate.currentItem.targetElement as? Element,
@@ -12,10 +18,5 @@ extension BidirectionalCollection where Element: Equatable, Element: NSObjectPro
         let newIndex = (predicate.searchDirection == .next ? index(after: currentIndex) : index(before: currentIndex))
         guard newIndex >= startIndex, newIndex < endIndex else { return nil }
         return .init(targetElement: self[newIndex], targetRange: nil)
-    }
-
-    /// Returns a UIAccessibilityCustomRotor with the provided system type which cycles through the contained elements.
-    public func accessibilityRotor(systemType type: UIAccessibilityCustomRotor.SystemRotorType) -> UIAccessibilityCustomRotor {
-        UIAccessibilityCustomRotor(systemType: type) { itemSearch($0) }
     }
 }

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -514,7 +514,7 @@ extension AttributedLabel {
             return links
         }
 
-        private func accessibilityRotor(for links: [Link], in string: NSAttributedString) -> UIAccessibilityCustomRotor {
+        internal func accessibilityRotor(for links: [Link], in string: NSAttributedString) -> UIAccessibilityCustomRotor {
             let elements: [LinkAccessibilityElement] = links
                 .sorted(by: { $0.range.location < $1.range.location })
                 .compactMap { link in

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -364,7 +364,7 @@ extension AttributedLabel {
                 }
 
                 assert(
-                    alignments.count == 1,
+                    alignments.count <= 1,
                     """
                     AttributedLabel links only support a single NSTextAlignment. \
                     Instead, found: \(alignments).

--- a/BlueprintUICommonControls/Sources/AttributedLabel.swift
+++ b/BlueprintUICommonControls/Sources/AttributedLabel.swift
@@ -211,7 +211,7 @@ extension AttributedLabel {
         }
 
         override var accessibilityCustomRotors: [UIAccessibilityCustomRotor]? {
-            set { fatalError() }
+            set { fatalError("accessibilityCustomRotors is not settable.") }
             get {
                 guard let attributedText, !links.isEmpty else { return [] }
                 return [accessibilityRotor(for: links, in: attributedText)]
@@ -681,7 +681,7 @@ extension AttributedLabel {
         }
 
         override var accessibilityFrameInContainerSpace: CGRect {
-            set { fatalError() }
+            set { fatalError("accessibilityFrameInContainerSpace") }
             get {
                 guard let container = container,
                       let textStorage = container.makeTextStorage(),

--- a/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
@@ -498,25 +498,53 @@ class AttributedLabelTests: XCTestCase {
         let rotor = labelView.accessibilityRotor(for: links, in: NSAttributedString(string: text as String))
         XCTAssertNotNil(rotor)
 
-        var results = [UIAccessibilityCustomRotorItemResult]()
-        let predicate = UIAccessibilityCustomRotorSearchPredicate()
-        predicate.searchDirection = .next
-        let first = rotor.itemSearchBlock(predicate)
-        XCTAssertNotNil(first)
-        results.append(first!)
-        predicate.currentItem = first!
-        while let last = results.last,
-              let next = rotor.itemSearchBlock(predicate),
-              last.targetElement as! NSObject != next.targetElement as! NSObject
-        {
-            results.append(next)
-            predicate.currentItem = next
-        }
-
         // links should be sorted by their position in the main string.
-        let sortedHobbits = results.map { ($0.targetElement as! NSObject).accessibilityLabel }
+        let sortedHobbits = rotor.dumpItems().map { $0.accessibilityLabel }
         XCTAssertEqual(sortedHobbits, ["Sam", "Frodo", "Pippin", "Merry"])
     }
+
+
+
+    func test_linkAccessibility_Rotors_update() {
+        let string = "The Fellowship of the ring was established at the Council of Elrond and consisted of Gandalf, Sam, Frodo, Aragorn, Gimli, Pippin, Boromir, Legolas, and Merry."
+        var attributedText = AttributedText(string)
+
+        for hobbit in ["Frodo", "Merry", "Sam", "Pippin"] {
+            let range = attributedText.range(of: hobbit)!
+            attributedText[range].link = URL(string: "https://one.ring")!
+        }
+
+        var label = AttributedLabel(attributedText: attributedText.attributedString)
+        let labelView = AttributedLabel.LabelView()
+        labelView.update(model: label, text: label.attributedText, environment: .empty, isMeasuring: false)
+
+        let rotor = labelView.accessibilityCustomRotors!.first!
+        XCTAssertNotNil(rotor)
+
+        // links should be sorted by their position in the main string.
+        let sortedHobbits = rotor.dumpItems().map { $0.accessibilityLabel }
+        XCTAssertEqual(sortedHobbits, ["Sam", "Frodo", "Pippin", "Merry"])
+
+        let removedLinks = AttributedText(string)
+        label.attributedText = removedLinks.attributedString
+        labelView.update(model: label, text: label.attributedText, environment: .empty, isMeasuring: false)
+        XCTAssertTrue(labelView.accessibilityCustomRotors!.isEmpty)
+
+        var updatedText = AttributedText(string)
+        for name in ["Aragorn", "Gandalf", "Gimli", "Legolas", "Boromir"] {
+            let range = updatedText.range(of: name)!
+            updatedText[range].link = URL(string: "https://one.ring")!
+        }
+        label.attributedText = updatedText.attributedString
+        labelView.update(model: label, text: label.attributedText, environment: .empty, isMeasuring: false)
+
+        let updatedRotor = labelView.accessibilityCustomRotors!.first!
+        XCTAssertNotNil(updatedRotor)
+
+        let notHobbits = updatedRotor.dumpItems().map { $0.accessibilityLabel }
+        XCTAssertEqual(notHobbits, ["Gandalf", "Aragorn", "Gimli", "Boromir", "Legolas"])
+    }
+
 
     func test_textContainerRects() {
         let lineBreakModes: [NSLineBreakMode?] = [
@@ -684,6 +712,26 @@ class AttributedLabelTests: XCTestCase {
         }
     }
 
+}
+
+extension UIAccessibilityCustomRotor {
+    fileprivate func dumpItems() -> [NSObject] {
+        var results = [UIAccessibilityCustomRotorItemResult]()
+        let predicate = UIAccessibilityCustomRotorSearchPredicate()
+        predicate.searchDirection = .next
+        let first = itemSearchBlock(predicate)
+        XCTAssertNotNil(first)
+        results.append(first!)
+        predicate.currentItem = first!
+        while let last = results.last,
+              let next = itemSearchBlock(predicate),
+              last.targetElement as! NSObject != next.targetElement as! NSObject
+        {
+            results.append(next)
+            predicate.currentItem = next
+        }
+        return results.compactMap { $0.targetElement as? NSObject }
+    }
 }
 
 fileprivate struct LabelTapDetectionGrid: Element {

--- a/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AttributedLabelTests.swift
@@ -717,19 +717,37 @@ class AttributedLabelTests: XCTestCase {
 extension UIAccessibilityCustomRotor {
     fileprivate func dumpItems() -> [NSObject] {
         var results = [UIAccessibilityCustomRotorItemResult]()
+
         let predicate = UIAccessibilityCustomRotorSearchPredicate()
         predicate.searchDirection = .next
+
         let first = itemSearchBlock(predicate)
         XCTAssertNotNil(first)
-        results.append(first!)
+        results = [first!]
+
+
         predicate.currentItem = first!
+
         while let last = results.last,
               let next = itemSearchBlock(predicate),
-              last.targetElement as! NSObject != next.targetElement as! NSObject
+              last.targetElement as? NSObject != next.targetElement as? NSObject
         {
-            results.append(next)
+            results = results + [next]
             predicate.currentItem = next
         }
+
+        predicate.searchDirection = .previous
+        predicate.currentItem = first!
+
+        while let last = results.first,
+              let next = itemSearchBlock(predicate),
+              last.targetElement as? NSObject != next.targetElement as? NSObject
+        {
+            results = [next] + results
+            predicate.currentItem = next
+        }
+
+
         return results.compactMap { $0.targetElement as? NSObject }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a bug in `AttributedLabel` which could cause a crash if the attributed string lacked a specified `NSTextAlignment`. 
+
 ### Added
+
 - `AccessibilityContainer` now supports configuration of `UIAccessibilityContainerType`, `AccessibilityLabel` and `AccessibilityValue`.
 
 ### Removed
@@ -17,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CocoaPods podspecs removed. Blueprint will only be vended via Swift Package Manager.
 
 ### Changed
+
+`AttributedLabel` accessibility links are now stateless.
 
 ### Deprecated
 


### PR DESCRIPTION
This PR migrates `AttributedLabel`'s link rotor from a stateful to functional pattern, eliminating the need for two variables and preventing voiceover from getting out of sync. 

I also fixed a bug in `links(at location: CGPoint)` that could cause a crash if the `AttributedString` lacked a specified `NSTextAlignment`.