### PR TITLE
Remove AccessibilityElement.deprecated_accessibility

### DIFF
--- a/BlueprintUICommonControls/Sources/AccessibilityElement.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityElement.swift
@@ -201,33 +201,4 @@ extension Element {
             wrapping: self
         )
     }
-
-
-    /// Wraps the receiver in an accessibility element with the provided values.
-    ///
-    /// - Important: ⚠️ This overrides the accessibility of the contained element and all of its children ⚠️
-    ///
-    /// - SeeAlso: ``accessibilityElement``
-    @available(
-        *,
-        deprecated,
-        renamed: "accessibilityElement(label:value:traits:hint:identifier:accessibilityFrameSize:)"
-    )
-    public func deprecated_accessibility(
-        label: String? = nil,
-        value: String? = nil,
-        hint: String? = nil,
-        identifier: String? = nil,
-        traits: Set<Accessibility.Trait> = [],
-        accessibilityFrameSize: CGSize? = nil
-    ) -> AccessibilityElement {
-        accessibilityElement(
-            label: label,
-            value: value,
-            traits: traits,
-            hint: hint,
-            identifier: identifier,
-            accessibilityFrameSize: accessibilityFrameSize
-        )
-    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Removed
+- `AccessibilityElement.deprecated_accessibility(…)`. This was deprecated in September 2021, and renamed from .accessibility(…) to .deprecated_accessibility(…) in Oct 2024.
 
 ### Changed
 


### PR DESCRIPTION
We got rid of the last of the code that uses this, so, maybe we can remove a long-deprecated function from Blueprint as well?