### PR TITLE
feat: Add `UserInterfaceOverridingElement `

### DIFF
--- a/BlueprintUICommonControls/Sources/Image.swift
+++ b/BlueprintUICommonControls/Sources/Image.swift
@@ -15,9 +15,6 @@ public struct Image: Element {
     /// not precisely match the size that the element is assigned.
     public var contentMode: ContentMode
 
-    /// Whether to override the user interface style, `nil` is the system style.
-    public var overrideUserInterfaceStyle: UIUserInterfaceStyle?
-
     /// iOS 14 added support for Image Descriptions using VoiceOver. This is not always appropriate.
     /// Set this to `true` to prevent VoiceOver from describing the displayed image.
     public var blockAccessibilityDescription: Bool
@@ -27,14 +24,12 @@ public struct Image: Element {
         image: UIImage?,
         contentMode: ContentMode = .aspectFill,
         tintColor: UIColor? = nil,
-        blockAccessibilityDescription: Bool = false,
-        overrideUserInterfaceStyle: UIUserInterfaceStyle? = nil
+        blockAccessibilityDescription: Bool = false
     ) {
         self.image = image
         self.contentMode = contentMode
         self.tintColor = tintColor
         self.blockAccessibilityDescription = blockAccessibilityDescription
-        self.overrideUserInterfaceStyle = overrideUserInterfaceStyle
     }
 
     public var content: ElementContent {
@@ -50,7 +45,6 @@ public struct Image: Element {
             config[\.contentMode] = contentMode.uiViewContentMode
             config[\.layer.minificationFilter] = .trilinear
             config[\.tintColor] = tintColor
-            config[\.overrideUserInterfaceStyle] = overrideUserInterfaceStyle
             if blockAccessibilityDescription {
                 // Seting `isAccessibilityElement = false` isn't enough here, VoiceOver is very aggressive in finding images to discribe. We need to explicitly remove the `.image` trait.
                 config[\.accessibilityTraits] = UIAccessibilityTraits.none

--- a/BlueprintUICommonControls/Sources/Image.swift
+++ b/BlueprintUICommonControls/Sources/Image.swift
@@ -15,6 +15,9 @@ public struct Image: Element {
     /// not precisely match the size that the element is assigned.
     public var contentMode: ContentMode
 
+    /// Whether to override the user interface style, `nil` is the system style.
+    public var overrideUserInterfaceStyle: UIUserInterfaceStyle?
+
     /// iOS 14 added support for Image Descriptions using VoiceOver. This is not always appropriate.
     /// Set this to `true` to prevent VoiceOver from describing the displayed image.
     public var blockAccessibilityDescription: Bool
@@ -24,12 +27,14 @@ public struct Image: Element {
         image: UIImage?,
         contentMode: ContentMode = .aspectFill,
         tintColor: UIColor? = nil,
-        blockAccessibilityDescription: Bool = false
+        blockAccessibilityDescription: Bool = false,
+        overrideUserInterfaceStyle: UIUserInterfaceStyle? = nil
     ) {
         self.image = image
         self.contentMode = contentMode
         self.tintColor = tintColor
         self.blockAccessibilityDescription = blockAccessibilityDescription
+        self.overrideUserInterfaceStyle = overrideUserInterfaceStyle
     }
 
     public var content: ElementContent {
@@ -45,6 +50,7 @@ public struct Image: Element {
             config[\.contentMode] = contentMode.uiViewContentMode
             config[\.layer.minificationFilter] = .trilinear
             config[\.tintColor] = tintColor
+            config[\.overrideUserInterfaceStyle] = overrideUserInterfaceStyle
             if blockAccessibilityDescription {
                 // Seting `isAccessibilityElement = false` isn't enough here, VoiceOver is very aggressive in finding images to discribe. We need to explicitly remove the `.image` trait.
                 config[\.accessibilityTraits] = UIAccessibilityTraits.none

--- a/BlueprintUICommonControls/Sources/UserInterfaceOverridingElement.swift
+++ b/BlueprintUICommonControls/Sources/UserInterfaceOverridingElement.swift
@@ -1,0 +1,73 @@
+import BlueprintUI
+import UIKit
+
+/// An element that allows overriding the user interface style (light/dark mode) for its wrapped content.
+///
+/// Use this element to force a specific appearance for a portion of your UI, regardless of the system-wide
+/// settings. This can be useful when you need to ensure certain UI elements maintain a consistent appearance
+/// across different user interface styles.
+///
+/// Example:
+/// ```swift
+/// let content = Label(text: "Hello, World!")
+/// let forcedLightMode = UserInterfaceOverridingElement(
+///     userInterfaceStyle: .light,
+///     wrapping: content
+/// )
+/// ```
+public struct UserInterfaceOverridingElement: Element {
+
+    /// The element being wrapped with the overridden interface style.
+    public var wrappedElement: Element
+
+    /// The user interface style to apply to the wrapped content.
+    /// This can be `.light`, `.dark`, or `.unspecified`.
+    public var userInterfaceStyle: UIUserInterfaceStyle
+
+    /// Creates a new element that overrides the user interface style for its wrapped content.
+    ///
+    /// - Parameters:
+    ///   - userInterfaceStyle: The desired interface style to apply (`.light`, `.dark`, or `.unspecified`).
+    ///   - element: The element whose interface style should be overridden.
+    public init(
+        userInterfaceStyle: UIUserInterfaceStyle,
+        wrapping element: Element
+    ) {
+        self.userInterfaceStyle = userInterfaceStyle
+        wrappedElement = element
+    }
+
+    public var content: ElementContent {
+        ElementContent(child: wrappedElement)
+    }
+
+    public func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
+        UIView.describe { config in
+            config[\.overrideUserInterfaceStyle] = userInterfaceStyle
+        }
+    }
+}
+
+extension Element {
+    /// Wraps this element in a `UserInterfaceOverridingElement` to override its interface style.
+    ///
+    /// This method provides a convenient way to override the user interface style (light/dark mode)
+    /// for any element.
+    ///
+    /// Example:
+    /// ```swift
+    /// Label(text: "Always Light Mode")
+    ///   .overrideUserInterfaceStyle(.light)
+    /// ```
+    ///
+    /// - Parameter override: The desired interface style to apply. Defaults to `.unspecified`.
+    /// - Returns: A new element wrapped with the specified interface style override.
+    public func overrideUserInterfaceStyle(
+        _ override: UIUserInterfaceStyle = .unspecified
+    ) -> UserInterfaceOverridingElement {
+        UserInterfaceOverridingElement(
+            userInterfaceStyle: override,
+            wrapping: self
+        )
+    }
+}

--- a/BlueprintUICommonControls/Sources/UserInterfaceOverridingElement.swift
+++ b/BlueprintUICommonControls/Sources/UserInterfaceOverridingElement.swift
@@ -10,7 +10,7 @@ import UIKit
 /// Example:
 /// ```swift
 /// let content = Label(text: "Hello, World!")
-/// let forcedLightMode = UserInterfaceOverridingElement(
+/// let forcedLightMode = UserInterfaceStyleOverridingElement(
 ///     userInterfaceStyle: .light,
 ///     wrapping: content
 /// )

--- a/BlueprintUICommonControls/Sources/UserInterfaceOverridingElement.swift
+++ b/BlueprintUICommonControls/Sources/UserInterfaceOverridingElement.swift
@@ -15,7 +15,7 @@ import UIKit
 ///     wrapping: content
 /// )
 /// ```
-public struct UserInterfaceOverridingElement: Element {
+public struct UserInterfaceStyleOverridingElement: Element {
 
     /// The element being wrapped with the overridden interface style.
     public var wrappedElement: Element
@@ -28,13 +28,13 @@ public struct UserInterfaceOverridingElement: Element {
     ///
     /// - Parameters:
     ///   - userInterfaceStyle: The desired interface style to apply (`.light`, `.dark`, or `.unspecified`).
-    ///   - element: The element whose interface style should be overridden.
+    ///   - wrapping: The content whose interface style should be overridden.
     public init(
         userInterfaceStyle: UIUserInterfaceStyle,
-        wrapping element: Element
+        wrapping content: () -> (Element)
     ) {
         self.userInterfaceStyle = userInterfaceStyle
-        wrappedElement = element
+        wrappedElement = content()
     }
 
     public var content: ElementContent {
@@ -49,7 +49,7 @@ public struct UserInterfaceOverridingElement: Element {
 }
 
 extension Element {
-    /// Wraps this element in a `UserInterfaceOverridingElement` to override its interface style.
+    /// Wraps this element in a `UserInterfaceStyleOverridingElement` to override its interface style.
     ///
     /// This method provides a convenient way to override the user interface style (light/dark mode)
     /// for any element.
@@ -64,10 +64,9 @@ extension Element {
     /// - Returns: A new element wrapped with the specified interface style override.
     public func overrideUserInterfaceStyle(
         _ override: UIUserInterfaceStyle = .unspecified
-    ) -> UserInterfaceOverridingElement {
-        UserInterfaceOverridingElement(
-            userInterfaceStyle: override,
-            wrapping: self
-        )
+    ) -> UserInterfaceStyleOverridingElement {
+        UserInterfaceStyleOverridingElement(userInterfaceStyle: override) {
+            self
+        }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Added
+- Added `UserInterfaceStyleOverridingElement` which allows child elements to have their `userInterfaceStyle` to be forced to light/dark. Additionally added a `overrideUserInterfaceStyle` convenience to `Element`.
 
 ### Removed
 - `AccessibilityElement.deprecated_accessibility(…)`. This was deprecated in September 2021, and renamed from .accessibility(…) to .deprecated_accessibility(…) in Oct 2024.


### PR DESCRIPTION
Adds a `UserInterfaceStyleOverridingElement` and a `overrideUserInterfaceStyle()` extension on `Element` so that subtrees of views can have their `userInterfaceStyle` (i.e. light/dark) overridden a la SwiftUI's `colorScheme` environment variable.