### PR TITLE
feat: Keyed layout traits

### DIFF
--- a/BlueprintUI/Sources/Element/ElementContent.swift
+++ b/BlueprintUI/Sources/Element/ElementContent.swift
@@ -107,9 +107,55 @@ extension ElementContent {
         /// Child elements.
         var children: [Child] = []
 
-        /// Adds the given child element.
+        /// Adds the given child element with this ``SingleTraitLayout``'s trait type.
+        ///
+        /// - Parameters:
+        ///   - traits: The traits to associate with this child.
+        ///   - key: An optional disambiguation key. By default, `nil`.
+        ///   - element: The child element.
         public mutating func add(
-            traits: LayoutType.Traits = LayoutType.defaultTraits,
+            traits: LayoutType.Traits,
+            key: AnyHashable? = nil,
+            element: Element
+        ) where LayoutType: SingleTraitLayout {
+            add(
+                traits: LayoutTraits(
+                    key: SingleTraitLayoutTraitsKey<LayoutType>.self,
+                    value: traits
+                ),
+                key: key,
+                element: element
+            )
+        }
+
+        /// Adds the given child element with a trait-value pair.
+        ///
+        /// - Parameters:
+        ///   - traitsType: The type of traits to associate with this child.
+        ///   - traits: The value of the traits.
+        ///   - key: An optional disambiguation key. By default, `nil`.
+        ///   - element: The child element.
+        public mutating func add<TraitsKey: LayoutTraitsKey>(
+            traitsType: TraitsKey.Type,
+            traits: TraitsKey.Value,
+            key: AnyHashable? = nil,
+            element: Element
+        ) {
+            add(
+                traits: LayoutTraits(key: TraitsKey.self, value: traits),
+                key: key,
+                element: element
+            )
+        }
+
+        /// Adds the given child element.
+        ///
+        /// - Parameters:
+        ///   - traits: Layout traits to associate with this child. By default, no traits.
+        ///   - key: An optional disambiguation key. By default, `nil`.
+        ///   - element: The child element.
+        public mutating func add(
+            traits: LayoutTraits = .empty,
             key: AnyHashable? = nil,
             element: Element
         ) {

--- a/BlueprintUI/Sources/Layout/Flow.swift
+++ b/BlueprintUI/Sources/Layout/Flow.swift
@@ -66,16 +66,20 @@ public struct Flow: Element {
     // MARK: Element
 
     public var content: ElementContent {
-        .init(
-            layout: Layout(
+        ElementContent(
+            layout: FlowLayout(
                 lineAlignment: lineAlignment,
                 lineSpacing: lineSpacing,
                 itemAlignment: itemAlignment,
                 itemSpacing: itemSpacing
             )
-        ) {
+        ) { builder in
             for child in children {
-                $0.add(traits: child.traits, key: child.key, element: child.element)
+                builder.add(
+                    traits: child.traits,
+                    key: child.key,
+                    element: child.element
+                )
             }
         }
     }
@@ -188,7 +192,7 @@ extension Element {
 
 extension Flow {
 
-    fileprivate struct Layout: BlueprintUI.Layout {
+    fileprivate struct FlowLayout: Layout, SingleTraitLayout {
 
         typealias Traits = Child.Traits
 
@@ -367,7 +371,7 @@ extension Flow {
 
 // MARK: - RowLayout
 
-extension Flow.Layout {
+extension Flow.FlowLayout {
 
     /// Helper for computing the frames for a row of items.
     fileprivate struct RowLayout {
@@ -398,7 +402,7 @@ extension Flow.Layout {
 
         struct Item {
             let size: CGSize
-            let traits: Flow.Layout.Traits
+            let traits: Flow.FlowLayout.Traits
         }
 
         /// `True` if we can fit an item of the given size in the row.

--- a/BlueprintUI/Sources/Layout/GridRow.swift
+++ b/BlueprintUI/Sources/Layout/GridRow.swift
@@ -70,8 +70,12 @@ public struct GridRow: Element {
     // MARK: - GridRow+Element -
     public var content: ElementContent {
         ElementContent(layout: GridRowLayout(verticalAlignment: verticalAlignment, spacing: spacing)) { builder in
-            children.forEach {
-                builder.add(traits: $0.width, key: $0.key, element: $0.element)
+            for child in children {
+                builder.add(
+                    traits: child.width,
+                    key: child.key,
+                    element: child.element
+                )
             }
         }
     }
@@ -83,7 +87,7 @@ public struct GridRow: Element {
 
 // MARK: - layout -
 extension GridRow {
-    struct GridRowLayout: Layout {
+    struct GridRowLayout: Layout, SingleTraitLayout {
         let verticalAlignment: Row.RowAlignment
         let spacing: CGFloat
 

--- a/BlueprintUI/Sources/Layout/Layout.swift
+++ b/BlueprintUI/Sources/Layout/Layout.swift
@@ -85,18 +85,20 @@ import CoreGraphics
 ///
 /// ## Access layout traits
 ///
-/// Subelements may have _traits_ that are specific to their container's layout. The traits are of
-/// the ``Layout`` protocol's associated type ``LegacyLayout/Traits``, and each subelement can have
-/// a distinct `Traits` value assigned. You can set this in the `configure` block of
-/// ``ElementContent/init(layout:configure:)``, when you call
-/// ``ElementContent/Builder/add(traits:key:element:)``. If you do not specify a `Traits` type for
-/// your layout, it defaults to the void type, `()`.
+/// Subelements may have _traits_ that are specific to their container's layout. Containers can
+/// choose to condition their behavior according to the traits of their subelements. For example,
+/// the ``Row`` and ``Column`` types allocate space for their subelements based in part on the grow
+/// and shrink priorities that you set on each child.
 ///
-/// Containers can choose to condition their behavior according to the traits of their subelements.
-/// For example, the ``Row`` and ``Column`` types allocate space for their subelements based in part
-/// on the grow and shrink priorities that you set on each child. Your layout container accesses the
-/// traits for a subelement by calling ``LayoutSubelement/traits(forLayoutType:)`` on the
-/// ``LayoutSubelement`` proxy.
+///  Traits are set on each child in the `configure` block of
+/// ``ElementContent/init(layout:configure:)``, when you call
+/// ``ElementContent/Builder/add(traits:key:element:)``. Your layout container accesses the traits
+/// for a subelement by calling ``LayoutSubelement/subscript(key:)`` on the ``LayoutSubelement``
+/// proxy. For more information about custom traits, see ``LayoutTraitsKey``.
+///
+/// Legacy layouts that support a single trait type can conform to ``SingleTraitLayout`` to define
+/// the trait type on the layout itself instead of using a key. These traits can be accessed with
+/// the ``LayoutSubelement/traits(forLayoutType:)`` method.
 ///
 /// - Note: The ``Layout`` API, and its documentation, are modeled after SwiftUI's
 ///   [Layout](https://developer.apple.com/documentation/swiftui/layout), with major differences
@@ -104,7 +106,7 @@ import CoreGraphics
 ///
 public protocol Layout: LegacyLayout, CaffeinatedLayout {}
 
-public protocol LegacyLayout {
+public protocol LegacyLayout: SingleTraitLayout {
     /// Per-item metadata that is used during the measuring and layout pass.
     associatedtype Traits = ()
 
@@ -127,10 +129,6 @@ public protocol LegacyLayout {
     ///
     /// - returns: Layout attributes for the given array of items.
     func layout(size: CGSize, items: [(traits: Self.Traits, content: Measurable)]) -> [LayoutAttributes]
-
-    /// Returns a default traits object.
-    static var defaultTraits: Self.Traits { get }
-
 }
 
 extension LegacyLayout where Traits == () {

--- a/BlueprintUI/Sources/Layout/LayoutSubelement.swift
+++ b/BlueprintUI/Sources/Layout/LayoutSubelement.swift
@@ -30,7 +30,7 @@ public struct LayoutSubelement {
     private var content: ElementContent
     var environment: Environment
     var node: LayoutTreeNode
-    private var traits: Any
+    private var traits: LayoutTraits
 
     private var cache: HintingSizeCache { node.sizeCache }
 
@@ -46,7 +46,7 @@ public struct LayoutSubelement {
         content: ElementContent,
         environment: Environment,
         node: LayoutTreeNode,
-        traits: Any
+        traits: LayoutTraits
     ) {
         self.identifier = identifier
         self.content = content
@@ -127,20 +127,22 @@ public struct LayoutSubelement {
         }
     }
 
-    /// Gets the layout traits of the subelement.
+    /// Gets the subelement's layout traits associated with the given ``SingleTraitLayout``.
     ///
-    /// Use this method to access the layout-specific ``LegacyLayout/Traits`` value for this
-    /// subelement.
-    ///
-    /// - Important: Only call this method with the type of your `Layout`. For compatibility with
-    ///   legacy layout, this is the only type of traits supported.
+    /// If this is not a subelement of the given layout type, it will return the default value. When
+    /// implementing a ``SingleTraitLayout`` be careful to call this with the type of your layout.
     ///
     /// - Parameter layoutType: The type of layout, which determines the type of the traits.
     /// - Returns: The subelements's layout traits.
-    public func traits<LayoutType>(
+    public func traits<LayoutType: SingleTraitLayout>(
         forLayoutType layoutType: LayoutType.Type
-    ) -> LayoutType.Traits where LayoutType: Layout {
-        traits as! LayoutType.Traits
+    ) -> LayoutType.Traits {
+        traits[layout: layoutType]
+    }
+
+    /// Gets the subelement's layout traits associated with the given key.
+    public subscript<Key: LayoutTraitsKey>(key: Key.Type) -> Key.Value {
+        traits[key]
     }
 }
 

--- a/BlueprintUI/Sources/Layout/LayoutTraits.swift
+++ b/BlueprintUI/Sources/Layout/LayoutTraits.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// A heterogeneous container of traits associated with a subelement being laid out.
+///
+/// Generally, layout implementations will not need to use this type directly. However, elements
+/// that apply multiple traits to each subelement will use this type to store the traits, and
+/// calling ``ElementContent/Builder/add(traits:key:element:)-3rxz0`` when creating the
+/// ``ElementContent``.
+///
+/// Layout implementations may access subelements' traits during layout using the
+/// ``LayoutSubelement/subscript(key:)`` subscript. For more information, see ``LayoutTraitsKey``.
+///
+public struct LayoutTraits {
+
+    /// An empty set of traits.
+    public static let empty = Self()
+
+    private var values: [ObjectIdentifier: Any] = [:]
+
+    private init() {}
+
+    /// Creates a set of traits containing the specified key and value.
+    public init<K: LayoutTraitsKey>(key: K.Type, value: K.Value) {
+        self[key] = value
+    }
+
+    /// Gets or sets a trait value by its key.
+    public subscript<Key>(key: Key.Type) -> Key.Value where Key: LayoutTraitsKey {
+        get {
+            let objectId = ObjectIdentifier(key)
+
+            if let value = values[objectId] {
+                return value as! Key.Value
+            }
+
+            return key.defaultValue
+        }
+        set {
+            values[ObjectIdentifier(key)] = newValue
+        }
+    }
+
+    subscript<LayoutType: SingleTraitLayout>(layout layout: LayoutType.Type) -> LayoutType.Traits {
+        get {
+            self[SingleTraitLayoutTraitsKey<LayoutType>.self]
+        }
+        set {
+            self[SingleTraitLayoutTraitsKey<LayoutType>.self] = newValue
+        }
+    }
+
+    /// Returns a copy of this set of traits with the specified key and value set.
+    public func setting<Key: LayoutTraitsKey>(key: Key.Type, to value: Key.Value) -> Self {
+        var copy = self
+        copy[key] = value
+        return copy
+    }
+}

--- a/BlueprintUI/Sources/Layout/LayoutTraitsKey.swift
+++ b/BlueprintUI/Sources/Layout/LayoutTraitsKey.swift
@@ -1,0 +1,74 @@
+/// A key for accessing a layout trait value of a layout container's subelements.
+///
+/// If you create a custom layout by defining a type that conforms to the ``Layout`` protocol, you
+/// can also create custom layout traits that you set on individual subelements, and that your
+/// container can access to guide its layout behavior. Your custom traits resemble the built-in
+/// layout traits such as the grow and shrink priorities of `Row` and `Column`, but have a purpose
+/// that you define.
+///
+/// To create a custom layout trait, first create a type that conforms to this protocol and
+/// implement the ``defaultValue`` property.
+///
+/// ## Set layout traits
+///
+/// Layout traits are set on subelements as part of the ``ElementContent``. Use the initializer that
+/// provides a builder closure, and set layout traits on each subelement by calling the
+/// ``ElementContent/Builder/add(traitsType:traits:key:element:)`` method.
+///
+/// ```swift
+/// enum MyPriorityKey: LayoutTraitsKey {
+///     static let defaultValue: CGFloat = 0
+/// }
+///
+/// struct MyElement: Element {
+///     var children: [(element: Element, priority: CGFloat)]
+///
+///     var content: ElementContent {
+///         ElementContent(layout: MyLayout()) { builder in
+///             for (element, priority) in children {
+///                 builder.add(
+///                     traitsType: MyPriorityKey.self,
+///                     traits: priority,
+///                     element: element
+///                 )
+///             }
+///         }
+///     }
+/// }
+/// ```
+///
+/// ## Read layout traits
+///
+/// To read the layout traits in your layout implementation, use the traits key type as an index on
+/// the ``LayoutSubelement``. You can define a convenience property on ``LayoutSubelement`` to make
+/// it easier to read the value.
+///
+/// ```swift
+/// extension LayoutSubelement {
+///     var myPriority: CGFloat {
+///         self[MyPriorityKey.self]
+///     }
+/// }
+///
+/// struct MyLayout: Layout {
+///     func placeSubelements(
+///         in size: CGSize,
+///         subelements: Subelements,
+///         environment: Environment,
+///         cache: inout ()
+///     ) {
+///         for subelement in subelements {
+///             let myPriority = subelement.myPriority
+///             // place subelement based on myPriority
+///         }
+///     }
+/// }
+/// ```
+///
+public protocol LayoutTraitsKey {
+    /// The type of value stored by this key.
+    associatedtype Value
+
+    /// The default value of the trait if it is not set.
+    static var defaultValue: Value { get }
+}

--- a/BlueprintUI/Sources/Layout/SingleTraitLayout.swift
+++ b/BlueprintUI/Sources/Layout/SingleTraitLayout.swift
@@ -1,0 +1,18 @@
+/// A protocol for layouts that have a single associated trait type.
+///
+/// Legacy layout implementations can implement this protocol to easily apply and read their traits
+/// without defining a custom trait key type.
+public protocol SingleTraitLayout {
+    associatedtype Traits
+
+    /// Returns a default traits object.
+    static var defaultTraits: Self.Traits { get }
+}
+
+enum SingleTraitLayoutTraitsKey<LayoutType: SingleTraitLayout>: LayoutTraitsKey {
+    typealias Value = LayoutType.Traits
+
+    static var defaultValue: Value {
+        LayoutType.defaultTraits
+    }
+}

--- a/BlueprintUI/Sources/Layout/Stack.swift
+++ b/BlueprintUI/Sources/Layout/Stack.swift
@@ -13,9 +13,13 @@ public protocol StackElement: Element {
 extension StackElement {
 
     public var content: ElementContent {
-        ElementContent(layout: layout) {
+        ElementContent(layout: layout) { builder in
             for child in self.children {
-                $0.add(traits: child.traits, key: child.key, element: child.element)
+                builder.add(
+                    traits: child.traits,
+                    key: child.key,
+                    element: child.element
+                )
             }
         }
     }
@@ -184,7 +188,7 @@ extension StackElement {
 
 
 /// A layout implementation that linearly lays out an array of children along either the horizontal or vertical axis.
-public struct StackLayout: Layout {
+public struct StackLayout: Layout, SingleTraitLayout {
 
     /// The default traits for a child contained within a stack layout
     public static var defaultTraits: Traits {

--- a/BlueprintUI/Tests/LayoutTraitsTests.swift
+++ b/BlueprintUI/Tests/LayoutTraitsTests.swift
@@ -1,0 +1,125 @@
+import BlueprintUI
+import UIKit
+import XCTest
+
+final class LayoutTraitsTests: XCTestCase {
+    func test_traitPropagation() {
+        let element = OptionalTraitElement(
+            children: [
+                (Empty(), 1),
+                (Empty(), 2),
+                (Empty(), nil),
+            ]
+        )
+
+        let size = element.content.measure(in: .unconstrained)
+
+        XCTAssertEqual(size, CGSize(width: 3, height: 3))
+    }
+
+    func test_multiTraits() {
+        let element = MultiTraitElement(
+            children: [
+                (Empty(), 1, 2),
+                (Empty(), 2, 3),
+                (Empty(), 3, 4),
+            ]
+        )
+
+        let size = element.content.measure(in: .unconstrained)
+
+        XCTAssertEqual(size, CGSize(width: 15, height: 15))
+    }
+
+    // single trait propagation is covered by all the legacy layout tests
+}
+
+private enum FooTrait: LayoutTraitsKey {
+    static var defaultValue: Int = 0
+}
+
+private enum BarTrait: LayoutTraitsKey {
+    static var defaultValue: Int = 0
+}
+
+private struct OptionalTraitElement: Element {
+    var children: [(Element, Int?)] = []
+
+    var content: ElementContent {
+        ElementContent(layout: FooBarSizingLayout()) { builder in
+            for (element, foo) in children {
+                if let foo = foo {
+                    builder.add(
+                        traitsType: FooTrait.self,
+                        traits: foo,
+                        element: element
+                    )
+                } else {
+                    builder.add(element: element)
+                }
+            }
+        }
+    }
+
+    func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
+        nil
+    }
+}
+
+private struct MultiTraitElement: Element {
+    var children: [(element: Element, foo: Int, bar: Int)] = []
+
+    var content: ElementContent {
+        ElementContent(layout: FooBarSizingLayout()) { builder in
+            for (element, foo, bar) in children {
+                builder.add(
+                    traits: .empty
+                        .setting(key: FooTrait.self, to: foo)
+                        .setting(key: BarTrait.self, to: bar),
+                    element: element
+                )
+            }
+        }
+    }
+
+    func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
+        nil
+    }
+}
+
+private struct FooBarSizingLayout: Layout {
+    func measure(
+        in constraint: SizeConstraint,
+        items: [(traits: (), content: any Measurable)]
+    ) -> CGSize {
+        .zero
+    }
+
+    func layout(
+        size: CGSize,
+        items: [(traits: (), content: any Measurable)]
+    ) -> [LayoutAttributes] {
+        items.map { _ in .init() }
+    }
+
+    func sizeThatFits(
+        proposal: SizeConstraint,
+        subelements: Subelements,
+        environment: Environment,
+        cache: inout ()
+    ) -> CGSize {
+        let fooBarCount = subelements.map { subelement in
+            subelement[FooTrait.self] + subelement[BarTrait.self]
+        }
+        .reduce(0, +)
+
+        return CGSize(width: fooBarCount, height: fooBarCount)
+    }
+
+    func placeSubelements(
+        in size: CGSize,
+        subelements: Subelements,
+        environment: Environment,
+        cache: inout ()
+    ) {}
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Layouts can define custom traits by creating types that conform to `LayoutTraitsKey`.
+- The `SingleTraitLayout` protocol preserves the existing API for legacy layouts that define a single trait type.
+
 ### Removed
 
 ### Changed


### PR DESCRIPTION
This PR adds keyed layout traits that work similarly to SwiftUI's [LayoutValueKey](https://developer.apple.com/documentation/swiftui/layoutvaluekey). You can define keys in the style of Environment keys, and then read the values off subelements during layout.

To support legacy layout implementations, the `SingleTraitLayout` protocol provides the existing API. When legacy layout is removed, layouts that have an associated trait type only need to conform to this protocol to keep working as-is.

Decoupling the legacy `Traits` type from the `Layout` protocol will allow us to remove the `LegacyLayout` requirements cleanly. I'll do that in a follow-up.