### PR TITLE
Fix multi-line link accessibility paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bounding rects for VoiceOver when an attributed label's link spans more than one line.
+
 ### Added
 
 - Added support for tabbing through links in `AttributedLabel`


### PR DESCRIPTION
This change is a fast-follow to [this](https://github.com/square/Blueprint/pull/558) PR. The previous PR improved how multi-line links were exposed to VoiceOver and Full Keyboard Access. However, it was flawed in that it would only expose the first fragment. This PR fixes that by encompassing the entire link inside a single bezier path.

### Demo

(For the "Before" view, refer to the description in [this](https://github.com/square/Blueprint/pull/558) PR.)

#### VoiceOver

https://github.com/user-attachments/assets/c8bcff72-5096-4331-9be8-12cdcba3c54d

#### Full keyboard access

https://github.com/user-attachments/assets/a1e3e6f8-3f85-46b5-b486-d8176eafe34d