### PR TITLE
Added support for `DEVELOPMENT_TEAM` environment variable

### DIFF
--- a/SampleApp/Project.swift
+++ b/SampleApp/Project.swift
@@ -4,7 +4,10 @@ import ProjectDescriptionHelpers
 
 let project = Project(
     name: "Development",
-    settings: .settings(base: ["ENABLE_MODULE_VERIFIER": "YES"]),
+    settings: .settings(base: [
+        "ENABLE_MODULE_VERIFIER": "YES",
+        "DEVELOPMENT_TEAM": SettingValue(stringLiteral: Environment.developmentTeam.getString(default: "")),
+    ]),
     targets: [
 
         .app(


### PR DESCRIPTION
Add `export TUIST_DEVELOPMENT_TEAM=ABCDEFG123` (where `ABCDEFG123` is your Apple development team ID) in your `.zshrc` or `.bashrc` file to set the `DEVELOPMENT_TEAM` environment variable. Alternatively, run `TUIST_DEVELOPMENT_TEAM=ABCDEFG123 tuist generate --path SampleApp` when generating the project.

Referred to doc [here](https://docs.tuist.dev/en/guides/features/projects/dynamic-configuration)