### PR TITLE
AccessibilityContainer allow custom elements

### DIFF
--- a/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
@@ -30,6 +30,9 @@ public struct AccessibilityContainer: Element {
     /// An optional `accessibilityValue` to give the container. Defaults to `nil`.
     public var value: String?
 
+    /// An optional array of accessibility elements, to override the wrapped children.
+    public var elements: [NSObjectProtocol]?
+
     public var wrapped: Element
 
 
@@ -39,12 +42,14 @@ public struct AccessibilityContainer: Element {
         label: String? = nil,
         value: String? = nil,
         identifier: String? = nil,
+        elements: [NSObjectProtocol]? = nil,
         wrapping element: Element
     ) {
         self.containerType = containerType
         self.label = label
         self.value = value
         self.identifier = identifier
+        self.elements = elements
         wrapped = element
     }
 
@@ -62,6 +67,7 @@ public struct AccessibilityContainer: Element {
             config[\.accessibilityValue] = value
             config[\.accessibilityIdentifier] = identifier
             config[\.accessibilityContainerType] = containerType.UIKitContainerType
+            config[\.elements] = elements
             config[\.layoutDirection] = context.environment.layoutDirection
         }
     }
@@ -106,14 +112,16 @@ extension Element {
 }
 
 extension AccessibilityContainer {
-    private final class AccessibilityContainerView: UIView {
+    internal final class AccessibilityContainerView: UIView {
         var layoutDirection: Environment.LayoutDirection = .leftToRight
+        var elements: [NSObjectProtocol]?
 
         override var accessibilityElements: [Any]? {
             get {
-                accessibilityElements(
-                    layoutDirection: layoutDirection
-                )
+                elements ??
+                    accessibilityElements(
+                        layoutDirection: layoutDirection
+                    )
             }
             set { fatalError("This property is not settable") }
         }

--- a/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityContainer.swift
@@ -31,7 +31,7 @@ public struct AccessibilityContainer: Element {
     public var value: String?
 
     /// An optional array of accessibility elements, to override the wrapped children.
-    public var elements: [NSObjectProtocol]?
+    public var elements: [Any]?
 
     public var wrapped: Element
 
@@ -42,7 +42,7 @@ public struct AccessibilityContainer: Element {
         label: String? = nil,
         value: String? = nil,
         identifier: String? = nil,
-        elements: [NSObjectProtocol]? = nil,
+        elements: [Any]? = nil,
         wrapping element: Element
     ) {
         self.containerType = containerType
@@ -114,7 +114,7 @@ extension Element {
 extension AccessibilityContainer {
     internal final class AccessibilityContainerView: UIView {
         var layoutDirection: Environment.LayoutDirection = .leftToRight
-        var elements: [NSObjectProtocol]?
+        var elements: [Any]?
 
         override var accessibilityElements: [Any]? {
             get {

--- a/BlueprintUICommonControls/Tests/Sources/AccessibilityContainerTests.swift
+++ b/BlueprintUICommonControls/Tests/Sources/AccessibilityContainerTests.swift
@@ -154,4 +154,26 @@ class AccessibilityContainerTests: XCTestCase {
 
         XCTAssertNil(accessibleSubviews.first)
     }
+
+    func test_elements_override() {
+
+        let accessibleView = UIView()
+        accessibleView.isAccessibilityElement = true
+
+        let containerView = AccessibilityContainer.AccessibilityContainerView()
+        containerView.addSubview(accessibleView)
+
+        let elements = containerView.accessibilityElements
+
+        XCTAssertEqual(elements?.first as? UIView, accessibleView)
+
+        let overrideElement = NSObject()
+        overrideElement.isAccessibilityElement = true
+
+        containerView.elements = [overrideElement]
+
+        let overriden = containerView.accessibilityElements
+        XCTAssertEqual(overriden?.first as? NSObject, overrideElement)
+
+    }
 }


### PR DESCRIPTION
now allowing child elements to be specified explicitly, allowing for elements that are not backed by uiviews



more for discussion really, is this something we should support?