### PR TITLE
Expose largeContentViewerInteraction on LargeContentViewer backing view via protocol

### DIFF
--- a/BlueprintUICommonControls/Sources/AccessibilityLargeContentViewer.swift
+++ b/BlueprintUICommonControls/Sources/AccessibilityLargeContentViewer.swift
@@ -212,8 +212,11 @@ extension Accessibility {
 }
 
 extension Accessibility {
+    public protocol LargeContentViewerInteractionContainerViewable: UIView {
+        var largeContentViewerInteraction: UILargeContentViewerInteraction? { get }
+    }
 
-    private final class LargeContentViewerInteractionContainerView: UIView, UILargeContentViewerInteractionDelegate {
+    private final class LargeContentViewerInteractionContainerView: UIView, LargeContentViewerInteractionContainerViewable, UILargeContentViewerInteractionDelegate {
 
         var largeContentViewerInteraction: UILargeContentViewerInteraction?
 

--- a/SampleApp/Sources/AccessibilityViewController.swift
+++ b/SampleApp/Sources/AccessibilityViewController.swift
@@ -6,9 +6,25 @@ final class AccessibilityViewController: UIViewController {
 
     private let blueprintView = BlueprintView()
 
+    private var isLongPressButtonDark: Bool = false {
+        didSet {
+            if oldValue != isLongPressButtonDark {
+                update()
+            }
+        }
+    }
+
     override func loadView() {
         view = blueprintView
+    }
+
+    func update() {
         blueprintView.element = element
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        update()
     }
 
     var firstTrigger = AccessibilityFocus.Trigger()
@@ -144,7 +160,17 @@ final class AccessibilityViewController: UIViewController {
                 )
                 .accessibilityShowsLargeContentViewer(display: .title("Large content item 5 display text", nil))
             }.accessibilityLargeContentViewerInteractionContainer()
-
+            Row {
+                Label(text: "Long press large content", configure: { label in
+                    label.color = isLongPressButtonDark ? .white : .black
+                })
+                .inset(by: .init(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0))
+                .box(background: isLongPressButtonDark ? .black : .lightGray)
+                .onLongPress {
+                    self.isLongPressButtonDark.toggle()
+                }
+                .accessibilityShowsLargeContentViewer(display: .title("Long press large content display text", nil))
+            }.accessibilityLargeContentViewerInteractionContainer()
         }
         .accessibilityContainer()
         .inset(uniform: 20)

--- a/SampleApp/Sources/LongPress.swift
+++ b/SampleApp/Sources/LongPress.swift
@@ -1,0 +1,89 @@
+import BlueprintUI
+import BlueprintUICommonControls
+import Foundation
+import UIKit
+
+public struct LongPress: Element {
+
+    public var wrappedElement: Element
+    public var onLongPress: () -> Void
+
+    public init(onLongPress: @escaping () -> Void, wrapping element: Element) {
+        wrappedElement = element
+        self.onLongPress = onLongPress
+    }
+
+    public var content: ElementContent {
+        ElementContent(child: wrappedElement)
+    }
+
+    public func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
+        LongPressableView.describe { config in
+            config[\.onLongPress] = onLongPress
+        }
+    }
+}
+
+extension Element {
+
+    /// Wraps the element and calls the provided closure when tapped.
+    func onLongPress(_ callback: @escaping () -> Void) -> LongPress {
+        LongPress(onLongPress: callback, wrapping: self)
+    }
+}
+
+// MARK: LongPressableView
+
+private final class LongPressableView: UIView, UIGestureRecognizerDelegate {
+
+    var onLongPress: (() -> Void)? = nil
+    let longPressRecognizer: UILongPressGestureRecognizer
+    private static let defaultPressDuration: TimeInterval = 0.5
+    private static let adjustedPressDuration: TimeInterval = 3.0
+
+    override init(frame: CGRect) {
+        let longPressRecognizer = UILongPressGestureRecognizer()
+        self.longPressRecognizer = longPressRecognizer
+
+        super.init(frame: frame)
+
+        longPressRecognizer.addTarget(self, action: #selector(longPressed(_:)))
+        longPressRecognizer.delegate = self
+        addGestureRecognizer(longPressRecognizer)
+
+        updateView()
+    }
+
+    func updateView() {
+        longPressRecognizer.minimumPressDuration = UILargeContentViewerInteraction.isEnabled ? Self.adjustedPressDuration : Self.defaultPressDuration
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        (gestureRecognizer == longPressRecognizer) && (otherGestureRecognizer == ancestorLargeContentViewerInteraction?.gestureRecognizerForExclusionRelationship)
+    }
+
+    var ancestorLargeContentViewerInteraction: UILargeContentViewerInteraction? {
+        sequence(first: self, next: { $0.superview })
+            .dropFirst()
+            .lazy
+            .compactMap { $0 as? Accessibility.LargeContentViewerInteractionContainerViewable }
+            .first?
+            .largeContentViewerInteraction
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func longPressed(_ sender: UILongPressGestureRecognizer) {
+        // This function is called multiple times during the lifecycle of a single long-press,
+        // so we only listen for the "begin" state to avoid calling the onLongPress callback too many times
+        guard sender.state == .began else { return }
+
+        onLongPress?()
+    }
+}
+


### PR DESCRIPTION
We need access to the `largeContentViewerInteraction` on the backing view so that, if a view supports a long press gesture, it's able to support both the large content viewer as well as the existing action, per [this](https://developer.apple.com/videos/play/wwdc2019/261/) WWDC session. This change exposes that property via a public protocol.

### Demo
Observe the colours on the "Long press large content" button.

https://github.com/user-attachments/assets/6893fbb5-5edf-425c-b39d-c4bc3c7631fc

