### PR TITLE
Stopped installing xcodes in GitHub Actions file

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,8 +42,8 @@ jobs:
     - name: Switch to Xcode ${{ env.xcode_version }}
       run: sudo xcode-select -s /Applications/Xcode_${{ env.xcode_version }}.app
 
-    - name: Install xcodes
-      run: brew install aria2 xcodesorg/made/xcodes
+    - name: Install aria2
+      run: brew install aria2
 
     - name: Install iOS ${{ matrix.sdk }}
       if: ${{ matrix.installation_required }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Stopped installing xcodes in GitHub Actions file.
+
 ## [6.2.0] - 2025-08-08
 
 - Added support for accessibility large content viewer.


### PR DESCRIPTION
As of [2025-08-25](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md), xcodes is provided by default on GitHub machines. Having the `brew install xcodesorg/made/xcodes` line was causing CI to fail.