### PR TITLE
fix: guard accessibility updates behind window != nil

### DIFF
--- a/BlueprintUIAccessibilityCore/Sources/AccessibilityComposition.swift
+++ b/BlueprintUIAccessibilityCore/Sources/AccessibilityComposition.swift
@@ -407,6 +407,7 @@ extension AccessibilityComposition {
         }
 
         private func updateAccessibility() {
+            guard window != nil else { return }
             let sorting = customSorting ?? Accessibility.frameSort(
                 direction: layoutDirection,
                 root: self,
@@ -438,6 +439,7 @@ extension AccessibilityComposition.CombinableView {
 
     public override var isAccessibilityElement: Bool {
         get {
+            guard window != nil else { return false }
             if needsAccessibilityUpdate {
                 updateAccessibility()
             }
@@ -484,6 +486,16 @@ extension AccessibilityComposition.CombinableView {
             return super.accessibilityIdentifier
         }
         set { super.accessibilityIdentifier = newValue }
+    }
+
+    public override var accessibilityTraits: UIAccessibilityTraits {
+        get {
+            if needsAccessibilityUpdate {
+                updateAccessibility()
+            }
+            return super.accessibilityTraits
+        }
+        set { super.accessibilityTraits = newValue }
     }
 
     public override var accessibilityElements: [Any]? {

--- a/BlueprintUIAccessibilityCore/Sources/AccessibilityDeferral.swift
+++ b/BlueprintUIAccessibilityCore/Sources/AccessibilityDeferral.swift
@@ -271,8 +271,6 @@ extension AccessibilityDeferral {
         public func backingViewDescription(with context: BlueprintUI.ViewDescriptionContext) -> BlueprintUI.ViewDescription? {
             ReceiverContainerView.describe { config in
                 config.apply { view in
-                    view.isAccessibilityElement = true
-                    view.needsAccessibilityUpdate = true
                     view.layoutDirection = context.environment.layoutDirection
                     view.element = wrappedElement
                 }
@@ -291,7 +289,6 @@ extension AccessibilityDeferral {
 
             override init(frame: CGRect) {
                 super.init(frame: frame)
-                isAccessibilityElement = true
                 mergeInteractiveSingleChild = false
 
                 blueprintView.backgroundColor = .clear
@@ -300,6 +297,14 @@ extension AccessibilityDeferral {
 
             @MainActor required init?(coder: NSCoder) {
                 fatalError("init(coder:) has not been implemented")
+            }
+
+            override func didMoveToWindow() {
+                super.didMoveToWindow()
+                isAccessibilityElement = (window != nil)
+                if window != nil {
+                    needsAccessibilityUpdate = true
+                }
             }
 
             override func layoutSubviews() {
@@ -335,6 +340,7 @@ extension AccessibilityDeferral {
             }
 
             public func updateDeferredAccessibility(frameProvider: FrameProvider?) {
+                guard window != nil else { return }
                 needsAccessibilityUpdate = true
 
                 self.frameProvider = frameProvider
@@ -420,6 +426,7 @@ extension AccessibilityDeferral {
         }
 
         private func updateAccessibility() {
+            guard window != nil else { return }
             needsAccessibilityUpdate = false
             blueprintView.layoutIfNeeded()
             let elements = blueprintView.recursiveAccessibleElements()

--- a/BlueprintUIAccessibilityCore/Tests/AccessibilityCompositionTests.swift
+++ b/BlueprintUIAccessibilityCore/Tests/AccessibilityCompositionTests.swift
@@ -331,7 +331,9 @@ class AccessibilityCompositionTests: XCTestCase {
     }
 
     func test_blockWhenNotAccessible_givenPopulatedAccessibility() {
+        let window = UIWindow()
         let view = AccessibilityComposition.CombinableView()
+        window.addSubview(view)
         view.blockWhenNotAccessible = true
         (1...3)
             .map { int in
@@ -358,7 +360,9 @@ class AccessibilityCompositionTests: XCTestCase {
     }
 
     func test_blockWhenNotAccessible_givenEmptyAccessibility() {
+        let window = UIWindow()
         let view = AccessibilityComposition.CombinableView()
+        window.addSubview(view)
         view.blockWhenNotAccessible = true
         (1...3)
             .map { int in
@@ -384,6 +388,39 @@ class AccessibilityCompositionTests: XCTestCase {
         XCTAssertFalse(view.isAccessibilityElement, "The view should not be accessible.")
     }
 
+    func test_updateAccessibility_skipsWhenNotInWindow() {
+        let view = AccessibilityComposition.CombinableView()
+        view.blockWhenNotAccessible = true
+        let subview = UIView()
+        subview.isAccessibilityElement = true
+        subview.accessibilityLabel = "Should not appear"
+        view.addSubview(subview)
+
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+
+        XCTAssertNil(view.accessibilityLabel)
+        XCTAssertTrue(view.needsAccessibilityUpdate)
+    }
+
+    func test_updateAccessibility_runsAfterMovingToWindow() {
+        let view = AccessibilityComposition.CombinableView()
+        view.blockWhenNotAccessible = true
+        let subview = UIView()
+        subview.isAccessibilityElement = true
+        subview.accessibilityLabel = "Now visible"
+        view.addSubview(subview)
+
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        XCTAssertNil(view.accessibilityLabel)
+        XCTAssertTrue(view.needsAccessibilityUpdate)
+
+        let window = UIWindow()
+        window.addSubview(view)
+        XCTAssertEqual(view.accessibilityLabel, "Now visible")
+        XCTAssertFalse(view.needsAccessibilityUpdate)
+    }
 
     func test_applyAccessibility() {
 


### PR DESCRIPTION
## Problem

AXRuntime maintains an internal element cache (a map table) that is allocated during the scene lifecycle. Under XCTest's test runner, the scene lifecycle is delayed — the cache is still NULL when the first accessibility broadcast fires, and `NSMapGet` crashes on the NULL pointer.

```
NSMapGet (x0 = 0x0, NULL map table)
  ← AXRuntime: _AXIsInElementCache
    ← AXRuntime: __AXCreateAXUIElementWithElement
      ← UIAccessibility: _axuiElementForNotificationData
        ← UIAccessibility: _massageNotificationDataBeforePost
          ← UIAccessibility: _UIAXBroadcastMainThread
            ← libdispatch: _dispatch_main_queue_drain
```

### Root cause

`ReceiverContainerView.init` sets `isAccessibilityElement = true` during init. When this view is added to the hierarchy via `addSubview`, UIKit internally posts an accessibility notification. Under XCTest's test runner, AXRuntime's element cache hasn't been allocated yet when that notification fires during a run-loop drain, crashing on the NULL map table.

We can't guard UIKit's internal notification post — the fix is to not set `isAccessibilityElement = true` until the view is in a window, at which point the scene lifecycle has completed and AXRuntime is initialized.

### Evidence

- Crash reproduced 100% when the app is launched via `xcodebuild test`
- Does NOT reproduce via `xcrun simctl launch` (normal launch)
- Confirmed with LLDB: conditional breakpoint on `NSMapGet` where `x0 == 0` hit the NULL map table
- Only appeared after adopting `.deferredAccessibilityReceiver()` on views present during initial layout

## Fix

- **`ReceiverContainerView`**: move `isAccessibilityElement = true` from `init` to `didMoveToWindow()`. The view only becomes an accessibility element after it has a window. Sets `isAccessibilityElement = false` when removed from a window. Also defers `needsAccessibilityUpdate = true` to `didMoveToWindow()` so the first accessibility update doesn't trigger before the scene is ready. Removed the redundant `isAccessibilityElement = true` and `needsAccessibilityUpdate = true` from the `backingViewDescription` apply block since `didMoveToWindow` handles both.

- **`CombinableView.updateAccessibility()`**, **`ReceiverContainerView.updateDeferredAccessibility()`**, **`SourceContainerView.updateAccessibility()`**: early-return when `window == nil`. Defensive guards to prevent unnecessary accessibility work on views not in the hierarchy.

- **Add missing `accessibilityTraits` override** on `CombinableView`: the getter was missing the lazy-update pattern that all other accessibility property overrides use. Added for consistency.