### PR TITLE
fix: defer reentrant BlueprintView updates

### DIFF
--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -384,6 +384,14 @@ public final class BlueprintView: UIView {
         }
     }
 
+    /// Schedules a coalesced view hierarchy update on a following main run loop turn.
+    ///
+    /// Used when an invalidation arrives while an update is already in progress — for example,
+    /// UIKit keyboard and safe-area callbacks can fire synchronously mid-update and force a
+    /// layout pass. Re-arming with `setNeedsLayout()` immediately would let a forcing
+    /// `layoutIfNeeded()` re-dirty this view while the in-flight update still holds
+    /// `isInsideUpdate`, preventing that forced layout from ever terminating, so the re-arm
+    /// is deferred until the current update has unwound.
     @MainActor
     private func scheduleDeferredViewHierarchyUpdate() {
         guard hasScheduledDeferredViewHierarchyUpdate == false else { return }
@@ -415,6 +423,9 @@ public final class BlueprintView: UIView {
         guard needsViewHierarchyUpdate || bounds != lastViewHierarchyUpdateBounds else { return }
 
         if isInsideUpdate {
+            // A reentrant update was triggered from within the in-flight update, e.g. by a
+            // safe-area or keyboard change synchronously forcing a layout pass. Defer it so
+            // the current update can finish; the deferred pass picks up the latest state.
             setNeedsViewHierarchyUpdate()
             return
         }
@@ -485,8 +496,9 @@ public final class BlueprintView: UIView {
 
         /// We intentionally deliver our lifecycle callbacks (eg, `onAppear`,
         /// `onDisappear`, etc, _after_ we've marked our view as updated.
-        /// This is in case the `onAppear` callback triggers a re-render,
-        /// we don't hit our recurisve update precondition.
+        /// This way, if an `onAppear` callback triggers a re-render, it is
+        /// applied synchronously on the next layout pass rather than being
+        /// treated as a reentrant update and deferred.
 
         for callback in updateResult.lifecycleCallbacks {
             callback()

--- a/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
+++ b/BlueprintUI/Sources/BlueprintView/BlueprintView.swift
@@ -33,6 +33,7 @@ public final class BlueprintView: UIView {
 
     /// Used to detect reentrant updates
     private var isInsideUpdate: Bool = false
+    private var hasScheduledDeferredViewHierarchyUpdate: Bool = false
 
     private let rootController: NativeViewController
 
@@ -364,13 +365,40 @@ public final class BlueprintView: UIView {
         invalidateIntrinsicContentSize()
         sizesThatFit.removeAll()
 
-        if needsViewHierarchyUpdate { return }
+        if needsViewHierarchyUpdate {
+            if isInsideUpdate {
+                scheduleDeferredViewHierarchyUpdate()
+            }
+
+            return
+        }
 
         needsViewHierarchyUpdate = true
 
         /// We use `UIView`'s layout pass to actually perform a hierarchy update.
         /// If a manual update is required, call `layoutIfNeeded()`.
-        setNeedsLayout()
+        if isInsideUpdate {
+            scheduleDeferredViewHierarchyUpdate()
+        } else {
+            setNeedsLayout()
+        }
+    }
+
+    @MainActor
+    private func scheduleDeferredViewHierarchyUpdate() {
+        guard hasScheduledDeferredViewHierarchyUpdate == false else { return }
+
+        hasScheduledDeferredViewHierarchyUpdate = true
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            hasScheduledDeferredViewHierarchyUpdate = false
+
+            guard needsViewHierarchyUpdate else { return }
+
+            setNeedsLayout()
+        }
     }
 
     @MainActor
@@ -386,10 +414,10 @@ public final class BlueprintView: UIView {
 
         guard needsViewHierarchyUpdate || bounds != lastViewHierarchyUpdateBounds else { return }
 
-        precondition(
-            !isInsideUpdate,
-            "Reentrant updates are not supported in BlueprintView. Ensure that view events from within the hierarchy are not synchronously triggering additional updates."
-        )
+        if isInsideUpdate {
+            setNeedsViewHierarchyUpdate()
+            return
+        }
 
         isInsideUpdate = true
 
@@ -830,4 +858,3 @@ extension BlueprintView.NativeViewController {
         }
     }
 }
-

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -320,6 +320,52 @@ class BlueprintViewTests: XCTestCase {
         view.layoutIfNeeded()
     }
 
+    func test_elementChangeAndForcedLayoutDuringUpdateDefersNestedUpdate() {
+        let view = BlueprintView(frame: CGRect(x: 0, y: 0, width: 200, height: 200))
+
+        var didTriggerReentrantUpdate = false
+
+        // Mirrors the navigation-bar crash shape: while the view is mid-update, a view
+        // callback replaces `element` and forces a synchronous layout pass.
+        view.element = CallbackElement {
+            guard !didTriggerReentrantUpdate else { return }
+            didTriggerReentrantUpdate = true
+
+            view.element = IdentifiedElement(identifier: "replacement")
+            view.setNeedsLayout()
+            view.layoutIfNeeded()
+        }
+
+        view.layoutIfNeeded()
+
+        XCTAssertTrue(didTriggerReentrantUpdate)
+
+        // The deferred update applies the replacement element on a following
+        // main run loop turn.
+        let deadline = Date(timeIntervalSinceNow: 5)
+
+        while findView(withAccessibilityIdentifier: "replacement", in: view) == nil, Date() < deadline {
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+            view.layoutIfNeeded()
+        }
+
+        XCTAssertNotNil(findView(withAccessibilityIdentifier: "replacement", in: view))
+    }
+
+    private func findView(withAccessibilityIdentifier identifier: String, in root: UIView) -> UIView? {
+        if root.accessibilityIdentifier == identifier {
+            return root
+        }
+
+        for subview in root.subviews {
+            if let match = findView(withAccessibilityIdentifier: identifier, in: subview) {
+                return match
+            }
+        }
+
+        return nil
+    }
+
     func test_baseEnvironment() {
         enum TestValue {
             case defaultValue
@@ -935,6 +981,20 @@ private struct TestContainer: Element {
             for subelement in subelements {
                 subelement.place(in: .zero)
             }
+        }
+    }
+}
+
+private struct IdentifiedElement: Element {
+    var identifier: String
+
+    var content: ElementContent {
+        ElementContent(intrinsicSize: .zero)
+    }
+
+    func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
+        UIView.describe { config in
+            config[\.accessibilityIdentifier] = identifier
         }
     }
 }

--- a/BlueprintUI/Tests/BlueprintViewTests.swift
+++ b/BlueprintUI/Tests/BlueprintViewTests.swift
@@ -227,6 +227,99 @@ class BlueprintViewTests: XCTestCase {
         XCTAssertTrue(layoutRecursed)
     }
 
+    func test_safeAreaChangeDuringUpdateDefersNestedUpdate() {
+        let viewController = UIViewController()
+        let view = BlueprintView(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+
+        viewController.view.frame = view.bounds
+        viewController.view.addSubview(view)
+
+        let window = UIWindow(frame: view.bounds)
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+
+        let safeAreaInvalidation = SafeAreaInvalidation()
+
+        struct SafeAreaInvalidatingElement: Element {
+            weak var viewController: UIViewController?
+            let safeAreaInvalidation: SafeAreaInvalidation
+
+            var content: ElementContent {
+                ElementContent(measuring: Spacer(width: 1, height: 1))
+            }
+
+            func backingViewDescription(with context: ViewDescriptionContext) -> ViewDescription? {
+                SafeAreaInvalidatingView.describe { config in
+                    config.builder = {
+                        SafeAreaInvalidatingView(
+                            frame: context.bounds,
+                            viewController: viewController,
+                            safeAreaInvalidation: safeAreaInvalidation
+                        )
+                    }
+
+                    config.apply { view in
+                        view.viewController = viewController
+                        view.safeAreaInvalidation = safeAreaInvalidation
+                    }
+                }
+            }
+        }
+
+        final class SafeAreaInvalidation {
+            var hasInvalidatedSafeArea = false
+        }
+
+        final class SafeAreaInvalidatingView: UIView {
+            weak var viewController: UIViewController?
+            var safeAreaInvalidation: SafeAreaInvalidation
+
+            init(
+                frame: CGRect,
+                viewController: UIViewController?,
+                safeAreaInvalidation: SafeAreaInvalidation
+            ) {
+                self.viewController = viewController
+                self.safeAreaInvalidation = safeAreaInvalidation
+                super.init(frame: frame)
+            }
+
+            required init?(coder: NSCoder) { fatalError() }
+
+            override func didMoveToWindow() {
+                super.didMoveToWindow()
+                invalidateSafeAreaOnce()
+            }
+
+            override func layoutSubviews() {
+                super.layoutSubviews()
+                invalidateSafeAreaOnce()
+            }
+
+            private func invalidateSafeAreaOnce() {
+                guard
+                    safeAreaInvalidation.hasInvalidatedSafeArea == false,
+                    window != nil,
+                    let viewController
+                else {
+                    return
+                }
+
+                safeAreaInvalidation.hasInvalidatedSafeArea = true
+
+                viewController.additionalSafeAreaInsets.bottom += 1
+                viewController.view.setNeedsLayout()
+                viewController.view.layoutIfNeeded()
+            }
+        }
+
+        view.element = SafeAreaInvalidatingElement(
+            viewController: viewController,
+            safeAreaInvalidation: safeAreaInvalidation
+        )
+        view.layoutIfNeeded()
+    }
+
     func test_baseEnvironment() {
         enum TestValue {
             case defaultValue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `BlueprintView` now defers view hierarchy updates that are triggered while an update is already in progress, instead of crashing with a "Reentrant updates are not supported" precondition failure. Reentrant invalidations (e.g. keyboard or safe-area changes that synchronously force a layout pass mid-update) are coalesced and applied on a following main run loop turn.
+
 ### Added
 
 ### Removed

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,10 @@ let package = Package(
         ),
         .testTarget(
             name: "BlueprintUITests",
-            dependencies: ["BlueprintUI"],
+            dependencies: [
+                "BlueprintUI",
+                "BlueprintUICommonControls",
+            ],
             path: "BlueprintUI/Tests"
         ),
         .target(


### PR DESCRIPTION
## Summary

- defer BlueprintView hierarchy invalidations that occur while Blueprint is already updating its view tree
- coalesce the deferred retry so UIKit safe-area/window callbacks cannot synchronously re-enter `updateViewHierarchyIfNeeded()`
- add a regression test that mutates `additionalSafeAreaInsets` during backing-view attach/layout, matching the production crash shape
- add the missing `BlueprintUICommonControls` dependency for the package test target so the focused package test builds

## Context

This came from an ios-register 7.10 crash investigation where `BlueprintView.safeAreaInsetsDidChange()` re-entered `BlueprintView.updateViewHierarchyIfNeeded()` during a Market keyboard/header layout update. A MarketUI harness reproduced the exact precondition crash locally before this Blueprint patch; with this patch copied into Market's Blueprint checkout, the same harness passes.

## Testing

- `xcodebuild test -scheme BlueprintUI-Package -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -only-testing:BlueprintUITests/BlueprintViewTests/test_safeAreaChangeDuringUpdateDefersNestedUpdate -quiet`
- Market validation with this Blueprint source copied into Market's local checkout: `xcodebuild test -workspace ios/MarketDevelopment.xcworkspace -scheme UnitTests -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -only-testing:MarketUI-Tests/MarketKeyboardReaderReentrantLayoutTests/test_safeAreaChangeDuringKeyboardReaderUpdateDoesNotReenterBlueprint -quiet`
